### PR TITLE
Add MongoClientSettings support for MongoDbHealthCheck

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -76,7 +76,7 @@
     <HealthCheckElasticsearch>2.2.1</HealthCheckElasticsearch>
     <HealthCheckOracle>2.2.0</HealthCheckOracle>
     <HealthCheckNpgSql>2.2.0</HealthCheckNpgSql>
-    <HealthCheckMongoDB>2.2.1</HealthCheckMongoDB>
+    <HealthCheckMongoDB>2.2.2</HealthCheckMongoDB>
     <HealthCheckMySql>2.2.0</HealthCheckMySql>
     <HealthCheckKafka>2.2.1</HealthCheckKafka>
     <HealthCheckSystem>2.2.1</HealthCheckSystem>

--- a/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
@@ -23,9 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, string mongodbConnectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            var mongoDbHealthCheck = new MongoDbHealthCheck(mongodbConnectionString);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new MongoDbHealthCheck(mongodbConnectionString),
+                sp => mongoDbHealthCheck,
                 failureStatus,
                 tags));
         }
@@ -45,9 +46,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, string mongodbConnectionString, string mongoDatabaseName, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            var mongoDbHealthCheck = new MongoDbHealthCheck(mongodbConnectionString, mongoDatabaseName);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new MongoDbHealthCheck(mongodbConnectionString, mongoDatabaseName),
+                sp => mongoDbHealthCheck,
                 failureStatus,
                 tags));
         }
@@ -66,9 +68,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            var mongoDbHealthCheck = new MongoDbHealthCheck(mongoClientSettings);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new MongoDbHealthCheck(mongoClientSettings),
+                sp => mongoDbHealthCheck,
                 failureStatus,
                 tags));
         }
@@ -88,9 +91,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string mongoDatabaseName, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
+            var mongoDbHealthCheck = new MongoDbHealthCheck(mongoClientSettings, mongoDatabaseName);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new MongoDbHealthCheck(mongoClientSettings, mongoDatabaseName),
+                sp => mongoDbHealthCheck,
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using HealthChecks.MongoDb;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Collections.Generic;
+using MongoDB.Driver;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -47,6 +48,49 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
                 sp => new MongoDbHealthCheck(mongodbConnectionString, mongoDatabaseName),
+                failureStatus,
+                tags));
+        }
+
+        /// <summary>
+        /// Add a health check for MongoDb database that list all collections from specified database on <paramref name="mongoDatabaseName"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="mongoClientSettings">The MongoClientSettings to be used.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'mongodb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new MongoDbHealthCheck(mongoClientSettings),
+                failureStatus,
+                tags));
+        }
+
+        /// <summary>
+        /// Add a health check for MongoDb database that list all collections from specified database on <paramref name="mongoDatabaseName"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="mongoClientSettings">The MongoClientSettings to be used.</param>
+        /// <param name="mongoDatabaseName">The Database name to check.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'mongodb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string mongoDatabaseName, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new MongoDbHealthCheck(mongoClientSettings, mongoDatabaseName),
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.MongoDb/DependencyInjection/MongoDbHealthCheckBuilderExtensions.cs
@@ -20,13 +20,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, string mongodbConnectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
-            var mongoDbHealthCheck = new MongoDbHealthCheck(mongodbConnectionString);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => mongoDbHealthCheck,
+                sp => new MongoDbHealthCheck(mongodbConnectionString),
                 failureStatus,
                 tags));
         }
@@ -43,13 +42,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, string mongodbConnectionString, string mongoDatabaseName, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
-            var mongoDbHealthCheck = new MongoDbHealthCheck(mongodbConnectionString, mongoDatabaseName);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => mongoDbHealthCheck,
+                sp => new MongoDbHealthCheck(mongodbConnectionString, mongoDatabaseName),
                 failureStatus,
                 tags));
         }
@@ -65,13 +63,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
-            var mongoDbHealthCheck = new MongoDbHealthCheck(mongoClientSettings);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => mongoDbHealthCheck,
+                sp => new MongoDbHealthCheck(mongoClientSettings),
                 failureStatus,
                 tags));
         }
