### PR TITLE
Add support for custom tags and failure status of azure storage queues

### DIFF
--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddAzureBlobStorage(this IHealthChecksBuilder builder, string connectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
             return builder.Add(new HealthCheckRegistration(
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddAzureTableStorage(this IHealthChecksBuilder builder, string connectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
             return builder.Add(new HealthCheckRegistration(
@@ -63,14 +63,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddAzureQueueStorage(this IHealthChecksBuilder builder, string connectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
             return builder.Add(new HealthCheckRegistration(
                name ?? AZUREQUEUE_NAME,
                sp => new AzureQueueStorageHealthCheck(connectionString),
-               null,
-               new string[] { AZUREQUEUE_NAME }));
+               failureStatus,
+               tags));
         }
     }
 }

--- a/test/UnitTests/DependencyInjection/AzureStorage/AzureQueueStorageUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureStorage/AzureQueueStorageUnitTests.cs
@@ -26,6 +26,7 @@ namespace UnitTests.DependencyInjection.AzureStorage
             registration.Name.Should().Be("azurequeue");
             check.GetType().Should().Be(typeof(AzureQueueStorageHealthCheck));
         }
+        
         [Fact]
         public void add_named_health_check_when_properly_configured()
         {
@@ -40,6 +41,42 @@ namespace UnitTests.DependencyInjection.AzureStorage
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("my-azurequeue-group");
+            check.GetType().Should().Be(typeof(AzureQueueStorageHealthCheck));
+        }
+       
+        [Fact] 
+        public void add_custom_tagged_health_check_when_properly_configured() 
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureQueueStorage("the-connection-string", name: "my-azurequeue-group", tags: new[] { "custom-tag" } );
+    
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+    
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+            
+            registration.Name.Should().Be("my-azurequeue-group");
+            registration.Tags.Should().Contain("custom-tag");
+            check.GetType().Should().Be(typeof(AzureQueueStorageHealthCheck));
+        }
+        
+        [Fact] 
+        public void add_health_check_with_custom_failure_status_when_properly_configured() 
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureQueueStorage("the-connection-string", name: "my-azurequeue-group", failureStatus: HealthStatus.Degraded );
+    
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+    
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+            
+            registration.Name.Should().Be("my-azurequeue-group");
+            registration.FailureStatus.Should().Be(HealthStatus.Degraded);
             check.GetType().Should().Be(typeof(AzureQueueStorageHealthCheck));
         }
     }


### PR DESCRIPTION
# General

In our project, we've faced an issue regarding the health checks of the storage queue within the package: **AspNetCore.HealthChecks.AzureStorage**

The problem was, that no matter what connection string has been passed to the health check, the result was always healthy.
After a quick look in the code, we found out, that the handling of the storage queue doesn't follow the same behavior as the tables and blobs.

For all three storage types, there is an option to pass user defined tags to the health check. However, the health check extension for the queue ignores them and uses an internal identifier.

# Solution

The simple solution here is to align the behavior of the storage queue to the behavior of the table and blobs.

# What has been changed

Instead of `new string[] { AZUREQUEUE_NAME }` which has been used as tags, no matter what the user has been passed to the extension method, the tags from the parameter will be passed to the health check builder now.

Corresponding unit tests has been added too.
