### PR TITLE
Kubernetes Service Discovery Enhancements

### DIFF
--- a/build-docker-image.ps1
+++ b/build-docker-image.ps1
@@ -19,7 +19,7 @@ function Exec
 #Select the UI version from dependencies.props and use it as image version
 
 
-$version = select-xml -Path .\build\dependencies.props -XPath "/Project/PropertyGroup[contains(@Label,'Health Checks Package Versions')]/HealthCheckUI"
+$version = select-xml -Path ${PSScriptRoot}/build/dependencies.props -XPath "/Project/PropertyGroup[contains(@Label,'Health Checks Package Versions')]/HealthCheckUI"
 
 $tag = $version.node.InnerXML
 
@@ -27,7 +27,7 @@ $tag = $version.node.InnerXML
 
 echo "building docker image with tag: $tag"
 
-exec { & docker build . -f .\build\docker-images\HealthChecks.UI.Image\Dockerfile -t xabarilcoding/healthchecksui:$tag }
+exec { & docker build . -f ${PSScriptRoot}/build/docker-images/HealthChecks.UI.Image/Dockerfile -t xabarilcoding/healthchecksui:$tag }
 exec { & docker tag xabarilcoding/healthchecksui:$tag xabarilcoding/healthchecksui:latest }
 
 echo "Created docker image healthchecksui:$tag. You can execute this image using docker run"

--- a/build/docker-images/HealthChecks.UI.Image/Dockerfile
+++ b/build/docker-images/HealthChecks.UI.Image/Dockerfile
@@ -37,3 +37,4 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .
 ENTRYPOINT ["dotnet", "HealthChecks.UI.Image.dll"]
+CMD []

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -34,7 +34,29 @@ To enable Kubernetes discovery you just need to configure some settings inside t
           "Enabled": true,
           "ClusterHost": "https://myaks-962d02ba.hcp.westeurope.azmk8s.io:443",
           "Token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3M...",
-          "HealthPath": "healthz"
+          "HealthPath": "healthz",
+          "ServicesLabel": "HealthChecks",
+          "ServicesPathLabel": "HealthChecksPath",
+          "ServicesPortLabel": "HealthChecksPort",
+          "ServicesSchemeLabel": "HealthChecksScheme"
+    }
+  }
+}
+```
+
+If you are hosting HealthChecks UI within Kubernetes, you can use the following configuration instead:
+
+```json
+{
+  "HealthChecksUI": {
+    "KubernetesDiscoveryService": {
+          "Enabled": true,
+          "InCluster": true,
+          "HealthPath": "healthz",
+          "ServicesLabel": "HealthChecks",
+          "ServicesPathLabel": "HealthChecksPath",
+          "ServicesPortLabel": "HealthChecksPort",
+          "ServicesSchemeLabel": "HealthChecksScheme"
     }
   }
 }
@@ -52,9 +74,9 @@ Here are all the available parameters detailed:
 | Token                | The token that will be sent to the cluster for authentication                                                                                     |                    |
 | HealthPath           | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
 | ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
-| HealthPathLabel      | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
-| HealthPortLabel      | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
-| HealthSchemeLabel    | The label on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used           | HealthChecksScheme |
+| ServicesPathLabel    | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
+| ServicesPortLabel    | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
+| ServicesSchemeLabel  | The label on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used           | HealthChecksScheme |
 | RefreshTimeOnSeconds | Healthchecks refresh time in seconds                                                                                                              | 300                |
 | Namespaces           | The namespace(s) to query services in                                                                                                             | []                 |
 

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -31,14 +31,14 @@ To enable Kubernetes discovery you just need to configure some settings inside t
 {
   "HealthChecksUI": {
     "KubernetesDiscoveryService": {
-          "Enabled": true,
-          "ClusterHost": "https://myaks-962d02ba.hcp.westeurope.azmk8s.io:443",
-          "Token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3M...",
-          "HealthPath": "healthz",
-          "ServicesLabel": "HealthChecks",
-          "ServicesPathLabel": "HealthChecksPath",
-          "ServicesPortLabel": "HealthChecksPort",
-          "ServicesSchemeLabel": "HealthChecksScheme"
+      "Enabled": true,
+      "ClusterHost": "https://myaks-962d02ba.hcp.westeurope.azmk8s.io:443",
+      "Token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3M...",
+      "HealthPath": "healthz",
+      "ServicesLabel": "HealthChecks",
+      "ServicesPathLabel": "HealthChecksPath",
+      "ServicesPortLabel": "HealthChecksPort",
+      "ServicesSchemeLabel": "HealthChecksScheme"
     }
   }
 }
