### PR TITLE
Features/elastic search cluster health

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -79,7 +79,7 @@
     <HealthCheckRedis>2.2.3</HealthCheckRedis>
     <HealthCheckRabbitMQ>2.2.1</HealthCheckRabbitMQ>
     <HealthCheckEventStore>2.2.2</HealthCheckEventStore>
-    <HealthCheckElasticsearch>2.2.2</HealthCheckElasticsearch>
+    <HealthCheckElasticsearch>2.2.3</HealthCheckElasticsearch>
     <HealthCheckOracle>2.2.0</HealthCheckOracle>
     <HealthCheckNpgSql>2.2.1</HealthCheckNpgSql>
     <HealthCheckMongoDB>2.2.3</HealthCheckMongoDB>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -36,7 +36,7 @@
     <MySqlConnector>0.40.4</MySqlConnector>
     <ConfluentKafka>1.0.0</ConfluentKafka>
     <SSHNet>2016.1.0</SSHNet>
-    <NEST>6.1.0</NEST>
+    <NEST>7.0.0</NEST>
     <SystemBuffers>4.5.0</SystemBuffers>
     <MicrosoftAzureDocumentDbCore>1.9.1</MicrosoftAzureDocumentDbCore>
     <MicrosoftAzureCosmosDB>3.0.0.9-preview</MicrosoftAzureCosmosDB>
@@ -79,7 +79,7 @@
     <HealthCheckRedis>2.2.3</HealthCheckRedis>
     <HealthCheckRabbitMQ>2.2.1</HealthCheckRabbitMQ>
     <HealthCheckEventStore>2.2.2</HealthCheckEventStore>
-    <HealthCheckElasticsearch>2.2.3</HealthCheckElasticsearch>
+    <HealthCheckElasticsearch>2.3.0</HealthCheckElasticsearch>
     <HealthCheckOracle>2.2.0</HealthCheckOracle>
     <HealthCheckNpgSql>2.2.1</HealthCheckNpgSql>
     <HealthCheckMongoDB>2.2.3</HealthCheckMongoDB>

--- a/src/HealthChecks.Elasticsearch/BaseElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/BaseElasticsearchHealthCheck.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Nest;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.Elasticsearch
+{
+    public abstract class BaseElasticsearchHealthCheck
+         : IHealthCheck
+    {
+        private static readonly ConcurrentDictionary<string, ElasticClient> _connections = new ConcurrentDictionary<string, ElasticClient>();
+
+        private readonly ElasticsearchOptions _options;
+
+        public BaseElasticsearchHealthCheck(ElasticsearchOptions options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public abstract Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default);
+
+        protected ElasticClient GenerateClient()
+        {
+            if (!_connections.TryGetValue(_options.Uri, out ElasticClient lowLevelClient))
+            {
+                var settings = new ConnectionSettings(new Uri(_options.Uri));
+
+                if (_options.AuthenticateWithBasicCredentials)
+                {
+                    settings = settings.BasicAuthentication(_options.UserName, _options.Password);
+                }
+                else if (_options.AuthenticateWithCertificate)
+                {
+                    settings = settings.ClientCertificate(_options.Certificate);
+                }
+
+                if (_options.CertificateValidationCallback != null)
+                {
+                    settings = settings.ServerCertificateValidationCallback(_options.CertificateValidationCallback);
+                }
+
+                lowLevelClient = new ElasticClient(settings);
+
+                if (!_connections.TryAdd(_options.Uri, lowLevelClient))
+                {
+                    lowLevelClient = _connections[_options.Uri];
+                }
+            }
+
+            return lowLevelClient;
+        }
+    }
+}

--- a/src/HealthChecks.Elasticsearch/DependencyInjection/ElasticsearchHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Elasticsearch/DependencyInjection/ElasticsearchHealthCheckBuilderExtensions.cs
@@ -24,10 +24,14 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var options = new ElasticsearchOptions();
             options.UseServer(elasticsearchUri);
-            
+
+            IHealthCheck healthCheck = options.CheckClusterHealth ?
+              (IHealthCheck)new ElasticsearchClusterHealthCheck(options) :
+              new ElasticsearchHealthCheck(options);
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new ElasticsearchHealthCheck(options),
+                sp => healthCheck,
                 failureStatus,
                 tags));
         }
@@ -47,10 +51,14 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var options = new ElasticsearchOptions();
             setup?.Invoke(options);
-            
+
+            IHealthCheck healthCheck = options.CheckClusterHealth ?
+                (IHealthCheck)new ElasticsearchClusterHealthCheck(options) :
+                new ElasticsearchHealthCheck(options);
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new ElasticsearchHealthCheck(options),
+                sp => healthCheck,
                 failureStatus,
                 tags));
         }

