### PR TITLE
Fixed incorrect package tag in RavenDB package

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -94,6 +94,6 @@
     <HealthCheckAWSS3>2.2.0</HealthCheckAWSS3>
     <HealthCheckKeyVault>2.2.2</HealthCheckKeyVault>
     <HealthCheckPublisherSeq>2.2.0</HealthCheckPublisherSeq>
-    <HealthCheckRavenDB>2.2.0</HealthCheckRavenDB>
+    <HealthCheckRavenDB>2.2.1</HealthCheckRavenDB>
   </PropertyGroup>
 </Project>

--- a/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
+++ b/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>$(NetStandardTargetVersion)</TargetFramework>
     <PackageLicenseUrl>$(PackageLicenseUrl)</PackageLicenseUrl>
     <PackageProjectUrl>$(PackageProjectUrl)</PackageProjectUrl>
-    <PackageTags>HealthCheck;Health;MongoDb</PackageTags>
+    <PackageTags>HealthCheck;Health;RavenDB</PackageTags>
     <Description>HealthChecks.RavenDB is the health check package for RavenDB.</Description>
     <Version>$(HealthCheckRavenDB)</Version>
     <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>


### PR DESCRIPTION
In previous PR #77 was add package `HealthChecks.RavenDB` with incorrect tag `MongoDB`.
I changed it into `RavenDB`.