### PR TITLE
Allow configurable timeout for URI health-checks

### DIFF
--- a/src/HealthChecks.Uris/UriHealthCheckOptions.cs
+++ b/src/HealthChecks.Uris/UriHealthCheckOptions.cs
@@ -9,6 +9,7 @@ namespace HealthChecks.Uris
         IUriOptions UseGet();
         IUriOptions UsePost();
         IUriOptions UseHttpMethod(HttpMethod methodToUse);
+        IUriOptions UseTimeout(TimeSpan timeout);
         IUriOptions ExpectHttpCode(int codeToExpect);
         IUriOptions ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect);
         IUriOptions AddCustomHeader(string name, string value);
@@ -17,6 +18,8 @@ namespace HealthChecks.Uris
     public class UriOptions : IUriOptions
     {
         public HttpMethod HttpMethod { get; private set; }
+
+        public TimeSpan Timeout { get; private set; }
 
         public (int Min, int Max)? ExpectedHttpCodes { get; private set; }
 
@@ -68,6 +71,12 @@ namespace HealthChecks.Uris
             HttpMethod = methodToUse;
             return this;
         }
+
+        IUriOptions IUriOptions.UseTimeout(TimeSpan timeout)
+        {
+            Timeout = timeout;
+            return this;
+        }
     }
 
     public class UriHealthCheckOptions
@@ -77,6 +86,8 @@ namespace HealthChecks.Uris
         internal IEnumerable<UriOptions> UrisOptions => _urisOptions;
 
         internal HttpMethod HttpMethod { get; private set; }
+
+        internal TimeSpan Timeout { get; private set; }
 
         internal (int Min, int Max) ExpectedHttpCodes { get; private set; }
 
@@ -101,6 +112,12 @@ namespace HealthChecks.Uris
         public UriHealthCheckOptions UseHttpMethod(HttpMethod methodToUse)
         {
             HttpMethod = methodToUse;
+            return this;
+        }
+
+        public UriHealthCheckOptions UseTimeout(TimeSpan timeout)
+        {
+            Timeout = timeout;
             return this;
         }
 


### PR DESCRIPTION
* Add `Timeout` option to `UriHealthCheckOptions`
* Pass health-check `CancellationToken` during HTTP request within `UriHealthCheck`

Related to https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/81 and https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/60