### PR TITLE
Save detailed info (optionally) for each HealthCheck in AppInsights

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -15,13 +15,14 @@ namespace HealthChecks.Publisher.ApplicationInsights.DependencyInjection
         /// </remarks>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="instrumentationKey">Specified Application Insights instrumentation key. Optional. If <c>null</c> TelemetryConfiguration.Active is used.</param>
+        /// <param name="saveDetailedReport">Specifies if save an Application Isnghts event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HEalthCheck</c></param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default)
+        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false)
         {
             builder.Services
                .AddSingleton<IHealthCheckPublisher>(sp =>
                {
-                   return new ApplicationInsightsPublisher(instrumentationKey);
+                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport);
                });
 
             return builder;


### PR DESCRIPTION
This change allows (optionally) to save detailed info for each _HealthRequest_ report on Application Insights.

It is configurable with the parameter _saveDetailedReport_ on _AddApplicationInsightsPublisher_ setting it to true save detailed info.