### PR TITLE
Azure * storage throws when connectionstring is invalid

### DIFF
--- a/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
@@ -10,16 +10,17 @@ namespace HealthChecks.AzureStorage
     public class AzureBlobStorageHealthCheck 
         : IHealthCheck
     {
-        private readonly CloudStorageAccount _storageAccount;
+        private readonly string _connectionString;
         public AzureBlobStorageHealthCheck(string connectionString)
         {
-            _storageAccount = CloudStorageAccount.Parse(connectionString);
+            _connectionString = connectionString;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var blobClient = _storageAccount.CreateCloudBlobClient();
+                var storageAccount = CloudStorageAccount.Parse(_connectionString);
+                var blobClient = storageAccount.CreateCloudBlobClient();
 
                 var serviceProperties = await blobClient.GetServicePropertiesAsync(
                     new BlobRequestOptions(),

--- a/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
@@ -10,16 +10,17 @@ namespace HealthChecks.AzureStorage
     public class AzureQueueStorageHealthCheck 
         : IHealthCheck
     {
-        private readonly CloudStorageAccount _storageAccount;
+        private readonly string _connectionString;
         public AzureQueueStorageHealthCheck(string connectionString)
         {
-            _storageAccount = CloudStorageAccount.Parse(connectionString);
+            _connectionString = connectionString;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var blobClient = _storageAccount.CreateCloudQueueClient();
+                var storageAccount = CloudStorageAccount.Parse(_connectionString);
+                var blobClient = storageAccount.CreateCloudQueueClient();
 
                 var serviceProperties = await blobClient.GetServicePropertiesAsync(
                     new QueueRequestOptions(),

--- a/src/HealthChecks.AzureStorage/AzureTableStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureTableStorageHealthCheck.cs
@@ -10,16 +10,18 @@ namespace HealthChecks.AzureStorage
     public class AzureTableStorageHealthCheck
         : IHealthCheck
     {
-        private readonly CloudStorageAccount _storageAccount;
+        private readonly string _connectionString;
         public AzureTableStorageHealthCheck(string connectionString)
         {
-            _storageAccount = CloudStorageAccount.Parse(connectionString);
+            _connectionString = connectionString;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var blobClient = _storageAccount.CreateCloudTableClient();
+                var storageAccount = CloudStorageAccount.Parse(_connectionString);
+
+                var blobClient = storageAccount.CreateCloudTableClient();
 
                 var serviceProperties = await blobClient.GetServicePropertiesAsync(
                     new TableRequestOptions(),

--- a/test/UnitTests/DependencyInjection/AzureStorage/AzureBlobStorageUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureStorage/AzureBlobStorageUnitTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using HealthChecks.AzureStorage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace UnitTests.DependencyInjection.AzureStorage
+{
+    public class azureblobstorage_registration_should
+    {
+        [Fact]
+        public void not_thrown_when_connectionstring_is_invalid()
+        {
+            var connectionString = "bla";
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                    .AddAzureBlobStorage(connectionString);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureblob");
+            check.GetType().Should().Be(typeof(AzureBlobStorageHealthCheck));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureStorage/AzureQueueStorageUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureStorage/AzureQueueStorageUnitTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using HealthChecks.AzureStorage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace UnitTests.DependencyInjection.AzureStorage
+{
+    public class azurequeuestorage_registration_should
+    {
+        [Fact]
+        public void not_thrown_when_connectionstring_is_invalid()
+        {
+            var connectionString = "bla";
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                    .AddAzureQueueStorage(connectionString);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeue");
+            check.GetType().Should().Be(typeof(AzureQueueStorageHealthCheck));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureStorage/AzureTableStorageUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureStorage/AzureTableStorageUnitTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using HealthChecks.AzureStorage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System.Linq;
+using Xunit;
+
+namespace UnitTests.DependencyInjection.AzureStorage
+{
+    public class azuretabletorage_registration_should
+    {
+        [Fact]
+        public void not_thrown_when_connectionstring_is_invalid()
+        {
+            var connectionString = "bla";
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                    .AddAzureTableStorage(connectionString);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretable");
+            check.GetType().Should().Be(typeof(AzureTableStorageHealthCheck));
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>    
     <ProjectReference Include="..\..\src\HealthChecks.AzureKeyVault\HealthChecks.AzureKeyVault.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.AzureServiceBus\HealthChecks.AzureServiceBus.csproj" />    
+    <ProjectReference Include="..\..\src\HealthChecks.AzureStorage\HealthChecks.AzureStorage.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.DocumentDb\HealthChecks.DocumentDb.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.Kafka\HealthChecks.Kafka.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.MongoDb\HealthChecks.MongoDb.csproj" />    
@@ -43,6 +44,9 @@
     <None Update="UI\Kubernetes\SampleData\remote-cluster-discovery-sample.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DependencyInjection\AzureStorage\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Based on the issue: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/68

Read commit per commit (4), the test is included in the commit itself.

Basically the `connectionstring` is parsed in the `CheckHealthAsync` function instead of the `constructor`.
Following HealthChecks in Scope:
- Azure Blob Storage
- Azure Queue Storage
- Azure Table Storage