### PR TITLE
Made TelemtryClient static for ApplicationInsights publisher

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -16,21 +16,28 @@ namespace HealthChecks.Publisher.ApplicationInsights
         const string METRIC_STATUS_NAME = "AspNetCoreHealthCheckStatus";
         const string METRIC_DURATION_NAME = "AspNetCoreHealthCheckDuration";
 
+        private readonly string _instrumentationKey;
         private static TelemetryClient _client;
 
         public ApplicationInsightsPublisher(string instrumentationKey = default)
         {
-            //override instrumentation key or use default instrumentation 
-            //key active on the project.
-
-            var configuration = string.IsNullOrWhiteSpace(instrumentationKey)
-                ? TelemetryConfiguration.Active
-                : new TelemetryConfiguration(instrumentationKey);
-            _client = new TelemetryClient(configuration);
+            _instrumentationKey = instrumentationKey;
         }
 
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
+            if (_client == null)
+            {
+                //override instrumentation key or use default instrumentation 
+                //key active on the project.
+
+                var configuration = string.IsNullOrWhiteSpace(_instrumentationKey)
+                    ? TelemetryConfiguration.Active
+                    : new TelemetryConfiguration(_instrumentationKey);
+
+                _client = new TelemetryClient(configuration);
+            }
+
             _client.TrackEvent(EVENT_NAME,
                 properties: new Dictionary<string, string>()
                 {

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -16,24 +16,22 @@ namespace HealthChecks.Publisher.ApplicationInsights
         const string METRIC_STATUS_NAME = "AspNetCoreHealthCheckStatus";
         const string METRIC_DURATION_NAME = "AspNetCoreHealthCheckDuration";
 
-        private readonly string _instrumentationKey;
+        private static TelemetryClient _client;
 
         public ApplicationInsightsPublisher(string instrumentationKey = default)
         {
-            _instrumentationKey = instrumentationKey;
+            //override instrumentation key or use default instrumentation 
+            //key active on the project.
+
+            var configuration = string.IsNullOrWhiteSpace(instrumentationKey)
+                ? TelemetryConfiguration.Active
+                : new TelemetryConfiguration(instrumentationKey);
+            _client = new TelemetryClient(configuration);
         }
 
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
-            //override instrumentation key or use default instrumentation 
-            //key active on the project.
-            var configuration = String.IsNullOrWhiteSpace(_instrumentationKey)
-                ? TelemetryConfiguration.Active
-                : new TelemetryConfiguration(_instrumentationKey);
-
-            var client = new TelemetryClient(configuration);
-
-            client.TrackEvent(EVENT_NAME,
+            _client.TrackEvent(EVENT_NAME,
                 properties: new Dictionary<string, string>()
                 {
                     {nameof(Environment.MachineName),Environment.MachineName},


### PR DESCRIPTION
Whilst looking at the issue I raised for Service Bus, I noticed the Insights Publisher also was not kept for the lifetime of the application, so I made it only initialise once.