### PR TITLE
[UI] #216 New Configuration Section Key Compatible with Azure Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ To show these HealthChecks in HealthCheck-UI they have to be configured through 
 }
 ```
 
+**Note**: The previous configuration section was HealthChecks-UI, but due to incompatibilies with Azure Web App environment variables the section has been moved to HealthChecksUI. The UI is retro compatible and it will check the new section first, and fallback to the old section if the new section has not been declared.
+
+
     1.- HealthChecks: The collection of health checks uris to evaluate.
     2.- EvaluationTimeOnSeconds: Number of elapsed seconds between health checks.
     3.- Webhooks: If any health check returns a *Failure* result, this collections will be used to notify the error status. (Payload is the json payload and must be escaped. For more information see the notifications documentation section)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To show these HealthChecks in HealthCheck-UI they have to be configured through 
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",
@@ -202,7 +202,7 @@ All health checks results are stored into a SqLite database persisted to disk wi
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",

--- a/build-docker-image.ps1
+++ b/build-docker-image.ps1
@@ -31,7 +31,7 @@ exec { & docker build . -f .\build\docker-images\HealthChecks.UI.Image\Dockerfil
 exec { & docker tag xabarilcoding/healthchecksui:$tag xabarilcoding/healthchecksui:latest }
 
 echo "Created docker image healthchecksui:$tag. You can execute this image using docker run"
-echo "Sample: docker run --name ui -p 5000:80 -e 'HealthChecks-UI:HealthChecks:0:Name=httpBasic' -e 'HealthChecks-UI:HealthChecks:0:Uri=http://www.google.es' -d healthchecksui:dev"
+echo "Sample: docker run --name ui -p 5000:80 -e 'HealthChecksUI:HealthChecks:0:Name=httpBasic' -e 'HealthChecksUI:HealthChecks:0:Uri=http://www.google.es' -d healthchecksui:dev"
 
 #Publish it
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -94,7 +94,7 @@
     <HealthCheckHangfire>2.2.2</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>2.2.4</HealthCheckAzureServiceBus>
     <HealthCheckConsul>2.2.2</HealthCheckConsul>
-    <HealthCheckUI>2.2.31</HealthCheckUI>
+    <HealthCheckUI>2.2.32</HealthCheckUI>
     <HealthCheckUIClient>2.2.4</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>2.2.4</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherPrometheus>2.2.0</HealthCheckPublisherPrometheus>

--- a/build/docker-images/HealthChecks.UI.Image/appsettings.json
+++ b/build/docker-images/HealthChecks.UI.Image/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
   "AllowedHosts": "*",
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [],
     "Webhooks": [],
     "EvaluationTimeOnSeconds": 10,

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -10,7 +10,7 @@ The default mechanism to register the target endpoints to be queried for health 
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "Http and UI on single project",
@@ -29,7 +29,7 @@ To enable Kubernetes discovery you just need to configure some settings inside t
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "KubernetesDiscoveryService": {
           "Enabled": true,
           "ClusterHost": "https://myaks-962d02ba.hcp.westeurope.azmk8s.io:443",

--- a/doc/ui-docker.md
+++ b/doc/ui-docker.md
@@ -10,7 +10,7 @@ docker run --name ui -p 5000:80 -d xabarilcoding/healthchecksui:latest
 You can use environment variables to configure all properties on *HealthChecksUI*. 
 
 ```bash
-docker run --name ui -p 5000:80 -e 'HealthChecks-UI:HealthChecks:0:Name=httpBasic' -e 'HealthChecks-UI:HealthChecks:0:Uri=http://the-healthchecks-server-path' -d xabarilcoding/healthchecksui:latest
+docker run --name ui -p 5000:80 -e 'HealthChecksUI:HealthChecks:0:Name=httpBasic' -e 'HealthChecksUI:HealthChecks:0:Uri=http://the-healthchecks-server-path' -d xabarilcoding/healthchecksui:latest
 ```
 
 Read the [DockerHub full description](https://hub.docker.com/r/xabarilcoding/healthchecksui/) to get more information about HealthChecksUI docker configuration.

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -118,7 +118,7 @@ public static async Task Run(HttpRequestMessage req, IAsyncCollector<Mail> messa
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",
@@ -157,7 +157,7 @@ And the HealthChecksUI configuration:
 
 ```json
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",

--- a/samples/HealthChecks.UI.Sample/appsettings.json
+++ b/samples/HealthChecks.UI.Sample/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",

