### PR TITLE
[Azure Service Bus] Move out string to connection key as it was not being used for adding

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -82,7 +82,7 @@
     <HealthCheckDynamoDb>2.2.0</HealthCheckDynamoDb>
     <HealthCheckDocumentDb>2.2.0</HealthCheckDocumentDb>
     <HealthCheckAzureStorage>2.2.0</HealthCheckAzureStorage>
-    <HealthCheckAzureServiceBus>2.2.3</HealthCheckAzureServiceBus>
+    <HealthCheckAzureServiceBus>2.2.4</HealthCheckAzureServiceBus>
     <HealthCheckUI>2.2.8</HealthCheckUI>
     <HealthCheckUIClient>2.2.2</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>2.2.1</HealthCheckPublisherAppplicationInsights>

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -33,11 +33,12 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                if (!_queueClientConnections.TryGetValue($"{_connectionString}_{_queueName}", out var queueClient))
+                var connectionKey = $"{_connectionString}_{_queueName}";
+                if (!_queueClientConnections.TryGetValue(connectionKey, out var queueClient))
                 {
                     queueClient = new QueueClient(_connectionString, _queueName,ReceiveMode.PeekLock, RetryPolicy.NoRetry);
 
-                    if (!_queueClientConnections.TryAdd(_connectionString, queueClient))
+                    if (!_queueClientConnections.TryAdd(connectionKey, queueClient))
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: "New QueueClient connection can't be added into dictionary.");
                     }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -34,11 +34,12 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                if (!_topicClient.TryGetValue($"{_connectionString}_{_topicName}", out var topicClient))
+                var connectionKey = $"{_connectionString}_{_topicName}";
+                if (!_topicClient.TryGetValue(connectionKey, out var topicClient))
                 {
                     topicClient = new TopicClient(_connectionString, _topicName, RetryPolicy.NoRetry);
 
-                    if (!_topicClient.TryAdd(_connectionString, topicClient))
+                    if (!_topicClient.TryAdd(connectionKey, topicClient))
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: "New TopicClient can't be added into dictionary.");
                     }


### PR DESCRIPTION
Sorry about this, I just realised the code I committed before was pretty flawed! Was not actually using the new key for adding so it would work once then fail on every subsequent request.

Updated `dependencies.props` this time as well