@@ -50,13 +50,13 @@ If you are hosting HealthChecks UI within Kubernetes, you can use the following 
 {
   "HealthChecksUI": {
     "KubernetesDiscoveryService": {
-          "Enabled": true,
-          "InCluster": true,
-          "HealthPath": "healthz",
-          "ServicesLabel": "HealthChecks",
-          "ServicesPathLabel": "HealthChecksPath",
-          "ServicesPortLabel": "HealthChecksPort",
-          "ServicesSchemeLabel": "HealthChecksScheme"
+      "Enabled": true,
+      "InCluster": true,
+      "HealthPath": "healthz",
+      "ServicesLabel": "HealthChecks",
+      "ServicesPathLabel": "HealthChecksPath",
+      "ServicesPortLabel": "HealthChecksPort",
+      "ServicesSchemeLabel": "HealthChecksScheme"
     }
   }
 }
@@ -66,19 +66,22 @@ If you are hosting HealthChecks UI within Kubernetes, you can use the following 
 
 Here are all the available parameters detailed:
 
-| Parameter            | Description                                                                                                                                       | Default Value      |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| Enabled              | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false              |
-| InCluster            | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false              |
-| ClusterHost          | The uri of the kubernetes cluster                                                                                                                 |                    |
-| Token                | The token that will be sent to the cluster for authentication                                                                                     |                    |
-| HealthPath           | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
-| ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
-| ServicesPathLabel    | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
-| ServicesPortLabel    | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
-| ServicesSchemeLabel  | The label on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used           | HealthChecksScheme |
-| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                                                                                                              | 300                |
-| Namespaces           | The namespace(s) to query services in                                                                                                             | []                 |
+| Parameter                | Description                                                                                                                                       | Default Value      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| Enabled                  | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false              |
+| InCluster                | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false              |
+| ClusterHost              | The uri of the kubernetes cluster                                                                                                                 |                    |
+| Token                    | The token that will be sent to the cluster for authentication                                                                                     |                    |
+| HealthPath               | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
+| ServicesLabel            | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
+| ServicesPathLabel        | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
+| ServicesPortLabel        | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
+| ServicesSchemeLabel      | The label on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used           | HealthChecksScheme |
+| ServicesPathAnnotation   | The annotation on a service that can override the configured url path                                                                             | HealthChecksPath   |
+| ServicesPortAnnotation   | The annotation on a service to define which port to call. If the label does not exist on the service the first defined port will be used          | HealthChecksPort   |
+| ServicesSchemeAnnotation | The annotation on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used      | HealthChecksScheme |
+| RefreshTimeOnSeconds     | Healthchecks refresh time in seconds                                                                                                              | 300                |
+| Namespaces               | The namespace(s) to query services in                                                                                                             | []                 |
 
 ## Labeling Services for discovery in Kubernetes
 
@@ -90,11 +93,11 @@ If you want to tag a service just execute the k8s command line tool (kubectl) us
 
 Change `HealthChecks=true` by your configured ServiceLabel if you gave another value for it.
 
-The `HealthPathLabel` option (by default HealthChecksPath) provides a method for services to override the default health path configured.
+The `ServicesPathLabel` option (by default HealthChecksPath) provides a method for services to override the default health path configured. `ServicesPathAnnotation` can be used instead to configure the path using annotations instead.
 
-The `HealthPortLabel` option (by default HealthChecksPort) provides a method for services to specify which port to use for health checks. By default the first port defined on the service will be used. The label can refer to either the name of the port or the port number.
+The `ServicesPortLabel` option (by default HealthChecksPort) provides a method for services to specify which port to use for health checks. By default the first port defined on the service will be used. The label can refer to either the name of the port or the port number. `ServicesPortAnnotation` can be used instead to configure the port using annotations instead.
 
