### PR TITLE
Added overload to Raven Health check to allow user to pass RavenDBOptions

### DIFF
--- a/src/HealthChecks.RavenDB/RavenDBOptions.cs
+++ b/src/HealthChecks.RavenDB/RavenDBOptions.cs
@@ -1,0 +1,13 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace HealthChecks.RavenDB
+{
+    public class RavenDBOptions
+    {
+        public string[] Urls { get; set; }
+
+        public X509Certificate2 Certificate { get; set; }
+
+        public string Database { get; set; }
+    }
+}

--- a/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithOptionsHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithOptionsHealthCheckTests.cs
@@ -1,0 +1,149 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthChecks.RavenDB
+{
+    [Collection("execution")]
+    public class ravendb_with_options_healthcheck_should
+    {
+        private readonly ExecutionFixture _fixture;
+        private readonly string[] _urls = new[] {"http://live-test.ravendb.net:80"};
+
+        public ravendb_with_options_healthcheck_should(ExecutionFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_healthy_if_ravendb_is_available()
+        {
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddHealthChecks()
+                        .AddRavenDB(_ => { _.Urls = _urls; }, tags: new string[] {"ravendb"});
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ravendb")
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.OK);
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_healthy_if_ravendb_is_available_and_contains_specific_database()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddHealthChecks()
+                        .AddRavenDB(_ =>
+                        {
+                            _.Urls = _urls;
+                            _.Database = "Demo";
+                        }, tags: new string[] {"ravendb"});
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ravendb")
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_ravendb_is_not_available()
+        {
+            var connectionString = "http://localhost:9999";
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddHealthChecks()
+                        .AddRavenDB(_ => { _.Urls = new string[] {connectionString}; }, tags: new string[] {"ravendb"});
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ravendb")
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_ravendb_is_available_but_database_doesnot_exist()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddHealthChecks()
+                        .AddRavenDB(_ =>
+                        {
+                            _.Urls = _urls;
+                            _.Database = "ThisDatabaseReallyDoesnExist";
+                        }, tags: new string[] {"ravendb"});
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ravendb")
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+    }
+}

--- a/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithSingleConnectionStringHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithSingleConnectionStringHealthCheckTests.cs
@@ -9,16 +9,17 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
+#pragma warning disable 618
 
 namespace FunctionalTests.HealthChecks.RavenDB
 {
     [Collection("execution")]
-    public class ravendb_healthcheck_should
+    public class ravendb_with_single_connection_string_healthcheck_should
     {
         private readonly ExecutionFixture _fixture;
         private const string ConnectionString = "http://live-test.ravendb.net:80";
 
-        public ravendb_healthcheck_should(ExecutionFixture fixture)
+        public ravendb_with_single_connection_string_healthcheck_should(ExecutionFixture fixture)
         {
             _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }

--- a/test/UnitTests/DependencyInjection/RavenDB/RavenWithOptionsUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/RavenDB/RavenWithOptionsUnitTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using HealthChecks.RavenDB;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System.Linq;
+using Xunit;
+
+namespace UnitTests.DependencyInjection.RavenDB
+{
+    public class ravendb_with_options_registration_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddRavenDB(_ => { _.Urls = new[] {"http://localhost:8080", "http://localhost:8081"}; });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("ravendb");
+            check.GetType().Should().Be(typeof(RavenDBHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddRavenDB(_ => { _.Urls = new[] {"http://localhost:8080", "http://localhost:8081"}; },
+                    name: "my-ravendb");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("my-ravendb");
+            check.GetType().Should().Be(typeof(RavenDBHealthCheck));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/RavenDB/RavenWithSingleConnectionStringUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/RavenDB/RavenWithSingleConnectionStringUnitTests.cs
@@ -5,10 +5,11 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using System.Linq;
 using Xunit;
+#pragma warning disable 618
 
 namespace UnitTests.DependencyInjection.RavenDB
 {
-    public class ravendb_registration_should
+    public class ravendb_with_single_conection_string_registration_should
     {
         [Fact]
         public void add_health_check_when_properly_configured()


### PR DESCRIPTION
With this pull request, I have added a method overload to allow user to pass <s>array of Raven URLs</s> `RavenDBOptions` instead of just single connection string. Note that existing method which allows the user to pass single connection string is still there but it has been marked `Obsolete`.

**Why this change?**
- This change is useful to test the health check for the Raven DB Cluster (that is multiple nodes) instead of a single connection string. For Load Balance and Fail over scenarios we would have multiple connection strings instead of one.
- In addition to this, `RavenDBOptions` also supports certificate authentication. That is user can _optionally_ pass the authentication certificate, which should ideally be a requirement for any production workload (like ours)

As an alternate (without the changes in this PR), we can add multiple raven DB urls as pseudocode below:

        var counter = 1;
        foreach(var url in urls)
        {
            healthCheckBuilder.AddRavenDB(url, "DemoDbName",$"ravendb node{counter}, url: {url} ");
            ++counter;
        }

However, this is less than ideal for following reasons:
- It means additional lines of code.
- If one of urls is down/ unavailable the overall health status would be returned as "Unhealthy" which is incorrect since server can still connect to the alternate Raven DB url.
- In scenarios where authentication is required we cannot use this health check library. 