--- a/src/HealthChecks.Elasticsearch/ElasticsearchClusterHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchClusterHealthCheck.cs
@@ -1,0 +1,54 @@
+﻿using Elasticsearch.Net;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Nest;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.Elasticsearch
+{
+    public class ElasticsearchClusterHealthCheck
+       : BaseElasticsearchHealthCheck
+    {
+        public ElasticsearchClusterHealthCheck(ElasticsearchOptions options) : base(options) { }
+
+        public override async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                ElasticClient lowLevelClient = GenerateClient();
+
+                ClusterHealthDescriptor clusterHealthDescriptor = new ClusterHealthDescriptor();
+
+                var clusterResult = await lowLevelClient
+                    .Cluster
+                    .HealthAsync(selector: c => clusterHealthDescriptor, ct: cancellationToken);
+
+                var isSuccessfulCall = clusterResult.ApiCall.HttpStatusCode == 200;
+
+                if (!isSuccessfulCall)
+                {
+                    return new HealthCheckResult(
+                        context.Registration.FailureStatus,
+                        description: $"Elastic Search responded with status: '{clusterResult.ApiCall.HttpStatusCode}'. {clusterResult.ApiCall.DebugInformation}");
+                }
+
+                switch (clusterResult.Status)
+                {
+                    case Health.Green:
+                        return HealthCheckResult.Healthy();
+                    case Health.Yellow:
+                        return HealthCheckResult.Degraded();
+                    case Health.Red:
+                    default:
+                        return HealthCheckResult.Unhealthy();
+                }
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+    }
+}

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -8,47 +8,17 @@ using System.Threading.Tasks;
 namespace HealthChecks.Elasticsearch
 {
     public class ElasticsearchHealthCheck
-        : IHealthCheck
+        : BaseElasticsearchHealthCheck, IHealthCheck
     {
-        private static readonly ConcurrentDictionary<string, ElasticClient> _connections = new ConcurrentDictionary<string, ElasticClient>();
+        public ElasticsearchHealthCheck(ElasticsearchOptions options) : base(options) {}
 
-        private readonly ElasticsearchOptions _options;
-
-        public ElasticsearchHealthCheck(ElasticsearchOptions options)
-        {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-        }
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        public override async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                if (!_connections.TryGetValue(_options.Uri, out ElasticClient lowLevelClient))
-                {
-                    var settings = new ConnectionSettings(new Uri(_options.Uri));
+                ElasticClient lowLevelClient = GenerateClient();
 
-                    if (_options.AuthenticateWithBasicCredentials)
-                    {
-                        settings = settings.BasicAuthentication(_options.UserName, _options.Password);
-                    }
-                    else if (_options.AuthenticateWithCertificate)
-                    {
-                        settings = settings.ClientCertificate(_options.Certificate);
-                    }
-
-                    if (_options.CertificateValidationCallback != null)
-                    {
-                        settings = settings.ServerCertificateValidationCallback(_options.CertificateValidationCallback);
-                    }
-
-                    lowLevelClient = new ElasticClient(settings);
-
-                    if (!_connections.TryAdd(_options.Uri, lowLevelClient))
-                    {
-                        lowLevelClient = _connections[_options.Uri];
-                    }
-                }
-
-                var pingResult = await lowLevelClient.PingAsync(cancellationToken: cancellationToken);
+                var pingResult = await lowLevelClient.PingAsync(ct: cancellationToken);
                 var isSuccess = pingResult.ApiCall.HttpStatusCode == 200;
 
                 return isSuccess

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -35,6 +35,11 @@ namespace HealthChecks.Elasticsearch
                         settings = settings.ClientCertificate(_options.Certificate);
                     }
 
+                    if (_options.CertificateValidationCallback != null)
+                    {
+                        settings = settings.ServerCertificateValidationCallback(_options.CertificateValidationCallback);
+                    }
+
                     lowLevelClient = new ElasticClient(settings);
 
                     if (!_connections.TryAdd(_options.Uri, lowLevelClient))

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 namespace HealthChecks.Elasticsearch
@@ -11,6 +12,7 @@ namespace HealthChecks.Elasticsearch
         public X509Certificate Certificate { get; private set; }
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
+        public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {
             UserName = name ?? throw new ArgumentNullException(nameof(name));
@@ -35,6 +37,11 @@ namespace HealthChecks.Elasticsearch
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
 
+            return this;
+        }
+        public ElasticsearchOptions UseCertificateValidationCallback(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> callback)
+        {
+            CertificateValidationCallback = callback;
             return this;
         }
     }

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -13,6 +13,7 @@ namespace HealthChecks.Elasticsearch
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
         public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
+        public bool CheckClusterHealth { get; private set; } = false;
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {
             UserName = name ?? throw new ArgumentNullException(nameof(name));
@@ -42,6 +43,11 @@ namespace HealthChecks.Elasticsearch
         public ElasticsearchOptions UseCertificateValidationCallback(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> callback)
         {
             CertificateValidationCallback = callback;
+            return this;
+        }
+        public ElasticsearchOptions UseClusterBasedHealthCheck()
+        {
+            CheckClusterHealth = true;
             return this;
         }
     }


### PR DESCRIPTION
Hi,

This update is to support the new version of NEST 7.0.0 (https://www.nuget.org/packages/NEST/7.0.0).

It also includes the optional ability to use the Cluster Health Check in Elastic Search (https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html). By doing the following:

`healthChecksBuilder.AddElasticsearch(cfg => cfg.UseClusterBasedHealthCheck);`

I wasn't sure of how you wanted to version it sorry, especially considering NEST 7.0.0 has some significant breaking changes.

Thanks