-The `HealthSchemeLabel` option (by default HealthChecksScheme) provides a method for services to specify which URI scheme to use for health checks. By default the HTTP will be used as the URI scheme.
+The `ServicesSchemeLabel` option (by default HealthChecksScheme) provides a method for services to specify which URI scheme to use for health checks. By default the HTTP will be used as the URI scheme. `ServicesSchemeAnnotation` can be used instead to configure the scheme using annotations instead.
 
 ## How it works
 

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -44,18 +44,19 @@ To enable Kubernetes discovery you just need to configure some settings inside t
 
 Here are all the available parameters detailed:
 
-| Parameter            | Description                                                                                                                                       | Default Value    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| Enabled              | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false            |
-| InCluster            | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false            |
-| ClusterHost          | The uri of the kubernetes cluster                                                                                                                 |                  |
-| Token                | The token that will be sent to the cluster for authentication                                                                                     |                  |
-| HealthPath           | The url path where the UI will call once the service is discovered                                                                                | hc               |
-| ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks     |
-| HealthPathLabel      | The label on a service that can override the configured url path                                                                                  | HealthChecksPath |
-| HealthPortLabel      | The label on a service to define which port to call. If it does not exist on the service the first defined port will be used                      | HealthChecksPort |
-| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                                                                                                              | 300              |
-| Namespaces           | The namespace(s) to query services in                                                                                                             | []               |
+| Parameter            | Description                                                                                                                                       | Default Value      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| Enabled              | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false              |
+| InCluster            | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false              |
+| ClusterHost          | The uri of the kubernetes cluster                                                                                                                 |                    |
+| Token                | The token that will be sent to the cluster for authentication                                                                                     |                    |
+| HealthPath           | The url path where the UI will call once the service is discovered                                                                                | hc                 |
+| ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
+| HealthPathLabel      | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
+| HealthPortLabel      | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
+| HealthSchemeLabel    | The label on a service to define which URI scheme to use for healthchecks. If the label does not exist on the service http will be used           | HealthChecksScheme |
+| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                                                                                                              | 300                |
+| Namespaces           | The namespace(s) to query services in                                                                                                             | []                 |
 
 ## Labeling Services for discovery in Kubernetes
 
@@ -70,6 +71,8 @@ Change `HealthChecks=true` by your configured ServiceLabel if you gave another v
 The `HealthPathLabel` option (by default HealthChecksPath) provides a method for services to override the default health path configured.
 
 The `HealthPortLabel` option (by default HealthChecksPort) provides a method for services to specify which port to use for health checks. By default the first port defined on the service will be used. The label can refer to either the name of the port or the port number.
+
+The `HealthSchemeLabel` option (by default HealthChecksScheme) provides a method for services to specify which URI scheme to use for health checks. By default the HTTP will be used as the URI scheme.
 
 ## How it works
 

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -33,8 +33,8 @@ To enable Kubernetes discovery you just need to configure some settings inside t
     "KubernetesDiscoveryService": {
           "Enabled": true,
           "ClusterHost": "https://myaks-962d02ba.hcp.westeurope.azmk8s.io:443",
-          "Token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3M...",      
-          "HealthPath": "healthz"      
+          "Token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3M...",
+          "HealthPath": "healthz"
     }
   }
 }
@@ -50,7 +50,7 @@ Here are all the available parameters detailed:
 | InCluster            | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false              |
 | ClusterHost          | The uri of the kubernetes cluster                                                                                                                 |                    |
 | Token                | The token that will be sent to the cluster for authentication                                                                                     |                    |
-| HealthPath           | The url path where the UI will call once the service is discovered                                                                                | hc                 |
+| HealthPath           | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
 | ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
 | HealthPathLabel      | The label on a service that can override the configured url path                                                                                  | HealthChecksPath   |
 | HealthPortLabel      | The label on a service to define which port to call. If the label does not exist on the service the first defined port will be used               | HealthChecksPort   |
@@ -85,3 +85,20 @@ If the InCluster option is set to true then the kubernetes service discovery wil
 If Namespaces is set only the labelled services within the specified namespace(s) will be queried. By default it will query all services in the cluster.
 
 **NOTE**: Remember if you are using `kubectl proxy` you can configure your cluster address as http://localhost:8001.
