### PR TITLE
[UI Docker image] Configurable Azure app configuration service #213

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
@@ -1,32 +1,43 @@
 using System;
 using System.Security.Policy;
+using HealthChecks.UI.Image.Configuration.Helpers;
 
 namespace HealthChecks.UI.Image.Configuration
 {
     public class AzureAppConfiguration
     {
-        public static bool Enabled => 
-            HasValue(AzureAppConfigurationKeys.Enabled) ? true : false;
+        public static bool Enabled
+        {
+            get
+            {
+                if (EnvironmentVariable.HasValue(AzureAppConfigurationKeys.Enabled))
+                {
+                    if (Boolean.TryParse(EnvironmentVariable.GetValue(AzureAppConfigurationKeys.Enabled)
+                        , out bool enabled))
+                    {
+                        return enabled;
+                    }
+
+                    return false;
+                }
+
+                return false;
+            }
+        }
 
         public static bool UseConnectionString => 
-            HasValue(AzureAppConfigurationKeys.ConnectionString) ? true : false;
+            EnvironmentVariable.HasValue(AzureAppConfigurationKeys.ConnectionString) ? true : false;
 
         public static bool UseLabel => 
-            HasValue(AzureAppConfigurationKeys.Label) ? true : false;
+            EnvironmentVariable.HasValue(AzureAppConfigurationKeys.Label) ? true : false;
 
         public static string ConnectionString => 
-            GetValue(AzureAppConfigurationKeys.ConnectionString);
+            EnvironmentVariable.GetValue(AzureAppConfigurationKeys.ConnectionString);
 
         public static string ManagedIdentityEndpoint => 
-            GetValue(AzureAppConfigurationKeys.ManagedIdentityEndpoint);
+            EnvironmentVariable.GetValue(AzureAppConfigurationKeys.ManagedIdentityEndpoint);
 
         public static string Label => 
-            GetValue(AzureAppConfigurationKeys.Label);
-
-        private static string GetValue(string variable) => 
-            Environment.GetEnvironmentVariable(variable);
-        
-        private static bool HasValue(string variable) => 
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable));
+            EnvironmentVariable.GetValue(AzureAppConfigurationKeys.Label);
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
@@ -28,7 +28,6 @@ namespace HealthChecks.UI.Image.Configuration
         
         private static bool HasValue(string variable) => 
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable));
-        
     }
    
 }

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
@@ -29,5 +29,4 @@ namespace HealthChecks.UI.Image.Configuration
         private static bool HasValue(string variable) => 
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable));
     }
