### PR TITLE
Register Azure Service Bus health checks with factories

### DIFF
--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
         /// <param name="queueNameFactory">A factory to build the name of the queue to check.</param>
-        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -377,7 +377,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
         /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
-        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -545,7 +545,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
         /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
         /// <param name="subscriptionNameFactory">A factory to build the subscription name of the topic to check.</param>
-        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then

--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -38,11 +38,50 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureEventHub(
+                _ => connectionString,
+                _ => eventHubName,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for specified Azure Event Hub.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the azure event hub connection string.</param>
+        /// <param name="eventHubNameFactory">A factory to build the azure event hub name.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azureeventhub' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureEventHub(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory,
+            Func<IServiceProvider, string> eventHubNameFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+            if (eventHubNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(eventHubNameFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREEVENTHUB_NAME,
-                sp => new AzureEventHubHealthCheck(connectionString, eventHubName),
+                sp => new AzureEventHubHealthCheck(connectionStringFactory(sp), eventHubNameFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -98,11 +137,50 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusQueue(
+                _ => connectionString,
+                _ => queueName,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Queue.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the azure service bus connection string to be used.</param>
+        /// <param name="queueNameFactory">A factory to build the queue name to check.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusQueue(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory,
+            Func<IServiceProvider, string> queueNameFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+            if (queueNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(queueNameFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREQUEUE_NAME,
-                sp => new AzureServiceBusQueueHealthCheck(connectionString, queueName),
+                sp => new AzureServiceBusQueueHealthCheck(connectionStringFactory(sp), queueNameFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -131,11 +209,60 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusQueue(
+                _ => endpoint,
+                _ => queueName,
+                _ => tokenCredential,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Queue.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="queueNameFactory">A factory to build the name of the queue to check.</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusQueue(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> endpointFactory,
+            Func<IServiceProvider, string> queueNameFactory,
+            Func<IServiceProvider, TokenCredential> tokenCredentialFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (endpointFactory == null)
+            {
+                throw new ArgumentNullException(nameof(endpointFactory));
+            }
+            if (queueNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(queueNameFactory));
+            }
+            if (tokenCredentialFactory == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredentialFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREQUEUE_NAME,
-                sp => new AzureServiceBusQueueHealthCheck(endpoint, queueName, tokenCredential),
+                sp => new AzureServiceBusQueueHealthCheck(
+                    endpointFactory(sp),
+                    queueNameFactory(sp),
+                    tokenCredentialFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -162,11 +289,50 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusTopic(
+                _ => connectionString,
+                _ => topicName,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Topic.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the Azure ServiceBus connection string to be used.</param>
+        /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusTopic(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory,
+            Func<IServiceProvider, string> topicNameFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+            if (topicNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(topicNameFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZURETOPIC_NAME,
-                sp => new AzureServiceBusTopicHealthCheck(connectionString, topicName),
+                sp => new AzureServiceBusTopicHealthCheck(connectionStringFactory(sp), topicNameFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -195,11 +361,60 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusTopic(
+                _ => endpoint,
+                _ => topicName,
+                _ => tokenCredential,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Topic.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusTopic(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> endpointFactory,
+            Func<IServiceProvider, string> topicNameFactory,
+            Func<IServiceProvider, TokenCredential> tokenCredentialFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (endpointFactory == null)
+            {
+                throw new ArgumentNullException(nameof(endpointFactory));
+            }
+            if (topicNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(topicNameFactory));
+            }
+            if (tokenCredentialFactory == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredentialFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZURETOPIC_NAME,
-                sp => new AzureServiceBusTopicHealthCheck(endpoint, topicName, tokenCredential),
+                sp => new AzureServiceBusTopicHealthCheck(
+                    endpointFactory(sp),
+                    topicNameFactory(sp),
+                    tokenCredentialFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -228,11 +443,60 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusSubscription(
+                _ => connectionString,
+                _ => topicName,
+                _ => subscriptionName,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Subscription.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the Azure ServiceBus connection string to be used.</param>
+        /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
+        /// <param name="subscriptionNameFactory">A factory to build the subscription name of the topic to check.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusSubscription(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory,
+            Func<IServiceProvider, string> topicNameFactory,
+            Func<IServiceProvider, string> subscriptionNameFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+            if (topicNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(topicNameFactory));
+            }
+            if (subscriptionNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(subscriptionNameFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZURESUBSCRIPTION_NAME,
-                sp => new AzureServiceBusSubscriptionHealthCheck(connectionString, topicName, subscriptionName),
+                sp => new AzureServiceBusSubscriptionHealthCheck(
+                    connectionStringFactory(sp),
+                    topicNameFactory(sp),
+                    subscriptionNameFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));
@@ -263,11 +527,68 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default) =>
+            builder.AddAzureServiceBusSubscription(
+                _ => endpoint,
+                _ => topicName,
+                _ => subscriptionName,
+                _ => tokenCredential,
+                name,
+                failureStatus,
+                tags,
+                timeout);
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Subscription.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpointFactory">A factory to build the azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="topicNameFactory">A factory to build the topic name of the topic to check.</param>
+        /// <param name="subscriptionNameFactory">A factory to build the subscription name of the topic to check.</param>
+        /// <param name="tokenCredentialFactory">A factory to build the token credential for auth</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusSubscription(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> endpointFactory,
+            Func<IServiceProvider, string> topicNameFactory,
+            Func<IServiceProvider, string> subscriptionNameFactory,
+            Func<IServiceProvider, TokenCredential> tokenCredentialFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
             TimeSpan? timeout = default)
         {
+            if (endpointFactory == null)
+            {
+                throw new ArgumentNullException(nameof(endpointFactory));
+            }
+            if (topicNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(topicNameFactory));
+            }
+            if (subscriptionNameFactory == null)
+            {
+                throw new ArgumentNullException(nameof(subscriptionNameFactory));
+            }
+            if (tokenCredentialFactory == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredentialFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZURESUBSCRIPTION_NAME,
-                sp => new AzureServiceBusSubscriptionHealthCheck(endpoint, topicName, subscriptionName, tokenCredential),
+                sp => new AzureServiceBusSubscriptionHealthCheck(
+                    endpointFactory(sp),
+                    topicNameFactory(sp),
+                    subscriptionNameFactory(sp),
+                    tokenCredentialFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureEventHubRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureEventHubRegistrationTests.cs
@@ -98,5 +98,34 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
         }
+
+        [Fact]
+        public void add_health_check_using_connection_string_factory_and_event_hub_name_factory_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool connectionStringFactoryCalled = false, eventHubNameFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureEventHub(_ =>
+                    {
+                        connectionStringFactoryCalled = true;
+                        return "Endpoint=sb://dummynamespace.servicebus.windows.net/;SharedAccessKeyName=DummyAccessKeyName;SharedAccessKey=5dOntTRytoC24opYThisAsit3is2B+OGY1US/fuL3ly=";
+                    },
+                    _ =>
+                    {
+                        eventHubNameFactoryCalled = true;
+                        return "hubName";
+                    });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureeventhub");
+            check.GetType().Should().Be(typeof(AzureEventHubHealthCheck));
+            connectionStringFactoryCalled.Should().BeTrue();
+            eventHubNameFactoryCalled.Should().BeTrue();
+        }
     }
 }

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueRegistrationTests.cs
@@ -75,7 +75,7 @@ namespace HealthChecks.AzureServiceBus.Tests
                         return "queueName";
                     });
 
-            var serviceProvider = services.BuildServiceProvider();
+            using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueRegistrationTests.cs
@@ -23,7 +23,6 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azurequeue");
             check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
-
         }
 
         [Fact]
@@ -57,6 +56,35 @@ namespace HealthChecks.AzureServiceBus.Tests
             var registration = options.Value.Registrations.First();
 
             Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+
+        [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool connectionStringFactoryCalled = false, queueNameFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue(_ =>
+                    {
+                        connectionStringFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        queueNameFactoryCalled = true;
+                        return "queueName";
+                    });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeue");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+            connectionStringFactoryCalled.Should().BeTrue();
+            queueNameFactoryCalled.Should().BeTrue();
         }
     }
 }

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
@@ -77,7 +77,7 @@ namespace HealthChecks.AzureServiceBus.Tests
                         return "hubName";
                     });
 
-            var serviceProvider = services.BuildServiceProvider();
+            using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
@@ -24,7 +24,41 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azurequeue");
             check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+        }
 
+        [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false, queueNameFactoryCalled = false, tokenCredentialFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue(_ =>
+                {
+                    endpointFactoryCalled = true;
+                    return "cnn";
+                },
+                _ =>
+                {
+                    queueNameFactoryCalled = true;
+                    return "queueName";
+                },
+                _ =>
+                {
+                    tokenCredentialFactoryCalled = true;
+                    return new AzureCliCredential();
+                });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeue");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            queueNameFactoryCalled.Should().BeTrue();
+            tokenCredentialFactoryCalled.Should().BeTrue();
         }
 
         [Fact]
@@ -43,6 +77,42 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azureservicebusqueuecheck");
             check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false, queueNameFactoryCalled = false, tokenCredentialFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue(_ =>
+                    {
+                        endpointFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        queueNameFactoryCalled = true;
+                        return "queueName";
+                    },
+                    _ =>
+                    {
+                        tokenCredentialFactoryCalled = true;
+                        return new AzureCliCredential();
+                    },
+                    "azureservicebusqueuecheck");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusqueuecheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            queueNameFactoryCalled.Should().BeTrue();
+            tokenCredentialFactoryCalled.Should().BeTrue();
         }
 
         [Fact]

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
@@ -59,34 +59,5 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
         }
-
-        [Fact]
-        public void add_health_check_using_factories_when_properly_configured()
-        {
-            var services = new ServiceCollection();
-            bool connectionStringFactoryCalled = false, eventHubNameFactoryCalled = false;
-            services.AddHealthChecks()
-                .AddAzureEventHub(_ =>
-                    {
-                        connectionStringFactoryCalled = true;
-                        return "Endpoint=sb://dummynamespace.servicebus.windows.net/;SharedAccessKeyName=DummyAccessKeyName;SharedAccessKey=5dOntTRytoC24opYThisAsit3is2B+OGY1US/fuL3ly=";
-                    },
-                    _ =>
-                    {
-                        eventHubNameFactoryCalled = true;
-                        return "hubName";
-                    });
-
-            using var serviceProvider = services.BuildServiceProvider();
-            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
-
-            var registration = options.Value.Registrations.First();
-            var check = registration.Factory(serviceProvider);
-
-            registration.Name.Should().Be("azureeventhub");
-            check.GetType().Should().Be(typeof(AzureEventHubHealthCheck));
-            connectionStringFactoryCalled.Should().BeTrue();
-            eventHubNameFactoryCalled.Should().BeTrue();
-        }
     }
 }

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusQueueUnitWithTokenRegistrationTests.cs
@@ -59,5 +59,34 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
         }
+
+        [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool connectionStringFactoryCalled = false, eventHubNameFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureEventHub(_ =>
+                    {
+                        connectionStringFactoryCalled = true;
+                        return "Endpoint=sb://dummynamespace.servicebus.windows.net/;SharedAccessKeyName=DummyAccessKeyName;SharedAccessKey=5dOntTRytoC24opYThisAsit3is2B+OGY1US/fuL3ly=";
+                    },
+                    _ =>
+                    {
+                        eventHubNameFactoryCalled = true;
+                        return "hubName";
+                    });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureeventhub");
+            check.GetType().Should().Be(typeof(AzureEventHubHealthCheck));
+            connectionStringFactoryCalled.Should().BeTrue();
+            eventHubNameFactoryCalled.Should().BeTrue();
+        }
     }
 }

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusSubscriptionRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusSubscriptionRegistrationTests.cs
@@ -26,6 +26,41 @@ namespace HealthChecks.AzureServiceBus.Tests
         }
 
         [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool connectionStringFactoryCalled = false, topicNameFactoryCalled = false, subscriptionNameFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription(_ =>
+                    {
+                        connectionStringFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        subscriptionNameFactoryCalled = true;
+                        return "subscriptionName";
+                    });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscription");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+            connectionStringFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            subscriptionNameFactoryCalled.Should().BeTrue();
+        }
+
+        [Fact]
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
@@ -41,6 +76,42 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azuresubscriptioncheck");
             check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool connectionStringFactoryCalled = false, topicNameFactoryCalled = false, subscriptionNameFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription(_ =>
+                    {
+                        connectionStringFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        subscriptionNameFactoryCalled = true;
+                        return "subscriptionName";
+                    },
+                    "azuresubscriptioncheck");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscriptioncheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+            connectionStringFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            subscriptionNameFactoryCalled.Should().BeTrue();
         }
 
         [Fact]

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusSubscriptionWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusSubscriptionWithTokenRegistrationTests.cs
@@ -27,6 +27,50 @@ namespace HealthChecks.AzureServiceBus.Tests
         }
 
         [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false,
+                topicNameFactoryCalled = false,
+                subscriptionNameFactoryCalled = false,
+                tokenCredentialsFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription(_ =>
+                    {
+                        endpointFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        subscriptionNameFactoryCalled = true;
+                        return "subscriptionName";
+                    },
+                    _ =>
+                    {
+                        tokenCredentialsFactoryCalled = true;
+                        return new AzureCliCredential();
+                    });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscription");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            subscriptionNameFactoryCalled.Should().BeTrue();
+            tokenCredentialsFactoryCalled.Should().BeTrue();
+        }
+
+        [Fact]
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
@@ -42,6 +86,51 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azuresubscriptioncheck");
             check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false,