+
+## Kubernetes Role-Based Access
+
+The service account being used for the Kubernetes Service Discovery needs the following role on its service account for the service discovery to work:
+
+``` yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: healthchecksui
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["list"]
+```
+
+The role needs to be added in every namespace configured, and a corresponding `RoleBinding` to bind it to the service account. If you wish to query all namespaces, replace `Role` with `ClusterRole` and `RoleBinding` to `ClusterRoleBinding`.

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -44,14 +44,18 @@ To enable Kubernetes discovery you just need to configure some settings inside t
 
 Here are all the available parameters detailed:
 
-| Parameter            | Description                                                        | Default Value |
-| -------------------- | ------------------------------------------------------------------ | ------------- |
-| Enabled              | Establishes if the k8s discovery service is enabled of disabled    | false         |
-| ClusterHost          | The uri of the kubernetes cluster                                  |               |
-| Token                | The token that will be sent to the cluster for authentication      |               |
-| HealthPath           | The url path where the UI will call once the service is discovered | hc            |
-| ServicesLabel        | The labeled services the UI will look for in k8s                   | HealthChecks  |
-| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                               | 300           |
+| Parameter            | Description                                                                                                                                       | Default Value    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| Enabled              | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false            |
+| InCluster            | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false            |
+| ClusterHost          | The uri of the kubernetes cluster                                                                                                                 |                  |
+| Token                | The token that will be sent to the cluster for authentication                                                                                     |                  |
+| HealthPath           | The url path where the UI will call once the service is discovered                                                                                | hc               |
+| ServicesLabel        | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks     |
+| HealthPathLabel      | The label on a service that can override the configured url path                                                                                  | HealthChecksPath |
+| HealthPortLabel      | The label on a service to define which port to call. If it does not exist on the service the first defined port will be used                      | HealthChecksPort |
+| RefreshTimeOnSeconds | Healthchecks refresh time in seconds                                                                                                              | 300              |
+| Namespaces           | The namespace(s) to query services in                                                                                                             | []               |
 
 ## Labeling Services for discovery in Kubernetes
 
@@ -63,10 +67,18 @@ If you want to tag a service just execute the k8s command line tool (kubectl) us
 
 Change `HealthChecks=true` by your configured ServiceLabel if you gave another value for it.
 
+The `HealthPathLabel` option (by default HealthChecksPath) provides a method for services to override the default health path configured.
+
+The `HealthPortLabel` option (by default HealthChecksPort) provides a method for services to specify which port to use for health checks. By default the first port defined on the service will be used. The label can refer to either the name of the port or the port number.
+
 ## How it works
 
 The kubernetes service discovery will retrieve from the k8s api all the labelled services and from the metadata it will try to build the target url to query for health.
 
-If you have exposed a deployment using for example a LoadBalancer on port 50000 and your configured  HealthPath is "healthz" the target url to be queried would be : (ip/host):50000/healthz
+If you have exposed a deployment using for example a LoadBalancer on port 50000 and your configured HealthPath is "healthz" the target url to be queried would be : (ip/host):50000/healthz
+
+If the InCluster option is set to true then the kubernetes service discovery will try to load the Cluster Host and the Token from the environment variables and service account token mounting that occurs by default in Kubernetes pods. If the InCluster option is set to false then the ClusterHost and Token options will need to be manually set.
+
+If Namespaces is set only the labelled services within the specified namespace(s) will be queried. By default it will query all services in the cluster.
 
 **NOTE**: Remember if you are using `kubectl proxy` you can configure your cluster address as http://localhost:8001.

--- a/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/KubernetesHttpClientExtensions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/KubernetesHttpClientExtensions.cs
@@ -46,7 +46,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S.Extensions
 
             if (!validHttpEndpoint)
             {
-                throw new Exception($"{nameof(host)} is not a valid Http Uri");
+                throw new Exception($"{hostString} is not a valid Http Uri");
             }
 
             client.BaseAddress = host;