@@ -88,13 +85,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddMongoDb(this IHealthChecksBuilder builder, MongoClientSettings mongoClientSettings, string mongoDatabaseName, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
-            var mongoDbHealthCheck = new MongoDbHealthCheck(mongoClientSettings, mongoDatabaseName);
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => mongoDbHealthCheck,
+                sp => new MongoDbHealthCheck(mongoClientSettings, mongoDatabaseName),
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -9,11 +9,19 @@ namespace HealthChecks.MongoDb
     public class MongoDbHealthCheck
         : IHealthCheck
     {
-        private readonly string _connectionString;
         private readonly string _specifiedDatabase;
+        private readonly MongoClientSettings _clientSettings;
         public MongoDbHealthCheck(string connectionString, string databaseName = default)
         {
-            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString == null)
+                throw new ArgumentNullException(nameof(connectionString));
+
+            _clientSettings = new MongoClient(connectionString).Settings.Clone();
+            _specifiedDatabase = databaseName;
+        }
+        public MongoDbHealthCheck(MongoClientSettings clientSettings, string databaseName = default)
+        {
+            _clientSettings = clientSettings;
             _specifiedDatabase = databaseName;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -26,13 +34,13 @@ namespace HealthChecks.MongoDb
                     // this you can list only collection on specified database.
                     // Related with issue #43
 
-                    await new MongoClient(_connectionString)
+                    await new MongoClient(_clientSettings)
                         .GetDatabase(_specifiedDatabase)
                         .ListCollectionsAsync();
                 }
                 else
                 {
-                    await new MongoClient(_connectionString)
+                    await new MongoClient(_clientSettings)
                         .ListDatabasesAsync(cancellationToken);
                 }
 

--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
 using MongoDB.Driver;
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,8 +10,9 @@ namespace HealthChecks.MongoDb
     public class MongoDbHealthCheck
         : IHealthCheck
     {
+        private static readonly ConcurrentDictionary<MongoClientSettings, MongoClient> _mongoClient = new ConcurrentDictionary<MongoClientSettings, MongoClient>();
+        private readonly MongoClientSettings _mongoClientSettings;
         private readonly string _specifiedDatabase;
-        private readonly IMongoClient _mongoClient;
 
         public MongoDbHealthCheck(string connectionString, string databaseName = default) : this(MongoClientSettings.FromUrl(MongoUrl.Create(connectionString)), databaseName)
         {
@@ -18,26 +20,35 @@ namespace HealthChecks.MongoDb
         public MongoDbHealthCheck(MongoClientSettings clientSettings, string databaseName = default)
         {
             _specifiedDatabase = databaseName;
-            _mongoClient = new MongoClient(clientSettings);
+            _mongoClientSettings = clientSettings;
         }
-
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
+                if (!_mongoClient.TryGetValue(_mongoClientSettings, out var mongoClient))
+                {
+                    mongoClient = new MongoClient(_mongoClientSettings);
+
+                    if (!_mongoClient.TryAdd(_mongoClientSettings, mongoClient))
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: "New MongoClient can't be added into dictionary.");
+                    }
+                }
+
                 if (!string.IsNullOrEmpty(_specifiedDatabase))
                 {
                     // some users can't list all databases depending on database privileges, with
                     // this you can list only collection on specified database.
                     // Related with issue #43
 
-                    await _mongoClient
+                    await mongoClient
                         .GetDatabase(_specifiedDatabase)
-                        .ListCollectionsAsync();
+                        .ListCollectionsAsync(cancellationToken: cancellationToken);
                 }
                 else
                 {
-                    await _mongoClient
+                    await mongoClient
                         .ListDatabasesAsync(cancellationToken);
                 }
 

--- a/test/UnitTests/DependencyInjection/MongoDb/MongoUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/MongoDb/MongoUnitTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.MongoDb
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddMongoDb(new MongoClient("mongodb://connectionstring").Settings.Clone());
+                .AddMongoDb(MongoClientSettings.FromUrl(MongoUrl.Create("mongodb://connectionstring")));
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
@@ -64,7 +64,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.MongoDb
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddMongoDb(new MongoClient("mongodb://connectionstring").Settings.Clone(), name: "my-mongodb-group");
+                .AddMongoDb(MongoClientSettings.FromUrl(MongoUrl.Create("mongodb://connectionstring")), name: "my-mongodb-group");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();

--- a/test/UnitTests/DependencyInjection/MongoDb/MongoUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/MongoDb/MongoUnitTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using System.Linq;
+using MongoDB.Driver;
 using Xunit;
 
 namespace UnitTests.HealthChecks.DependencyInjection.MongoDb
@@ -11,11 +12,11 @@ namespace UnitTests.HealthChecks.DependencyInjection.MongoDb
     public class mongodb_registration_should
     {
         [Fact]
-        public void add_health_check_when_properly_configured()
+        public void add_health_check_when_properly_configured_connectionString()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddMongoDb("connectionstring");
+                .AddMongoDb("mongodb://connectionstring");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
@@ -27,11 +28,43 @@ namespace UnitTests.HealthChecks.DependencyInjection.MongoDb
             check.GetType().Should().Be(typeof(MongoDbHealthCheck));
         }
         [Fact]
-        public void add_named_health_check_when_properly_configured()
+        public void add_health_check_when_properly_configured_mongoClientSettings()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddMongoDb("connectionstring", name: "my-mongodb-group");
+                .AddMongoDb(new MongoClient("mongodb://connectionstring").Settings.Clone());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("mongodb");
+            check.GetType().Should().Be(typeof(MongoDbHealthCheck));
+        }
+        [Fact]
+        public void add_named_health_check_when_properly_configured_connectionString()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddMongoDb("mongodb://connectionstring", name: "my-mongodb-group");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("my-mongodb-group");
+            check.GetType().Should().Be(typeof(MongoDbHealthCheck));
+        }
+        [Fact]
+        public void add_named_health_check_when_properly_configured_mongoClientSettings()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddMongoDb(new MongoClient("mongodb://connectionstring").Settings.Clone(), name: "my-mongodb-group");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();


### PR DESCRIPTION
Hi!
It will be good if clients are able to pass MogoClientSettings to healthcheck (for example with SSL settings).