+                topicNameFactoryCalled = false,
+                subscriptionNameFactoryCalled = false,
+                tokenCredentialsFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription(_ =>
+                    {
+                        endpointFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        subscriptionNameFactoryCalled = true;
+                        return "subscriptionName";
+                    },
+                    _ =>
+                    {
+                        tokenCredentialsFactoryCalled = true;
+                        return new AzureCliCredential();
+                    },
+                    "azuresubscriptioncheck");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscriptioncheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            subscriptionNameFactoryCalled.Should().BeTrue();
+            tokenCredentialsFactoryCalled.Should().BeTrue();
         }
 
         [Fact]

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusTopicRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusTopicRegistrationTests.cs
@@ -75,7 +75,7 @@ namespace HealthChecks.AzureServiceBus.Tests
                         return "topicName";
                     });
 
-            var serviceProvider = services.BuildServiceProvider();
+            using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();

--- a/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusTopicWithTokenRegistrationTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/DependencyInjection/AzureServiceBusTopicWithTokenRegistrationTests.cs
@@ -27,6 +27,41 @@ namespace HealthChecks.AzureServiceBus.Tests
         }
 
         [Fact]
+        public void add_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false, topicNameFactoryCalled = false, tokenCredentialFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusTopic(_ =>
+                    {
+                        endpointFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        tokenCredentialFactoryCalled = true;
+                        return new AzureCliCredential();
+                    });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretopic");
+            check.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            tokenCredentialFactoryCalled.Should().BeTrue();
+        }
+
+        [Fact]
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
@@ -42,6 +77,42 @@ namespace HealthChecks.AzureServiceBus.Tests
 
             registration.Name.Should().Be("azuretopiccheck");
             check.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_using_factories_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            bool endpointFactoryCalled = false, topicNameFactoryCalled = false, tokenCredentialFactoryCalled = false;