--- a/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/KubernetesHttpClientExtensions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/KubernetesHttpClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -13,8 +14,35 @@ namespace HealthChecks.UI.Core.Discovery.K8S.Extensions
         {
             var options = serviceProvider.GetRequiredService<KubernetesDiscoverySettings>();
             
-            var validHttpEndpoint = Uri.TryCreate(options.ClusterHost, UriKind.Absolute, out var host)
-                && (host.Scheme == Uri.UriSchemeHttp || host.Scheme == Uri.UriSchemeHttps);
+            string token;
+            string hostString;
+
+            if(options.InCluster)
+            {
+                var clusterHost = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST");
+                var clusterPort = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT");
+
+                string fullClusterHost;
+                // Support IPv6 address hosts
+                if(clusterHost.Contains(":"))
+                {
+                    hostString = $"https://[{clusterHost}]:{clusterPort}";
+                }
+                else
+                {
+                    hostString = $"https://{clusterHost}:{clusterPort}";
+                }
+
+                token = File.ReadAllText("/var/run/secrets/kubernetes.io/serviceaccount/token").Trim();
+            }
+            else
+            {
+                token = options.Token;
+                hostString = options.ClusterHost;
+            }
+            
+            var validHttpEndpoint = Uri.TryCreate(hostString, UriKind.Absolute, out var host)
+                    && (host.Scheme == Uri.UriSchemeHttp || host.Scheme == Uri.UriSchemeHttps);
 
             if (!validHttpEndpoint)
             {

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesAddressFactory.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesAddressFactory.cs
@@ -41,7 +41,15 @@ namespace HealthChecks.UI.Core.Discovery.K8S
             }
             healthPath = healthPath.TrimStart('/');
 
-            return $"http://{address}{port}/{healthPath}";
+            // Support IPv6 address hosts
+            if(address.Contains(":"))
+            {
+                return $"http://[{address}]{port}/{healthPath}";
+            }
+            else
+            {
+                return $"http://{address}{port}/{healthPath}";
+            }
         }
         private string GetLoadBalancerAddress(Service service)
         {

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesApiEndpoints.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesApiEndpoints.cs
@@ -3,5 +3,6 @@
     public class KubernetesApiEndpoints
     {
         public const string ServicesV1 = "api/v1/services";
+        public const string NamespacedServicesV1 = "api/v1/namespaces/{0}/services";
     }
 }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -35,7 +35,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
             _discoveryClient = httpClientFactory.CreateClient(Keys.K8S_DISCOVERY_HTTP_CLIENT_NAME);
             _clusterServiceClient = httpClientFactory.CreateClient(Keys.K8S_CLUSTER_SERVICE_HTTP_CLIENT_NAME);
-            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath);
+            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.HealthPathLabel, discoveryOptions.HealthPortLabel);
 
         }
         public Task StartAsync(CancellationToken cancellationToken)

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -35,7 +35,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
             _discoveryClient = httpClientFactory.CreateClient(Keys.K8S_DISCOVERY_HTTP_CLIENT_NAME);
             _clusterServiceClient = httpClientFactory.CreateClient(Keys.K8S_CLUSTER_SERVICE_HTTP_CLIENT_NAME);
-            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.ServicesPathLabel, discoveryOptions.ServicesPortLabel, discoveryOptions.ServicesSchemeLabel);
+            _addressFactory = new KubernetesAddressFactory(discoveryOptions);
 
         }
         public Task StartAsync(CancellationToken cancellationToken)

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -57,7 +57,8 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                _logger.LogInformation($"Starting kubernetes service discovery on cluster {_discoveryOptions.ClusterHost}");
+                var clusterName = _discoveryOptions.InCluster ? "host" : _discoveryOptions.ClusterHost;
+                _logger.LogInformation($"Starting kubernetes service discovery on cluster {clusterName}");
 
                 using (var scope = _serviceProvider.CreateScope())
                 {
@@ -65,7 +66,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
                     try
                     {
-                        var services = await _discoveryClient.GetServices(_discoveryOptions.ServicesLabel);
+                        var services = await _discoveryClient.GetServices(_discoveryOptions.ServicesLabel, _discoveryOptions.Namespaces);
                         foreach (var item in services.Items)
                         {
                             try
@@ -82,9 +83,9 @@ namespace HealthChecks.UI.Core.Discovery.K8S
                                     }
                                 }
                             }
-                            catch (Exception)
+                            catch (Exception ex)
                             {
-                                _logger.LogError($"Error discovering service {item.Metadata.Name}. It might not be visible");
+                                _logger.LogError(ex, $"Error discovering service {item.Metadata.Name}. It might not be visible");
                             }
                         }
                     }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -35,7 +35,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
             _discoveryClient = httpClientFactory.CreateClient(Keys.K8S_DISCOVERY_HTTP_CLIENT_NAME);
             _clusterServiceClient = httpClientFactory.CreateClient(Keys.K8S_CLUSTER_SERVICE_HTTP_CLIENT_NAME);
