### PR TITLE
Added overload of WriteHealthCheckUIResponse that allows for custom JSON serialization settings

### DIFF
--- a/src/HealthChecks.UI.Client/UIResponseWriter.cs
+++ b/src/HealthChecks.UI.Client/UIResponseWriter.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+using System;
 using System.Threading.Tasks;
 
 namespace HealthChecks.UI.Client
@@ -10,7 +11,9 @@ namespace HealthChecks.UI.Client
     public static class UIResponseWriter
     {
         const string DEFAULT_CONTENT_TYPE = "application/json";
-        public static Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report)
+        public static Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report) => WriteHealthCheckUIResponse(httpContext, report, null);
+
+        public static Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report, Action<JsonSerializerSettings> jsonConfigurator)
         {
             var response = "{}";
 
@@ -22,6 +25,8 @@ namespace HealthChecks.UI.Client
                     NullValueHandling = NullValueHandling.Ignore,
                     ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 };
+
+                jsonConfigurator?.Invoke(settings);
 
                 settings.Converters.Add(new StringEnumConverter());
 


### PR DESCRIPTION
This will allow users to customize the way their health check responses are serialized. For example, to use something other than camel case:

```csharp
app.UseHealthChecks("/healthz", new HealthCheckOptions
{
        Predicate = _ => true,
        ResponseWriter = (context, report) => UIResponseWriter.WriteHealthCheckUIResponse(context, report, settings =>
        {
            settings.ContractResolver = new DefaultContractResolver();
        })
});
```

It maintains full backwards compatibility with the existing API.