### PR TITLE
Fix functional tests running locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,9 @@ services:
         ports:
           - ${IDSVR_PORT}:80
     oracle:
-        image: wnameless/oracle-xe-11g
+# Build image from src, pending legal issues with binary distribution https://github.com/wnameless/docker-oracle-xe-11g/issues/118
+        build:
+          context: https://github.com/wnameless/docker-oracle-xe-11g.git
         ports: 
             - ${ORACLE_PORT}:1521
         environment:


### PR DESCRIPTION
wnameless/oracle-xe-11g docker image no longer exists as Oracle DMCA'd it. See https://github.com/wnameless/docker-oracle-xe-11g/issues/118  

This PR changes it to be built from source instead.  

Note that if you already have the wnameless/oracle-xe-11g docker image cached locally, it will still be working for you, so delete that image to reproduce the issue.