### PR TITLE
Fix JsonReaderException when a service has a named targetPort

### DIFF
--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -44,14 +44,14 @@ To enable Kubernetes discovery you just need to configure some settings inside t
 
 Here are all the available parameters detailed:
 
-| Parameter  | Description  |  Default Value |
-|---|---|---|
-|  Enabled | Establishes if the k8s discovery service is enabled of disabled  | false  |
-| ClusterHost | The uri of the kubernetes cluster |   |
-| Token | The token that will be sent to the cluster for authentication | |
-| HealthPath | The url path where the UI will call once the service is discovered |  hc | 
-| ServicesLabel | The labeled services the UI will look for in k8s | HealtChecks
-| RefreshTimeOnSeconds | Healthchecks refresh time in seconds | 300
+| Parameter            | Description                                                        | Default Value |
+| -------------------- | ------------------------------------------------------------------ | ------------- |
+| Enabled              | Establishes if the k8s discovery service is enabled of disabled    | false         |
+| ClusterHost          | The uri of the kubernetes cluster                                  |               |
+| Token                | The token that will be sent to the cluster for authentication      |               |
+| HealthPath           | The url path where the UI will call once the service is discovered | hc            |
+| ServicesLabel        | The labeled services the UI will look for in k8s                   | HealthChecks  |
+| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                               | 300           |
 
 ## Labeling Services for discovery in Kubernetes
 

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
@@ -46,6 +46,6 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         [JsonProperty("Port")]
         public int PortNumber { get; set; }
         public int NodePort { get; set; }
-        public int TargetPort { get; set; }
+        public string TargetPort { get; set; }
     }
 }

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -30,8 +30,9 @@ namespace UnitTests.UI.Kubernetes
 
             serviceAddresses[0].Should().Be("http://localhost:10000/healthz");
             serviceAddresses[1].Should().Be("http://localhost:9000/healthz");
-            serviceAddresses[2].Should().Be("http://localhost:30000/healthz");            
+            serviceAddresses[2].Should().Be("http://localhost:30000/healthz");
             serviceAddresses[3].Should().Be("http://10.97.1.153:80/healthz");
+            serviceAddresses[4].Should().Be("http://10.152.183.35:5341/healthz");
 
         }
 
@@ -56,6 +57,7 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[1].Should().Be("http://13.80.181.10:51000/healthz");
             serviceAddresses[2].Should().Be("http://12.0.0.190:5672/healthz");
             serviceAddresses[3].Should().Be("http://12.0.0.168:30478/healthz");
+            serviceAddresses[4].Should().Be("http://10.152.183.35:5341/healthz");
 
         }
 

--- a/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
@@ -115,6 +115,39 @@
         "sessionAffinity": "None"
       },
       "status": { "loadBalancer": {} }
+    },
+    {
+      "metadata": {
+        "name": "seq",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/seq",
+        "uid": "7e1071b4-29c7-422e-80e3-326129590a30",
+        "resourceVersion": "134427",
+        "creationTimestamp": "2019-07-12T02:42:38Z",
+        "labels": {
+          "HealthChecks": "true",
+          "app": "seq"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "protocol": "TCP",
+            "port": 5341,
+            "targetPort": "ui"
+          }
+        ],
+        "selector": {
+          "app": "seq"
+        },
+        "clusterIP": "10.152.183.35",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
     }
   ]
 }

--- a/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
@@ -157,6 +157,39 @@
       "status": {
         "loadBalancer": {}
       }
+    },
+    {
+      "metadata": {
+        "name": "seq",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/seq",
+        "uid": "7e1071b4-29c7-422e-80e3-326129590a30",
+        "resourceVersion": "134427",
+        "creationTimestamp": "2019-07-12T02:42:38Z",
+        "labels": {
+          "HealthChecks": "true",
+          "app": "seq"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "protocol": "TCP",
+            "port": 5341,
+            "targetPort": "ui"
+          }
+        ],
+        "selector": {
+          "app": "seq"
+        },
+        "clusterIP": "10.152.183.35",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
     }
   ]
 }


### PR DESCRIPTION
When the targetPort of a Kubernetes service is named instead of a static int, this error occurs:

```
Newtonsoft.Json.JsonReaderException : Could not convert string to integer: ui. Path 'items[4].spec.ports[0].targetPort', line 180, position 30.
```

This error has prevented the Kubernetes service discovery from being used in most clusters, as many services (such as Tiller) use named target ports. The fix is simply to change the TargetPort to a string. This shouldn't cause any issues, as Newtonsoft.JSON will deserialize ints as strings, and the field isn't being used.