### PR TITLE
#186 Application Insights publisher relays on Dependency Injection for Telemetry Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ services.AddHealthChecks()
         .AddPrometheusGatewayPublisher();
 ```
 
+Note:
+
+Following Microsoft good practices, Application Insights Publisher relays on dependency injection so it will try to get the TelemetryClient from the service provider.
+To register your own TelemetryClient you can use the package **Microsoft.AspNetCore.ApplicationInsights.HostingStartup**
+and use the extension method UseApplicationInsights().
+
+
+```csharp
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseApplicationInsights("your-telemetry-key")
+                .UseStartup<Startup>();
+```
+
+
 ## HealthCheckUI and failure notifications
 
 The project HealthChecks.UI is a minimal UI interface that stores and shows the health checks results from the configured HealthChecks uris.

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -96,7 +96,7 @@
     <HealthCheckConsul>2.2.2</HealthCheckConsul>
     <HealthCheckUI>2.2.31</HealthCheckUI>
     <HealthCheckUIClient>2.2.4</HealthCheckUIClient>
-    <HealthCheckPublisherAppplicationInsights>2.2.4</HealthCheckPublisherAppplicationInsights>
+    <HealthCheckPublisherAppplicationInsights>2.2.5</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherPrometheus>2.2.0</HealthCheckPublisherPrometheus>
     <HealthCheckAWSS3>2.2.0</HealthCheckAWSS3>
     <HealthCheckKeyVault>2.2.2</HealthCheckKeyVault>

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -17,16 +17,15 @@ namespace HealthChecks.Publisher.ApplicationInsights
         const string METRIC_STATUS_NAME = "AspNetCoreHealthCheckStatus";
         const string METRIC_DURATION_NAME = "AspNetCoreHealthCheckDuration";
         const string HEALTHCHECK_NAME = "AspNetCoreHealthCheckName";
-
-        private readonly string _instrumentationKey;
-        private static TelemetryClient _client;
-        private static readonly object sync_root = new object();
+     
+        private readonly TelemetryClient _client;
+        
         private readonly bool _saveDetailedReport;
         private readonly bool _excludeHealthyReports;
 
-        public ApplicationInsightsPublisher(string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false)
+        public ApplicationInsightsPublisher(TelemetryClient client, bool saveDetailedReport = false, bool excludeHealthyReports = false)
         {
-            _instrumentationKey = instrumentationKey;
+            _client = client;
             _saveDetailedReport = saveDetailedReport;
             _excludeHealthyReports = excludeHealthyReports;
         }
@@ -36,25 +35,23 @@ namespace HealthChecks.Publisher.ApplicationInsights
             {
                 return Task.CompletedTask;
             }
-
-            var client = GetOrCreateTelemetryClient();
-
+            
             if (_saveDetailedReport)
             {
-                SaveDetailedReport(report, client);
+                SaveDetailedReport(report);
             }
             else
             {
-                SaveGeneralizedReport(report, client);
+                SaveGeneralizedReport(report);
             }
 
             return Task.CompletedTask;
         }
-        private void SaveDetailedReport(HealthReport report, TelemetryClient client)
+        private void SaveDetailedReport(HealthReport report)
         {
             foreach (var reportEntry in report.Entries.Where(entry => !_excludeHealthyReports || entry.Value.Status != HealthStatus.Healthy))
             {
-                client.TrackEvent($"{EVENT_NAME}:{reportEntry.Key}",
+                _client.TrackEvent($"{EVENT_NAME}:{reportEntry.Key}",
                     properties: new Dictionary<string, string>()
                     {
                         { nameof(Environment.MachineName), Environment.MachineName },
@@ -68,9 +65,9 @@ namespace HealthChecks.Publisher.ApplicationInsights
                     });
             }
         }
-        private static void SaveGeneralizedReport(HealthReport report, TelemetryClient client)
+        private void SaveGeneralizedReport(HealthReport report)
         {
-            client.TrackEvent(EVENT_NAME,
+            _client.TrackEvent(EVENT_NAME,
                 properties: new Dictionary<string, string>
                 {
                     { nameof(Environment.MachineName), Environment.MachineName },
@@ -81,27 +78,6 @@ namespace HealthChecks.Publisher.ApplicationInsights
                     { METRIC_STATUS_NAME, report.Status == HealthStatus.Healthy ? 1 : 0 },
                     { METRIC_DURATION_NAME, report.TotalDuration.TotalMilliseconds }
                 });
-        }
-        private TelemetryClient GetOrCreateTelemetryClient()
-        {
-            if (_client == null)
-            {
-                lock (sync_root)
-                {
-                    if (_client == null)
-                    {
-                        //override instrumentation key or use default instrumentation 
-                        //key active on the project.
-
-                        var configuration = string.IsNullOrWhiteSpace(_instrumentationKey)
-                            ? TelemetryConfiguration.Active
-                            : new TelemetryConfiguration(_instrumentationKey);
-
-                        _client = new TelemetryClient(configuration);
-                    }
-                }
-            }
-            return _client;
-        }
+        }     
     }
 }

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -17,12 +19,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HealthCheck</c></param>
         /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false)
+        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, bool saveDetailedReport = false, bool excludeHealthyReports = false)
         {
             builder.Services
                .AddSingleton<IHealthCheckPublisher>(sp =>
                {
-                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport, excludeHealthyReports);
+                   var telemetryClient = sp.GetService<TelemetryClient>()  ?? throw new Exception($"Application insights telemetry client has not been registered in the application"); 
+
+                   return new ApplicationInsightsPublisher(telemetryClient, saveDetailedReport, excludeHealthyReports);
                });
 
             return builder;


### PR DESCRIPTION
Following #186 
With this change, the application insights publisher will relay in dependency injection to retrieve the Telemetry Client, this reduces complexity in the publisher when trying to create the client and also follows Microsoft good practices.

Updated documentation as the hosting application will need to register Application Insights using 

 ```
  public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
            WebHost.CreateDefaultBuilder(args)
                .UseApplicationInsights()
                .UseStartup<Startup>();
```