+            services.AddHealthChecks()
+                .AddAzureServiceBusTopic(_ =>
+                    {
+                        endpointFactoryCalled = true;
+                        return "cnn";
+                    },
+                    _ =>
+                    {
+                        topicNameFactoryCalled = true;
+                        return "topicName";
+                    },
+                    _ =>
+                    {
+                        tokenCredentialFactoryCalled = true;
+                        return new AzureCliCredential();
+                    },
+                    "azuretopiccheck");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretopiccheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+            endpointFactoryCalled.Should().BeTrue();
+            topicNameFactoryCalled.Should().BeTrue();
+            tokenCredentialFactoryCalled.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
As done for SQL Server in #175 

This allows for you to use `services.AddAzureServiceBusTopic(...`, `services.AddAzureServiceBusQueue(...` and `services.AddAzureEventHub(...` if you use dependency injection for your configuration. 

Sample usage:
```cs
services.AddAzureServiceBusQueue(
  provider => provider.GetService<SasmpleQueueConfig>().ConnStr, 
  provider => provider.GetService<SampleQueueConfig>().QueueName, 
  tags: new string[] { "liveness" });
```

Please let me know your thoughts on having two factories for these (one for the connection string, and one for the name). The alternative is for there to be a single factory that returns some new object with both the connection string and queue name on, but I wasn't sure what would be preferred.