### PR TITLE
Service Bus + Event Hub: Not a new connection for each check

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
+using System.Collections.Concurrent;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,21 +14,35 @@ namespace HealthChecks.AzureServiceBus
         private const string TEST_MESSAGE = "HealthCheckTest";
         private readonly string _connectionString;
         private readonly string _queueName;
+        private static readonly ConcurrentDictionary<string, ServiceBusConnection> ServiceBusConnections = new ConcurrentDictionary<string, ServiceBusConnection>();
+
         public AzureServiceBusQueueHealthCheck(string connectionString, string queueName)
         {
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
             if (string.IsNullOrEmpty(queueName)) throw new ArgumentNullException(nameof(queueName));
-
             _connectionString = connectionString;
             _queueName = queueName;
         }
+
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var queueClient = new QueueClient(_connectionString,
+                if (ServiceBusConnections.TryGetValue(_connectionString, out var serviceBusConnection))
+                {
+                    serviceBusConnection = new ServiceBusConnection(_connectionString);
+
+                    if (!ServiceBusConnections.TryAdd(_connectionString, serviceBusConnection))
+                    {
+                        return
+                            new HealthCheckResult(context.Registration.FailureStatus, description: "New service bus connection can't be added into dictionary.");
+                    }
+                }
+
+                var queueClient = new QueueClient(serviceBusConnection,
                     _queueName,
-                    ReceiveMode.PeekLock);
+                    ReceiveMode.PeekLock,
+                    RetryPolicy.NoRetry);
 
                 var scheduledMessageId = await queueClient.ScheduleMessageAsync(
                     new Message(Encoding.UTF8.GetBytes(TEST_MESSAGE)),

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
+using System.Collections.Concurrent;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,8 @@ namespace HealthChecks.AzureServiceBus
         private const string TEST_MESSAGE = "HealthCheckTestMessage";
         private readonly string _connectionString;
         private readonly string _topicName;
+        private static readonly ConcurrentDictionary<string, ServiceBusConnection> ServiceBusConnections = new ConcurrentDictionary<string, ServiceBusConnection>();
+
         public AzureServiceBusTopicHealthCheck(string connectionString, string topicName)
         {
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
@@ -25,7 +28,18 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var topicClient = new TopicClient(_connectionString, _topicName);
+                if (ServiceBusConnections.TryGetValue(_connectionString, out var serviceBusConnection))
+                {
+                    serviceBusConnection = new ServiceBusConnection(_connectionString);
+
+                    if (!ServiceBusConnections.TryAdd(_connectionString, serviceBusConnection))
+                    {
+                        return
+                            new HealthCheckResult(context.Registration.FailureStatus, description: "New service bus connection can't be added into dictionary.");
+                    }
+                }
+
+                var topicClient = new TopicClient(serviceBusConnection, _topicName, RetryPolicy.NoRetry);
 
                 var scheduledMessageId = await topicClient.ScheduleMessageAsync(
                     new Message(Encoding.UTF8.GetBytes(TEST_MESSAGE)),

--- a/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
+++ b/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="$(MicrosoftAzureEventHubs)" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="$(MicrosoftAzureServiceBus)" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.2.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
       <PrivateAssets>all</PrivateAssets>

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureEventHubUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureEventHubUnitTests.cs
@@ -18,7 +18,8 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddAzureEventHub("cnn", "hubName");
+                .AddAzureEventHub("Endpoint=sb://dummynamespace.servicebus.windows.net/;SharedAccessKeyName=DummyAccessKeyName;SharedAccessKey=5dOntTRytoC24opYThisAsit3is2B+OGY1US/fuL3ly=", 
+                    "hubName");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
@@ -35,8 +36,8 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddAzureEventHub("cnn", "hubName",
-                name: "azureeventhubcheck");
+                .AddAzureEventHub("Endpoint=sb://dummynamespace.servicebus.windows.net/;SharedAccessKeyName=DummyAccessKeyName;SharedAccessKey=5dOntTRytoC24opYThisAsit3is2B+OGY1US/fuL3ly=", 
+                    "hubName", name: "azureeventhubcheck");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();


### PR DESCRIPTION
Tried to keep as close to the Redis implementation as I could for the Service Bus one as ServiceBusConnection is exposed which helps.

However, Event Hub does not expose this so I made the client initialise in the constructor instead.

I've also updated the libraries. The Service Bus update is necessary to expose the connection so needs to be at minimum 3.X.X.

If I need to move them down to a just the latest major I can do that.