### PR TITLE
[UI] Allow configuring custom HttpMessageHandler in hc collector HttpClient

### DIFF
--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http;
 
 namespace HealthChecks.UI.Configuration
 {
@@ -9,6 +10,7 @@ namespace HealthChecks.UI.Configuration
         internal int EvaluationTimeInSeconds { get; set; } = 10;
         internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
         internal string HealthCheckDatabaseConnectionString { get; set; }
+        internal HttpMessageHandler HttpHandler { get; set; }
 
         public Settings AddHealthCheckEndpoint(string name, string uri)
         {
@@ -48,6 +50,12 @@ namespace HealthChecks.UI.Configuration
         public Settings SetHealthCheckDatabaseConnectionString(string connectionString)
         {
             HealthCheckDatabaseConnectionString = connectionString;
+            return this;
+        }
+
+        public Settings UseHttpMessageHandler(HttpMessageHandler handler)
+        {
+            HttpHandler = handler;
             return this;
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,17 +30,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     configuration.GetSection(Keys.HEALTHCHECKSUI_SECTION_SETTING_KEY)
                         .Bind(settings, c => c.BindNonPublicProperties = true);
-                    
+
                     setupSettings?.Invoke(settings);
                 })
-                .Configure<KubernetesDiscoverySettings>(settings=>
+                .Configure<KubernetesDiscoverySettings>(settings =>
                 {
                     configuration.Bind(Keys.HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY, settings);
                 })
                 .AddSingleton<IHostedService, HealthCheckCollectorHostedService>()
                 .AddScoped<IHealthCheckFailureNotifier, WebHookFailureNotifier>()
                 .AddScoped<IHealthCheckReportCollector, HealthCheckReportCollector>()
-                .AddHttpClient(Keys.HEALTH_CHECK_HTTP_CLIENT_NAME);
+                .AddHttpClient(Keys.HEALTH_CHECK_HTTP_CLIENT_NAME)
+                    .ConfigurePrimaryHttpMessageHandler(sp =>
+                   {
+                       var settings = sp.GetService<IOptions<Settings>>();
+                       return settings?.Value.HttpHandler ?? new HttpClientHandler();
+                   });
+
 
             var healthCheckSettings = services.BuildServiceProvider()
                 .GetService<IOptions<Settings>>()

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .ConfigurePrimaryHttpMessageHandler(sp =>
                    {
                        var settings = sp.GetService<IOptions<Settings>>();
-                       return settings?.Value.HttpHandler ?? new HttpClientHandler();
+                       return settings.Value.HttpHandler ?? new HttpClientHandler();
                    });
 
 


### PR DESCRIPTION
Extend settings to allow the user configuring a custom HttpMessageHandler for registered named client that is used by the HealthCheckReportCollector, this will allow user to configure credentials, proxy credentials, client certificates and all the other stuff that is present in the the message handler.

```
  var customHandler = new HttpClientHandler
            {
                DefaultProxyCredentials = CredentialCache.DefaultNetworkCredentials,
                UseDefaultCredentials = true,
                Properties =
                        {
                            ["1"] ="prop1",
                            ["2"] = "prop2"
                        }
            };

   services
          .AddHealthChecksUI(setupSettings: setup => {
                    setup.UseHttpMessageHandler(customHandler);
          });
```