--- a/samples/HealthChecks.UIAndApi/appsettings.json
+++ b/samples/HealthChecks.UIAndApi/appsettings.json
@@ -4,7 +4,7 @@
       "Default": "Error"
     }
   },
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "Http and UI on single project",

--- a/samples/HealthChecks.UIAndApiCustomization/appsettings.json
+++ b/samples/HealthChecks.UIAndApiCustomization/appsettings.json
@@ -4,7 +4,7 @@
       "Default": "Error"
     }
   },
-  "HealthChecks-UI": {
+  "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "Http and UI on single project with customizations-1",

--- a/src/HealthChecks.UI/ConfigurationExtensions.cs
+++ b/src/HealthChecks.UI/ConfigurationExtensions.cs
@@ -1,0 +1,33 @@
+using HealthChecks.UI;
+using HealthChecks.UI.Configuration;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.Configuration
+{
+    public static class ConfigurationExtensions
+    {
+        public static Settings BindUISettings(this IConfiguration configuration, Settings settings)
+        {
+            configuration.GetSectionWithFallBack(
+                    Keys.HEALTHCHECKSUI_SECTION_SETTING_KEY,
+                    fallback: Keys.HEALTHCHECKSUI_OLD_SECTION_SETTING_KEY)
+                .Bind(settings, c => c.BindNonPublicProperties = true);
+
+            return settings;
+        }
+
+        public static IConfigurationSection GetSectionWithFallBack
+            (this IConfiguration configuration, string section, string fallback)
+        {
+            IConfigurationSection configurationSection = configuration.GetSection(section);
+            
+            if (!configurationSection.Exists())
+            {
+                configurationSection = configuration.GetSection(fallback);
+            }
+
+            return configurationSection;
+        }
+    }
+}

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -8,7 +8,7 @@ namespace HealthChecks.UI
         internal const string HEALTHCHECKSUI_SECTION_SETTING_KEY = "HealthChecksUI";
         internal const string HEALTHCHECKS_DEFAULT_PATH = "hc";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL = "HealthChecks";
-        internal const string HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY = "HealthChecks-UI:KubernetesDiscoveryService";        
+        internal const string HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY = "HealthChecksUI:KubernetesDiscoveryService";        
         internal const string HEALTHCHECKSUI_MAIN_UI_RESOURCE = "index.html";
         internal const string HEALTHCHECKSUI_MAIN_UI_API_TARGET = "#apiPath#";
         internal const string HEALTHCHECKSUI_WEBHOOKS_API_TARGET = "#webhookPath#";

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -1,8 +1,11 @@
-﻿namespace HealthChecks.UI
+﻿using System;
+
+namespace HealthChecks.UI
 {
     class Keys
     {
-        internal const string HEALTHCHECKSUI_SECTION_SETTING_KEY = "HealthChecks-UI";
+        internal const string HEALTHCHECKSUI_OLD_SECTION_SETTING_KEY = "HealthChecks-UI";        
+        internal const string HEALTHCHECKSUI_SECTION_SETTING_KEY = "HealthChecksUI";
         internal const string HEALTHCHECKS_DEFAULT_PATH = "hc";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL = "HealthChecks";
         internal const string HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY = "HealthChecks-UI:KubernetesDiscoveryService";        

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -27,9 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddOptions()
                 .Configure<Settings>(settings =>
                 {
-                    configuration.GetSection(Keys.HEALTHCHECKSUI_SECTION_SETTING_KEY)
-                        .Bind(settings, c => c.BindNonPublicProperties = true);
-                    
+                    configuration.BindUISettings(settings);
                     setupSettings?.Invoke(settings);
                 })
                 .Configure<KubernetesDiscoverySettings>(settings=>

--- a/test/FunctionalTests/HealthChecks.UI/Configuration/appsettings.json
+++ b/test/FunctionalTests/HealthChecks.UI/Configuration/appsettings.json
@@ -4,7 +4,7 @@
             "Default": "Error"
         }
     },
-    "HealthChecks-UI": {
+    "HealthChecksUI": {
         "HealthChecks": [
             {
                 "Name": "api1",


### PR DESCRIPTION
Fixes #216 being retro compatible.
It reads the new section (HealthChecksUI) and if not declared it fallbacks to the previous key setting.(HealthChecks-UI)

Updated all documentation containing old key HealthChecks-UI

I have built a docker image using this bytes and published it to an Azure Web App for Containers and it is now working as you can check here:

https://landechecks.azurewebsites.net/healthchecks-ui
