### PR TITLE
Cleaned old code for ApplicationInsightsPublisher Issue #122

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -89,7 +89,7 @@
     <HealthCheckConsul>2.2.1</HealthCheckConsul>
     <HealthCheckUI>2.2.18</HealthCheckUI>
     <HealthCheckUIClient>2.2.2</HealthCheckUIClient>
-    <HealthCheckPublisherAppplicationInsights>2.2.2</HealthCheckPublisherAppplicationInsights>
+    <HealthCheckPublisherAppplicationInsights>2.2.3</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherPrometheus>2.2.0</HealthCheckPublisherPrometheus>
     <HealthCheckAWSS3>2.2.0</HealthCheckAWSS3>
     <HealthCheckKeyVault>2.2.2</HealthCheckKeyVault>

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -29,12 +29,6 @@ namespace HealthChecks.Publisher.ApplicationInsights
         }
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
-            //override instrumentation key or use default instrumentation 
-            //key active on the project.
-            var configuration = String.IsNullOrWhiteSpace(_instrumentationKey)
-                ? TelemetryConfiguration.Active
-                : new TelemetryConfiguration(_instrumentationKey);
-
             var client = GetOrCreateTelemetryClient();
 
             if (_saveDetailedReport)
@@ -94,6 +88,7 @@ namespace HealthChecks.Publisher.ApplicationInsights
                             ? TelemetryConfiguration.Active
                             : new TelemetryConfiguration(_instrumentationKey);
 
+                        
                         _client = new TelemetryClient(configuration);
                     }
                 }


### PR DESCRIPTION
It created non-used and non-disposed objects for TelemetryConfiguration which can cause OutOfMemory exceptions. Cleaned the old code ensureing only one TelemetryConfiguration object is created for a singleton instance of TelemetryClient