### PR TITLE
Elastic Search Health Checks - Support for Certificate Validation

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -79,7 +79,7 @@
     <HealthCheckRedis>2.2.3</HealthCheckRedis>
     <HealthCheckRabbitMQ>2.2.1</HealthCheckRabbitMQ>
     <HealthCheckEventStore>2.2.2</HealthCheckEventStore>
-    <HealthCheckElasticsearch>2.2.2</HealthCheckElasticsearch>
+    <HealthCheckElasticsearch>2.2.3</HealthCheckElasticsearch>
     <HealthCheckOracle>2.2.0</HealthCheckOracle>
     <HealthCheckNpgSql>2.2.1</HealthCheckNpgSql>
     <HealthCheckMongoDB>2.2.3</HealthCheckMongoDB>

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -35,6 +35,11 @@ namespace HealthChecks.Elasticsearch
                         settings = settings.ClientCertificate(_options.Certificate);
                     }
 
+                    if (_options.CertificateValidationCallback != null)
+                    {
+                        settings = settings.ServerCertificateValidationCallback(_options.CertificateValidationCallback);
+                    }
+
                     lowLevelClient = new ElasticClient(settings);
 
                     if (!_connections.TryAdd(_options.Uri, lowLevelClient))

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 namespace HealthChecks.Elasticsearch
@@ -11,6 +12,7 @@ namespace HealthChecks.Elasticsearch
         public X509Certificate Certificate { get; private set; }
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
+        public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {
             UserName = name ?? throw new ArgumentNullException(nameof(name));
@@ -35,6 +37,11 @@ namespace HealthChecks.Elasticsearch
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
 
+            return this;
+        }
+        public ElasticsearchOptions UseCertificateValidationCallback(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> callback)
+        {
+            CertificateValidationCallback = callback;
             return this;
         }
     }


### PR DESCRIPTION
Hi,

This update is to allow Elastic Search Health Checks to support a server certificate validation callback. The elastic search IConnectionSettingValues supports this.

Thanks
Trent