### PR TITLE
extended rabbitMq health check with tls option.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -71,7 +71,7 @@
     <HealthCheckSqlite>2.2.0</HealthCheckSqlite>
     <HealthCheckUri>2.2.2</HealthCheckUri>
     <HealthCheckRedis>2.2.2</HealthCheckRedis>
-    <HealthCheckRabbitMQ>2.2.0</HealthCheckRabbitMQ>
+    <HealthCheckRabbitMQ>2.2.1</HealthCheckRabbitMQ>
     <HealthCheckEventStore>2.2.0</HealthCheckEventStore>
     <HealthCheckElasticsearch>2.2.1</HealthCheckElasticsearch>
     <HealthCheckOracle>2.2.0</HealthCheckOracle>

--- a/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using HealthChecks.RabbitMQ;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Collections.Generic;
+using RabbitMQ.Client;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="rabbitMQConnectionString">The RabbitMQ connection string to be used.</param>
+        /// <param name="sslOption">The RabbitMQ ssl options. Optional. If <c>null</c>, the ssl option will counted as disabled and not used.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -20,11 +22,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddRabbitMQ(this IHealthChecksBuilder builder, string rabbitMQConnectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        public static IHealthChecksBuilder AddRabbitMQ(this IHealthChecksBuilder builder, string rabbitMQConnectionString, SslOption sslOption = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new RabbitMQHealthCheck(rabbitMQConnectionString),
+                sp => new RabbitMQHealthCheck(rabbitMQConnectionString, sslOption),
                 failureStatus,
                 tags));
         }


### PR DESCRIPTION
The rabbitMq health check was missing tls option, thus it would be useless in many cases where tls with rabbitMq is enabled.