### PR TITLE
Added an optional action for Npgsql-specific configurations

### DIFF
--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -1,18 +1,22 @@
-﻿using HealthChecks.NpgSql;
+﻿using System;
+using HealthChecks.NpgSql;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Collections.Generic;
+using Npgsql;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class NpgSqlHealthCheckBuilderExtensions
     {
         const string NAME = "npgsql";
+
         /// <summary>
         /// Add a health check for Postgres databases.
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="npgsqlConnectionString">The Postgres connection string to be used.</param>
         /// /// <param name="healthQuery">The query to be used in check. Optional. If <c>null</c> SELECT 1 is used.</param>
+        /// <param name="connectionAction">An optional action to allow additional Npgsql-specific configuration.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -20,11 +24,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, string npgsqlConnectionString, string healthQuery = "SELECT 1;", string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
+        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, string npgsqlConnectionString, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default)
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new NpgSqlHealthCheck(npgsqlConnectionString, healthQuery),
+                sp => new NpgSqlHealthCheck(npgsqlConnectionString, healthQuery, connectionAction),
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
@@ -11,10 +11,12 @@ namespace HealthChecks.NpgSql
     {
         private readonly string _connectionString;
         private readonly string _sql;
-        public NpgSqlHealthCheck(string npgsqlConnectionString, string sql)
+        private readonly Action<NpgsqlConnection> _connectionAction;
+        public NpgSqlHealthCheck(string npgsqlConnectionString, string sql, Action<NpgsqlConnection> connectionAction = null)
         {
             _connectionString = npgsqlConnectionString ?? throw new ArgumentNullException(nameof(npgsqlConnectionString));
             _sql = sql ?? throw new ArgumentNullException(nameof(sql));
+            _connectionAction = connectionAction;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
@@ -22,6 +24,8 @@ namespace HealthChecks.NpgSql
             {
                 using (var connection = new NpgsqlConnection(_connectionString))
                 {
+                    _connectionAction?.Invoke(connection);
+
                     await connection.OpenAsync(cancellationToken);
 
                     using (var command = connection.CreateCommand())


### PR DESCRIPTION
The NpgSql healthcheck missed the option for a ClientCertificateCallback (to connect to SSL encrypted database instances). The motivation for this PR. However, it is now also possible to set other properties within the NpgsqlConnection class (the type of the action).

**Note:** I've changed the Unit test for the NpgSql project locally to test my certificate on my database instance and it passed the test.