### PR TITLE
[WIP] Updates URI Health checks to leverage IHttpClientFactory

### DIFF
--- a/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
@@ -10,6 +10,12 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         const string NAME = "uri-group";
 
+        static IHealthCheck CreateHealthCheck(IServiceProvider sp, string name, UriHealthCheckOptions options)
+        {
+            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+            return new UriHealthCheck(options, () => httpClientFactory.CreateClient(name));
+        }
+
         /// <summary>
         /// Add a health check for single uri.
         /// </summary>
@@ -24,12 +30,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            builder.Services.AddHttpClient();
+
             var options = new UriHealthCheckOptions();
             options.AddUri(uri);
 
+            var n = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
-                name ?? NAME,
-                sp => new UriHealthCheck(options),
+                n,
+                sp => CreateHealthCheck(sp, n, options),
                 failureStatus,
                 tags));
         }
@@ -49,13 +58,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            builder.Services.AddHttpClient();
+
             var options = new UriHealthCheckOptions();
             options.AddUri(uri);
             options.UseHttpMethod(httpMethod);
 
+            var n = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
-                name ?? NAME,
-                sp => new UriHealthCheck(options),
+                n,
+                sp => CreateHealthCheck(sp, n, options),
                 failureStatus,
                 tags));
         }
@@ -73,11 +85,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            builder.Services.AddHttpClient();
+
             var options = UriHealthCheckOptions.CreateFromUris(uris);
 
+            var n = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
-                name ?? NAME,
-                sp => new UriHealthCheck(options),
+                n,
+                sp => CreateHealthCheck(sp, n, options),
                 failureStatus,
                 tags));
         }
@@ -96,12 +111,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            builder.Services.AddHttpClient();
+
             var options = UriHealthCheckOptions.CreateFromUris(uris);
             options.UseHttpMethod(httpMethod);
 
+            var n = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
-                name ?? NAME,
-                sp => new UriHealthCheck(options),
+                n,
+                sp => CreateHealthCheck(sp, n, options),
                 failureStatus,
                 tags));
         }
@@ -119,12 +137,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            builder.Services.AddHttpClient();
+
             var options = new UriHealthCheckOptions();
             uriOptions?.Invoke(options);
 
+            var n = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
-                name ?? NAME,
-                sp => new UriHealthCheck(options),
+                n,
+                sp => CreateHealthCheck(sp, n, options),
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.Uris/HealthChecks.Uris.csproj
+++ b/src/HealthChecks.Uris/HealthChecks.Uris.csproj
@@ -15,6 +15,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
       <PrivateAssets>all</PrivateAssets>

--- a/src/HealthChecks.Uris/UriHealthCheck.cs
+++ b/src/HealthChecks.Uris/UriHealthCheck.cs
@@ -10,9 +10,12 @@ namespace HealthChecks.Uris
         : IHealthCheck
     {
         private readonly UriHealthCheckOptions _options;
-        public UriHealthCheck(UriHealthCheckOptions options)
+        private readonly Func<HttpClient> _httpClientFactory;
+
+        public UriHealthCheck(UriHealthCheckOptions options, Func<HttpClient> httpClientFactory)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
@@ -32,24 +35,23 @@ namespace HealthChecks.Uris
                         return new HealthCheckResult(context.Registration.FailureStatus, description: $"{nameof(UriHealthCheck)} execution is cancelled.");
                     }
 
-                    using (var httpClient = new HttpClient())
+                    var httpClient = _httpClientFactory();
+                    
+                    var requestMessage = new HttpRequestMessage(method, item.Uri);
+
+                    foreach (var header in item.Headers)
                     {
-                        var requestMessage = new HttpRequestMessage(method, item.Uri);
-
-                        foreach (var header in item.Headers)
-                        {
-                            requestMessage.Headers.Add(header.Name, header.Value);
-                        }
-
-                        var response = await httpClient.SendAsync(requestMessage);
-
-                        if (!((int)response.StatusCode >= expectedCodes.Min && (int)response.StatusCode <= expectedCodes.Max))
-                        {
-                            return new HealthCheckResult(context.Registration.FailureStatus, description: $"Discover endpoint #{idx} is not responding with code in {expectedCodes.Min}...{expectedCodes.Max} range, the current status is {response.StatusCode}.");
-                        }
-
-                        ++idx;
+                        requestMessage.Headers.Add(header.Name, header.Value);
                     }
+
+                    var response = await httpClient.SendAsync(requestMessage);
+
+                    if (!((int)response.StatusCode >= expectedCodes.Min && (int)response.StatusCode <= expectedCodes.Max))
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: $"Discover endpoint #{idx} is not responding with code in {expectedCodes.Min}...{expectedCodes.Max} range, the current status is {response.StatusCode}.");
+                    }
+
+                    ++idx;
                 }
 
                 return HealthCheckResult.Healthy();

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\HealthChecks.Sqlite\HealthChecks.Sqlite.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.SqlServer\HealthChecks.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.System\HealthChecks.System.csproj" />
+    <ProjectReference Include="..\..\src\HealthChecks.Uris\HealthChecks.Uris.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/FunctionalTests/HealthChecks.Uris/UriHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.Uris/UriHealthCheckTests.cs
@@ -1,0 +1,144 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthChecks.Uris
+{
+    [Collection("execution")]
+    public class uri_healthcheck_should
+    {
+        private readonly ExecutionFixture _fixture;
+
+        public uri_healthcheck_should(ExecutionFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [Fact]
+        public async Task be_healthy_if_uri_is_available()
+        {
+            var uri = new Uri("https://httpbin.org/get");
+
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddUrlGroup(uri, tags: new string[] { "uris" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("uris")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task be_healthy_if_method_is_available()
+        {
+            var uri = new Uri("https://httpbin.org/post");
+
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddUrlGroup(uri, HttpMethod.Post, tags: new string[] { "uris" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("uris")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_uri_is_not_available()
+        {
+            var uri = new Uri("http://200.0.0.100");
+
+            var webHostBuilder = new WebHostBuilder()
+              .UseStartup<DefaultStartup>()
+              .ConfigureServices(services =>
+              {
+                  services.AddHealthChecks()
+                   .AddUrlGroup(uri, tags: new string[] { "uris" });
+              })
+              .Configure(app =>
+              {
+                  app.UseHealthChecks("/health", new HealthCheckOptions()
+                  {
+                      Predicate = r => r.Tags.Contains("uris")
+                  });
+              });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [InlineData(199)]
+        [InlineData(300)]
+        [Theory]
+        public async Task be_unhealthy_if_status_code_is_error(int statusCode)
+        {
+            var uri = new Uri($"https://httpbin.org/status/{statusCode}");
+
+            var webHostBuilder = new WebHostBuilder()
+              .UseStartup<DefaultStartup>()
+              .ConfigureServices(services =>
+              {
+                  services.AddHealthChecks()
+                   .AddUrlGroup(uri, tags: new string[] { "uris" });
+              })
+              .Configure(app =>
+              {
+                  app.UseHealthChecks("/health", new HealthCheckOptions()
+                  {
+                      Predicate = r => r.Tags.Contains("uris")
+                  });
+              });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                    .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+    }
+}


### PR DESCRIPTION
Addresses concerns in #30 by adding the `Microsoft.Extensions.Http` package to include lifetime management for `HttpClient`. This also adds functional tests for the health checks.

New Dependencies:
* Runtime: `Microsoft.Extensions.Http`
* Testing: `https://httpbin.org`

I think that we can do some work to adjust the testing dependency and change it so that we integrate directly with a testing host that mimics the same functionality, or we can host the `httpbin` dependency ourselves with docker.