### PR TITLE
Add fluent api configuration for healthchecks

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -88,7 +88,7 @@
     <HealthCheckHangfire>2.2.1</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>2.2.4</HealthCheckAzureServiceBus>
     <HealthCheckConsul>2.2.1</HealthCheckConsul>
-    <HealthCheckUI>2.2.26</HealthCheckUI>
+    <HealthCheckUI>2.2.27</HealthCheckUI>
     <HealthCheckUIClient>2.2.3</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>2.2.3</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherPrometheus>2.2.0</HealthCheckPublisherPrometheus>

--- a/samples/HealthChecks.UIAndApiCustomization/Startup.cs
+++ b/samples/HealthChecks.UIAndApiCustomization/Startup.cs
@@ -19,6 +19,13 @@ namespace HealthChecks.UIAndApi
 
             services
                 .AddHealthChecksUI()
+//                .AddHealthChecksUI(setupSettings: settings =>
+//                {
+//                    settings
+//                        .AddHealthCheckEndpoint("api1", "http://localhost:8001/custom/healthz")
+//                        .AddWebhookNotification("webhook1", "http://webhook", "mypayload")
+//                        .SetEvaluationTimeInSeconds(16);
+//                })
                 .AddHealthChecks()
                 .AddUrlGroup(new Uri("http://httpbin.org/status/200"), name: "uri-1")
                 .AddUrlGroup(new Uri("http://httpbin.org/status/200"), name: "uri-2")

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -4,11 +4,52 @@ namespace HealthChecks.UI.Configuration
 {
     public class Settings
     {
-        public List<HealthCheckSetting> HealthChecks { get; set; } = new List<HealthCheckSetting>();
-        public List<WebHookNotification> Webhooks { get; set; } = new List<WebHookNotification>();
-        public int EvaluationTimeOnSeconds { get; set; } = 10;
-        public int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
-        public string HealthCheckDatabaseConnectionString { get; set; }
+        internal List<HealthCheckSetting> HealthChecks { get; set; } = new List<HealthCheckSetting>();
+        internal List<WebHookNotification> Webhooks { get; set; } = new List<WebHookNotification>();
+        internal int EvaluationTimeInSeconds { get; set; } = 10;
+        internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
+        internal string HealthCheckDatabaseConnectionString { get; set; }
+
+        public Settings AddHealthCheckEndpoint(string name, string uri)
+        {
+            HealthChecks.Add(new HealthCheckSetting
+            {
+                Name = name,
+                Uri = uri
+            });
+
+            return this;
+        }
+        
+        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "")
+        {
+            Webhooks.Add(new WebHookNotification
+            {
+                Name = name,
+                Uri = uri,
+                Payload = payload,
+                RestoredPayload = restorePayload
+            });
+            return this;
+        }
+
+        public Settings SetEvaluationTimeInSeconds(int seconds)
+        {
+            EvaluationTimeInSeconds = seconds;
+            return this;
+        }
+        
+        public Settings SetMinimumSecondsBetweenFailureNotifications(int seconds)
+        {
+            MinimumSecondsBetweenFailureNotifications = seconds;
+            return this;
+        }
+
+        public Settings SetHealthCheckDatabaseConnectionString(string connectionString)
+        {
+            HealthCheckDatabaseConnectionString = connectionString;
+            return this;
+        }
     }
 
     public class HealthCheckSetting

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollectorHostedService.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollectorHostedService.cs
@@ -66,7 +66,7 @@ namespace HealthChecks.UI.Core.HostedService
                     }
                 }
 
-                await Task.Delay(_settings.EvaluationTimeOnSeconds * 1000, cancellationToken);
+                await Task.Delay(_settings.EvaluationTimeInSeconds * 1000, cancellationToken);
             }
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddOptions()
                 .Configure<Settings>(settings =>
                 {
-                    configuration.Bind(Keys.HEALTHCHECKSUI_SECTION_SETTING_KEY, settings);
+                    configuration.GetSection(Keys.HEALTHCHECKSUI_SECTION_SETTING_KEY)
+                        .Bind(settings, c => c.BindNonPublicProperties = true);
+                    
                     setupSettings?.Invoke(settings);
                 })
                 .Configure<KubernetesDiscoverySettings>(settings=>


### PR DESCRIPTION
We received a PR some weeks ago to expose Action<Settings> so remote endpoints, webhooks and UI stuff can be configured by code instead of using appsettings.json.

This commit allows combining appsettings.json with Action<Settings> configuration callback or start configuring the checks from scratch without appsetting.json file.

However, it is not very friendly to apply configuration with the current settings class, and although we are not applying any kind of **validations** on settings yet, the current configuration class does not allow to do it as we expose collections and settings directly:

```csharp
  settings.HealthChecks.Add(new HealthCheckSetting
                       { 
                               Name = "api1", Uri = "http://localhost:5000/health-ui
                       });

  settings.WebHooks.Add(new WebHookNotification
         {
           Name = "webhook1",
           Uri = "http://localhost/webhookuri/sample,
           Payload = "mypayload"
        });

  settings.EvaluationTimeInSeconds = 20;
  settings.MinimumSecondsBetweenFailureNotifications = 10;

```
The current proposal is a fluent api that helps configuring healthchecks and webhooks and allow us to configure future validations inside settings class:

```csharp
 .AddHealthChecksUI(setupSettings: settings =>
               {
                  settings
                      .AddHealthCheckEndpoint("api1", "http://localhost:8001/custom/healthz")
                      .AddWebhookNotification("webhook1", "http://webhook", "mypayload")
                      .SetEvaluationTimeInSeconds(16)
              });
```