-            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.HealthPathLabel, discoveryOptions.HealthPortLabel);
+            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.HealthPathLabel, discoveryOptions.HealthPortLabel, discoveryOptions.HealthSchemeLabel);
 
         }
         public Task StartAsync(CancellationToken cancellationToken)

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -35,7 +35,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
             _discoveryClient = httpClientFactory.CreateClient(Keys.K8S_DISCOVERY_HTTP_CLIENT_NAME);
             _clusterServiceClient = httpClientFactory.CreateClient(Keys.K8S_CLUSTER_SERVICE_HTTP_CLIENT_NAME);
-            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.HealthPathLabel, discoveryOptions.HealthPortLabel, discoveryOptions.HealthSchemeLabel);
+            _addressFactory = new KubernetesAddressFactory(discoveryOptions.HealthPath, discoveryOptions.ServicesPathLabel, discoveryOptions.ServicesPortLabel, discoveryOptions.ServicesSchemeLabel);
 
         }
         public Task StartAsync(CancellationToken cancellationToken)
@@ -66,7 +66,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
                     try
                     {
-                        var services = await _discoveryClient.GetServices(_discoveryOptions.ServicesLabel, _discoveryOptions.Namespaces);
+                        var services = await _discoveryClient.GetServices(_logger, _discoveryOptions.ServicesLabel, _discoveryOptions.Namespaces);
                         foreach (var item in services.Items)
                         {
                             try

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
@@ -9,6 +9,7 @@
         public string ServicesLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL;
         public string HealthPathLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
         public string HealthPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
+        public string HealthSchemeLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL;
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
         public string[] Namespaces { get; set; } = new string[] {};

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
@@ -11,6 +11,6 @@
         public string HealthPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
-        public string[] Namespaces { get; set; } = new string[] {}
+        public string[] Namespaces { get; set; } = new string[] {};
     }
 }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
@@ -3,10 +3,14 @@
     class KubernetesDiscoverySettings
     {
         public bool Enabled { get; set; } = false;
+        public bool InCluster { get; set; } = false;
         public string ClusterHost { get; set; }
         public string HealthPath { get; set; } = Keys.HEALTHCHECKS_DEFAULT_PATH;
         public string ServicesLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL;
+        public string HealthPathLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
+        public string HealthPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
+        public string[] Namespaces { get; set; } = new string[] {}
     }
 }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoverySettings.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoverySettings.cs
@@ -10,6 +10,9 @@
         public string ServicesPathLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
         public string ServicesPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
         public string ServicesSchemeLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL;
