### PR TITLE
Register a SQL Server Health Check with a factory for the connection string

### DIFF
--- a/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using HealthChecks.SqlServer;
+﻿using System;
+using HealthChecks.SqlServer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Collections.Generic;
 
@@ -6,7 +7,9 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class SqlServerHealthCheckBuilderExtensions
     {
-        const string NAME = "sqlserver";
+        private const string HEALTH_QUERY = "SELECT 1;";
+        private const string NAME = "sqlserver";
+
         /// <summary>
         /// Add a health check for SqlServer services.
         /// </summary>
@@ -19,12 +22,39 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddSqlServer(this IHealthChecksBuilder builder, string connectionString, string healthQuery = "SELECT 1;", string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddSqlServer(this IHealthChecksBuilder builder, string connectionString,
+            string healthQuery = default, string name = default, HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default)
         {
+            return builder.AddSqlServer(_ => connectionString, healthQuery, name, failureStatus, tags);
+        }
+
+        /// <summary>
+        /// Add a health check for SqlServer services.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the SQL Server connection string to use.</param>
+        /// <param name="healthQuery">The query to be executed.Optional. If <c>null</c> select 1 is used.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'sqlserver' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddSqlServer(this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory, string healthQuery = default,
+            string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new SqlServerHealthCheck(connectionString, healthQuery),
+                sp => new SqlServerHealthCheck(connectionStringFactory(sp), healthQuery ?? HEALTH_QUERY),
                 failureStatus,
                 tags));
         }

--- a/test/UnitTests/DependencyInjection/SqlServer/SqlServerUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/SqlServer/SqlServerUnitTests.cs
@@ -25,7 +25,6 @@ namespace UnitTests.HealthChecks.DependencyInjection.SqlServer
 
             registration.Name.Should().Be("sqlserver");
             check.GetType().Should().Be(typeof(SqlServerHealthCheck));
-
         }
 
         [Fact]
@@ -43,6 +42,39 @@ namespace UnitTests.HealthChecks.DependencyInjection.SqlServer
 
             registration.Name.Should().Be("my-sql-server-1");
             check.GetType().Should().Be(typeof(SqlServerHealthCheck));
+        }
+
+        [Fact]
+        public void add_health_check_with_connection_string_factory_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            var factoryCalled = false;
+            services.AddHealthChecks()
+                .AddSqlServer(_ =>
+                {
+                    factoryCalled = true;
+                    return "connectionstring";
+                });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("sqlserver");
+            check.GetType().Should().Be(typeof(SqlServerHealthCheck));
+            factoryCalled.Should().BeTrue();
+        }
+
+        private class SqlServerConfig
+        {
+            public readonly string ConnectionString;
+
+            public SqlServerConfig(string connectionString)
+            {
+                ConnectionString = connectionString;
+            }
         }
     }
 }

--- a/test/UnitTests/DependencyInjection/SqlServer/SqlServerUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/SqlServer/SqlServerUnitTests.cs
@@ -66,15 +66,5 @@ namespace UnitTests.HealthChecks.DependencyInjection.SqlServer
             check.GetType().Should().Be(typeof(SqlServerHealthCheck));
             factoryCalled.Should().BeTrue();
         }
-
-        private class SqlServerConfig
-        {
-            public readonly string ConnectionString;
-
-            public SqlServerConfig(string connectionString)
-            {
-                ConnectionString = connectionString;
-            }
-        }
     }
 }


### PR DESCRIPTION
As discussed in #173 

This allows you to use `services.AddSqlServer(...` if you use dependency injection for your configuration. Sample usage:
```cs
services.AddHealthChecks()
	.AddSqlServer(provider => provider.GetService<DatabaseSettings>().ConnectionString,
		name: "db", tags: new string[] {"readiness"});
```

which would currently require using `services.Add(new HealthCheckRegistration(...` from Microsoft.Extensions.Diagnostics.HealthChecks:
```cs
services.AddHealthChecks()
	.Add(new HealthCheckRegistration("db", provider =>
	{
		DatabaseSettings dbSettings = provider.GetService<DatabaseSettings>();
		return new SqlServerHealthCheck(dbSettings.ConnectionString, "SELECT 1;");
	}, null, new string[] { "readiness" }));
```

If this seems reasonable for SQL Server, it may make sense for most (all?) other health checks too.