### PR TITLE
exclude reports that indicate a healthy status

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -15,14 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="instrumentationKey">Specified Application Insights instrumentation key. Optional. If <c>null</c> TelemetryConfiguration.Active is used.</param>
-        /// <param name="saveDetailedReport">Specifies if save an Application Isnghts event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HEalthCheck</c></param>
+        /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HealthCheck</c></param>
+        /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false)
+        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false)
         {
             builder.Services
                .AddSingleton<IHealthCheckPublisher>(sp =>
                {
-                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport);
+                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport, excludeHealthyReports);
                });
 
             return builder;

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using HealthChecks.Publisher.ApplicationInsights;
-using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.DependencyInjection


### PR DESCRIPTION
Fix for #138 that makes it possible to configure the Application Insights publisher to only publish reports that indicate an unhealthy state by adding an optional flag `excludeHealthyReports`. 

When the publisher is configured to publish the details (using `saveDetailedReport`) only those detailed reports indicating an unhealthy state will be published if `excludeHealthyReports` is set to `true`

I am all open for creating a functional test for this (as there are none for this particalur publisher) but I would like to add a dependency to [Moq](https://github.com/Moq/moq4/wiki/Quickstart) or [NSubstitute](https://nsubstitute.github.io/) in order to be able to fake the application insights classes involved. If that is ok with you I can add those tests, otherwise I need to figure out other ways.