+        public string ServicesPathAnnotation { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
+        public string ServicesPortAnnotation { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
+        public string ServicesSchemeAnnotation { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL;
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
         public string[] Namespaces { get; set; } = new string[] {};

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoverySettings.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoverySettings.cs
@@ -7,9 +7,9 @@
         public string ClusterHost { get; set; }
         public string HealthPath { get; set; } = Keys.HEALTHCHECKS_DEFAULT_PATH;
         public string ServicesLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL;
-        public string HealthPathLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
-        public string HealthPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
-        public string HealthSchemeLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL;
+        public string ServicesPathLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL;
+        public string ServicesPortLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL;
+        public string ServicesSchemeLabel { get; set; } = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL;
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
         public string[] Namespaces { get; set; } = new string[] {};

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
@@ -20,6 +20,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         public string Namespace { get; set; }
         public string Uid { get; set; }
         public IDictionary<string, string> Labels { get; set; }
+        public IDictionary<string, string> Annotations { get; set; }
     }
     internal class LoadBalancer
     {     

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesResponses.cs
@@ -19,6 +19,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         public string Name { get; set; }
         public string Namespace { get; set; }
         public string Uid { get; set; }
+        public IDictionary<string, string> Labels { get; set; }
     }
     internal class LoadBalancer
     {     
@@ -42,6 +43,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
     }
     internal class Port
     {
+        public string Name { get; set; }
         public string Protocol { get; set; }
         [JsonProperty("Port")]
         public int PortNumber { get; set; }

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -10,6 +10,7 @@ namespace HealthChecks.UI
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL = "HealthChecks";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL = "HealthChecksPath";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL = "HealthChecksPort";
+        internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL = "HealthChecksScheme";
         internal const string HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY = "HealthChecksUI:KubernetesDiscoveryService";        
         internal const string HEALTHCHECKSUI_MAIN_UI_RESOURCE = "index.html";
         internal const string HEALTHCHECKSUI_MAIN_UI_API_TARGET = "#apiPath#";

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -4,7 +4,7 @@ namespace HealthChecks.UI
 {
     class Keys
     {
-        internal const string HEALTHCHECKSUI_OLD_SECTION_SETTING_KEY = "HealthChecks-UI";        
+        internal const string HEALTHCHECKSUI_OLD_SECTION_SETTING_KEY = "HealthChecks-UI";
         internal const string HEALTHCHECKSUI_SECTION_SETTING_KEY = "HealthChecksUI";
         internal const string HEALTHCHECKS_DEFAULT_PATH = "hc";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL = "HealthChecks";

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -8,6 +8,8 @@ namespace HealthChecks.UI
         internal const string HEALTHCHECKSUI_SECTION_SETTING_KEY = "HealthChecksUI";
         internal const string HEALTHCHECKS_DEFAULT_PATH = "hc";
         internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_LABEL = "HealthChecks";
+        internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL = "HealthChecksPath";
+        internal const string HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL = "HealthChecksPort";
         internal const string HEALTHCHECKSUI_KUBERNETES_DISCOVERY_SETTING_KEY = "HealthChecksUI:KubernetesDiscoveryService";        
         internal const string HEALTHCHECKSUI_MAIN_UI_RESOURCE = "index.html";
         internal const string HEALTHCHECKSUI_MAIN_UI_API_TARGET = "#apiPath#";

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -20,7 +20,12 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(healthPath, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL);
+            var addressFactory = new KubernetesAddressFactory(
+                healthPath,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
+            );
 
             List<string> serviceAddresses = new List<string>();
             
@@ -45,7 +50,12 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(healthPath, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL);
+            var addressFactory = new KubernetesAddressFactory(
+                healthPath,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
+                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
+            );
 
             List<string> serviceAddresses = new List<string>();
 
@@ -58,7 +68,7 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[1].Should().Be("http://13.80.181.10:51000/healthz");
             serviceAddresses[2].Should().Be("http://12.0.0.190:5672/healthz");
             serviceAddresses[3].Should().Be("http://12.0.0.168:30478/healthz");
-            serviceAddresses[4].Should().Be("http://10.152.183.35:8080/custom/health/path");
+            serviceAddresses[4].Should().Be("https://10.152.183.35:8080/custom/health/path");
 
         }
 

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -20,12 +20,14 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(
-                healthPath,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
-            );
+
+            var addressFactory = new KubernetesAddressFactory(new KubernetesDiscoverySettings
+            {
+                HealthPath = healthPath,
+                ServicesPathLabel = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
+                ServicesPortLabel = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
+                ServicesSchemeLabel = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
+            });
 
             List<string> serviceAddresses = new List<string>();
             
@@ -50,12 +52,13 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(
-                healthPath,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
-                Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
-            );
+            var addressFactory = new KubernetesAddressFactory(new KubernetesDiscoverySettings
+            {
+                HealthPath = healthPath,
+                ServicesPathAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL,
+                ServicesPortAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL,
+                ServicesSchemeAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_LABEL
+            });
 
             List<string> serviceAddresses = new List<string>();
 

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using HealthChecks.UI;
 using HealthChecks.UI.Core.Discovery.K8S;
 using Newtonsoft.Json;
 using System;
@@ -19,7 +20,7 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(healthPath);
+            var addressFactory = new KubernetesAddressFactory(healthPath, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL);
 
             List<string> serviceAddresses = new List<string>();
             
@@ -32,7 +33,7 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[1].Should().Be("http://localhost:9000/healthz");
             serviceAddresses[2].Should().Be("http://localhost:30000/healthz");
             serviceAddresses[3].Should().Be("http://10.97.1.153:80/healthz");
-            serviceAddresses[4].Should().Be("http://10.152.183.35:5341/healthz");
+            serviceAddresses[4].Should().Be("http://10.152.183.35:7070/custom/health/path");
 
         }
 
@@ -44,7 +45,7 @@ namespace UnitTests.UI.Kubernetes
 
             var services = JsonConvert.DeserializeObject<ServiceList>(apiResponse);
 
-            var addressFactory = new KubernetesAddressFactory(healthPath);
+            var addressFactory = new KubernetesAddressFactory(healthPath, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_LABEL, Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_LABEL);
 
             List<string> serviceAddresses = new List<string>();
 
@@ -57,7 +58,7 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[1].Should().Be("http://13.80.181.10:51000/healthz");
             serviceAddresses[2].Should().Be("http://12.0.0.190:5672/healthz");
             serviceAddresses[3].Should().Be("http://12.0.0.168:30478/healthz");
-            serviceAddresses[4].Should().Be("http://10.152.183.35:5341/healthz");
+            serviceAddresses[4].Should().Be("http://10.152.183.35:8080/custom/health/path");
 
         }
 

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[1].Should().Be("http://localhost:9000/healthz");
             serviceAddresses[2].Should().Be("http://localhost:30000/healthz");
             serviceAddresses[3].Should().Be("http://10.97.1.153:80/healthz");
-            serviceAddresses[4].Should().Be("http://10.152.183.35:7070/custom/health/path");
+            serviceAddresses[4].Should().Be("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:7070/custom/health/path");
 
         }
 

--- a/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
@@ -126,16 +126,30 @@
         "creationTimestamp": "2019-07-12T02:42:38Z",
         "labels": {
           "HealthChecks": "true",
+          "HealthChecksPath": "custom/health/path",
+          "HealthChecksPort": "7070",
           "app": "seq"
         }
       },
       "spec": {
         "ports": [
           {
-            "name": "http",
+            "name": "ingestion",
             "protocol": "TCP",
             "port": 5341,
             "targetPort": "ui"
+          },
+          {
+            "name": "http",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": "ui"
+          },
+          {
+            "name": "healthcheck",
+            "protocol": "TCP",
+            "port": 7070,
+            "targetPort": "healthcheck"
           }
         ],
         "selector": {

--- a/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
@@ -155,7 +155,7 @@
         "selector": {
           "app": "seq"
         },
-        "clusterIP": "10.152.183.35",
+        "clusterIP": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       },

--- a/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
@@ -168,16 +168,30 @@
         "creationTimestamp": "2019-07-12T02:42:38Z",
         "labels": {
           "HealthChecks": "true",
+          "HealthChecksPath": "/custom/health/path",
+          "HealthChecksPort": "healthcheck",
           "app": "seq"
         }
       },
       "spec": {
         "ports": [
           {
-            "name": "http",
+            "name": "ingestion",
             "protocol": "TCP",
             "port": 5341,
+            "targetPort": "ingestion"
+          },
+          {
+            "name": "http",
+            "protocol": "TCP",
+            "port": 80,
             "targetPort": "ui"
+          },
+          {
+            "name": "healthcheck",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": "healthcheck"
           }
         ],
         "selector": {

--- a/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
@@ -168,10 +168,12 @@
         "creationTimestamp": "2019-07-12T02:42:38Z",
         "labels": {
           "HealthChecks": "true",
+          "app": "seq"
+        },
+        "annotations": {
           "HealthChecksPath": "/custom/health/path",
           "HealthChecksPort": "healthcheck",
-          "HealthChecksScheme": "https",
-          "app": "seq"
+          "HealthChecksScheme": "https"
         }
       },
       "spec": {

--- a/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json
@@ -170,6 +170,7 @@
           "HealthChecks": "true",
           "HealthChecksPath": "/custom/health/path",
           "HealthChecksPort": "healthcheck",
+          "HealthChecksScheme": "https",
           "app": "seq"
         }
       },


### PR DESCRIPTION
* Include changes from [https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/228](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/228) to fix the data type of targetPorts.
*  Add support for service labels to override the defaults on a per-service basis:
  * **HealthChecksPath**: Override the health check path.
  * **HealthChecksPort**: Override the health check port if it isn't using the first defined port.
  * **HealthChecksScheme**: Override the URI scheme (for HTTPS support).
* Add support for limiting the service discovery to specified namespaces.
* Add support for easier in-cluster support.
* Add IPv6 support.
* Add an example for role based access in the README.