### PR TITLE
Fix spelling/grammer issues in HangfireHealthCheck error message.

### DIFF
--- a/src/HealthChecks.Hangfire/HangfireHealthCheck.cs
+++ b/src/HealthChecks.Hangfire/HangfireHealthCheck.cs
@@ -27,7 +27,7 @@ namespace HealthChecks.Hangfire
                     var failedJobsCount = hangfireMonitoringApi.FailedCount();
                     if (failedJobsCount >= _hangfireOptions.MaximumJobsFailed)
                     {
-                        errorList.Add($"Hangfire have #{failedJobsCount} failed jobs and the maximun available is {_hangfireOptions.MaximumJobsFailed}.");
+                        errorList.Add($"Hangfire has #{failedJobsCount} failed jobs and the maximum available is {_hangfireOptions.MaximumJobsFailed}.");
                     }
                 }
 


### PR DESCRIPTION
Addressing issue #169.   Small fixes to some spelling / grammer issues in HangfireHealthCheck.