### PR TITLE
Uniform conversion for all datetime.

### DIFF
--- a/src/HealthChecks.UI/Core/Data/Configuration/HealthCheckExecutionHistoryMap.cs
+++ b/src/HealthChecks.UI/Core/Data/Configuration/HealthCheckExecutionHistoryMap.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace HealthChecks.UI.Core.Data.Configuration
@@ -9,7 +10,8 @@ namespace HealthChecks.UI.Core.Data.Configuration
         public void Configure(EntityTypeBuilder<HealthCheckExecutionHistory> builder)
         {
             builder.Property(le => le.On)
-                .IsRequired(true);
+                .IsRequired(true)
+                .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
             builder.Property(le => le.Status)
                 .HasMaxLength(50)

--- a/src/HealthChecks.UI/Core/Data/Configuration/HealthCheckFailureNotificationsMap.cs
+++ b/src/HealthChecks.UI/Core/Data/Configuration/HealthCheckFailureNotificationsMap.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace HealthChecks.UI.Core.Data.Configuration
@@ -13,7 +14,8 @@ namespace HealthChecks.UI.Core.Data.Configuration
                 .IsRequired();
 
             builder.Property(lf => lf.LastNotified)
-                .IsRequired();
+                .IsRequired()
+                .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
             builder.Property(lf => lf.IsUpAndRunning)
                 .IsRequired();


### PR DESCRIPTION
hi, thx for providing healthchecks code.

We have an error, only in our Docker/Rancher environment as this: 'Unknown Date' with no exception or details. This is not true json, witch have the side effect, that all logning is disgarded.
 

`
21.5.2019 14.03.13{"Timestamp":"2019-05-21T12:03:13.0745532+00:00","Level":"Information","MessageTemplate":"Executed DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}","Properties":{"elapsed":"0","parameters":"@p1='?', @p0='?'","commandType":"Text","commandTimeout":30,"newLine":"\n","commandText":"UPDATE \"HealthCheckExecutionEntries\" SET \"Duration\" = @p0\nWHERE \"Id\" = @p1;\nSELECT changes();","EventId":{"Id":20101,"Name":"Microsoft.EntityFrameworkCore.Database.Command.CommandExecuted"},"SourceContext":"Microsoft.EntityFrameworkCore.Database.Command","Scope":["HealthReportCollector is collecting health checks results."]}}
21.5.2019 14.03.13{"Timestamp":"2019-05-21T12:03:13.0843973+00:00","Level":"Debug","MessageTemplate":"HealthReportCollector has completed.","Properties":{"SourceContext":"HealthChecks.UI.Core.HostedService.HealthCheckReportCollector","Scope":["HealthReportCollector is collecting health checks results."]}}
21.5.2019 14.03.13{"Timestamp":"2019-05-21T12:03:13.0844621+00:00","Level":"Debug","MessageTemplate":"HealthCheck collector HostedService executed successfully.","Properties":{"SourceContext":"HealthChecks.UI.Core.HostedService.HealthCheckCollectorHostedService"}}
**Unknown Date**
`
Since I dont know, what timezone our environment is using and sqlite dont have datetime. 
We beleave that missing convertion for datetime i missing and may be the root of your error.

I have tryed to test the code, but have not had any success in doing that in our environment witch will include jenkins, push to docker, running in rancher.  