-   
 }

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfiguration.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Security.Policy;
+
+namespace HealthChecks.UI.Image.Configuration
+{
+    public class AzureAppConfiguration
+    {
+        public static bool Enabled => 
+            HasValue(AzureAppConfigurationKeys.Enabled) ? true : false;
+
+        public static bool UseConnectionString => 
+            HasValue(AzureAppConfigurationKeys.ConnectionString) ? true : false;
+
+        public static bool UseLabel => 
+            HasValue(AzureAppConfigurationKeys.Label) ? true : false;
+
+        public static string ConnectionString => 
+            GetValue(AzureAppConfigurationKeys.ConnectionString);
+
+        public static string ManagedIdentityEndpoint => 
+            GetValue(AzureAppConfigurationKeys.ManagedIdentityEndpoint);
+
+        public static string Label => 
+            GetValue(AzureAppConfigurationKeys.Label);
+
+        private static string GetValue(string variable) => 
+            Environment.GetEnvironmentVariable(variable);
+        
+        private static bool HasValue(string variable) => 
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable));
+        
+    }
+   
+}

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfigurationKeys.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/AzureAppConfigurationKeys.cs
@@ -1,0 +1,10 @@
+namespace HealthChecks.UI.Image.Configuration
+{
+    public class AzureAppConfigurationKeys
+    {
+        public const string Enabled = "AAC_Enabled";
+        public const string ConnectionString = "AAC_ConnectionString";
+        public const string ManagedIdentityEndpoint = "AAC_ManagedIdentityEndpoint";
+        public const string Label = "AAC_Label";
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/Helpers/EnvironmentVariable.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/Helpers/EnvironmentVariable.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace HealthChecks.UI.Image.Configuration.Helpers
+{
+    public class EnvironmentVariable
+    {
+        public static string GetValue(string variable) => 
+            Environment.GetEnvironmentVariable(variable);
+        
+        public static bool HasValue(string variable) => 
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable));
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/IConfigurationBuilderExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/IConfigurationBuilderExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using HealthChecks.UI.Image.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+
+namespace HealthChecks.UI.Image.Extensions
+{
+    public static class IConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder UseAzureAppConfiguration(this IConfigurationBuilder builder)
+        {
+            if (AzureAppConfiguration.UseConnectionString)
+            {
+                builder.AddAzureAppConfiguration(AzureConfigurationSetup.WithConnectionString);
+            }
+            else
+            {
+                builder.AddAzureAppConfiguration(AzureConfigurationSetup.WithManagedIdentity);
+            }
+
+            return builder;
+        }
+    }
+
+    internal class AzureConfigurationSetup
+    {
+        public static void WithConnectionString(AzureAppConfigurationOptions options)
+        {
+            options.Connect(AzureAppConfiguration.ConnectionString);
+            
+            if (AzureAppConfiguration.UseLabel)
+            {
+                options.Use(KeyFilter.Any, AzureAppConfiguration.Label);
+            }
+        }
+
+        public static void WithManagedIdentity(AzureAppConfigurationOptions options)
+        {
+            options.ConnectWithManagedIdentity(AzureAppConfiguration.ManagedIdentityEndpoint);
+            if (AzureAppConfiguration.UseLabel)
+            {
+                options.Use(KeyFilter.Any, AzureAppConfiguration.Label);
+            }
+        }
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/IConfigurationBuilderExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/IConfigurationBuilderExtensions.cs
@@ -11,18 +11,18 @@ namespace HealthChecks.UI.Image.Extensions
         {
             if (AzureAppConfiguration.UseConnectionString)
             {
-                builder.AddAzureAppConfiguration(AzureConfigurationSetup.WithConnectionString);
+                builder.AddAzureAppConfiguration(AzureAppConfigurationSetup.WithConnectionString);
             }
             else
             {
-                builder.AddAzureAppConfiguration(AzureConfigurationSetup.WithManagedIdentity);
+                builder.AddAzureAppConfiguration(AzureAppConfigurationSetup.WithManagedIdentity);
             }
 
             return builder;
         }
     }
 
-    internal class AzureConfigurationSetup
+    internal class AzureAppConfigurationSetup
     {
         public static void WithConnectionString(AzureAppConfigurationOptions options)
         {
@@ -37,6 +37,7 @@ namespace HealthChecks.UI.Image.Extensions
         public static void WithManagedIdentity(AzureAppConfigurationOptions options)
         {
             options.ConnectWithManagedIdentity(AzureAppConfiguration.ManagedIdentityEndpoint);
+            
             if (AzureAppConfiguration.UseLabel)
             {
                 options.Use(KeyFilter.Any, AzureAppConfiguration.Label);

--- a/build/docker-images/HealthChecks.UI.Image/HealthChecks.UI.Image.csproj
+++ b/build/docker-images/HealthChecks.UI.Image/HealthChecks.UI.Image.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="1.0.0-preview-008920001-990" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/docker-images/HealthChecks.UI.Image/Program.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Program.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using HealthChecks.UI.Image.Configuration;
+using HealthChecks.UI.Image.Extensions;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Logging;
 
 namespace HealthChecks.UI.Image
@@ -17,8 +20,19 @@ namespace HealthChecks.UI.Image
             CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
+        {
+
+            return WebHost.CreateDefaultBuilder(args)
+                
+                .ConfigureAppConfiguration(config =>
+                {
+                    if (AzureAppConfiguration.Enabled)
+                    {
+                        config.UseAzureAppConfiguration();
+                    }
+                })
                 .UseStartup<Startup>();
+        }
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Program.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Program.cs
@@ -22,9 +22,7 @@ namespace HealthChecks.UI.Image
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {
-
             return WebHost.CreateDefaultBuilder(args)
-                
                 .ConfigureAppConfiguration(config =>
                 {
                     if (AzureAppConfiguration.Enabled)

--- a/doc/ui-docker.md
+++ b/doc/ui-docker.md
@@ -13,4 +13,46 @@ You can use environment variables to configure all properties on *HealthChecksUI
 docker run --name ui -p 5000:80 -e 'HealthChecksUI:HealthChecks:0:Name=httpBasic' -e 'HealthChecksUI:HealthChecks:0:Uri=http://the-healthchecks-server-path' -d xabarilcoding/healthchecksui:latest
 ```
 
+## Azure App Configuration Service
+
+Since version 2.2.32, our docker image supports configuration by using Azure App Configuration service.
+
+Configuring a large amount of healthchecks and webhooks will require to pass a lot of environment variables or mounting a volume so Asp.Net Core configuration providers can find a settings file containing the HealthChecks config section.
+
+By using Azure App Configuration service you can centralize HealthChecks configuration in Azure and bind it directly to the executing container at ease.
+
+You should use environment variables to configure Azure App Confuration Service (AAC from now for brevity) in the UI docker image.
+
+The existing environment variables are explained below:
+
+| Environment Variable  | Description   | Notes   |
+|---|---|---|
+| AAC_Enabled   | Enables AAC config provider   | Not set by default |
+| AAC_ConnectionString   | Connection string to configuration service  | If set, Managed Service Identity won't be used   |
+| AAC_ManagedIdentityEndpoint | Your AAC endpoint to connect using Managed Identity | Don't provide a Sample: https://your-endpoint.azconfig.io
+| AAC_Label   | Filter configuration keys containing this label   | Sample: HealthChecksConfig  |
+
+
+As table explains, if **AAC_ConnectionString** is set, the image will connect to AAC using that connection string.
+If you want to connect using managed identity service only specify **AAC_ManagedIdentityEndpoint** environment variable.
+
+## Samples
+
+- Creating an Azure Container instance using a connection string:
+
+```bash
+
+az container create --resource-group group-name --name container-name -e 'AAC_Enabled=true' 'AAC_Label=HealthChecksConfig' 'AAC_ConnectionString=Endpoint={your_connectionstring}' --image xabarilcoding/healthchecksui:latest --dns-name-label dns-checks --ports 80
+
+```
+
+- Creating an Azure Container instance using managed service identity:
+
+```bash
+
+az container create --resource-group group-name  --name container-name -e 'AAC_Enabled=true' 'AAC_Label=HealthChecksConfig' 'AAC_ManagedIdentityEndpoint=https://your-endpoint.azconfig.io' --image xabarilcoding/healthchecksui:latest  --dns-name-label dns-checks-msi --ports 80 --assign-identity
+
+```
+
+
 Read the [DockerHub full description](https://hub.docker.com/r/xabarilcoding/healthchecksui/) to get more information about HealthChecksUI docker configuration.


### PR DESCRIPTION
Adds feature #213 
Configuring health checks using Enviroment Variables with current docker image is a little bit tricky. We should give the chance to the users to use Azure App Configuration to setup their healthchecks, webhooks and other settings in Azure

