### PR TITLE
Datadog Publisher

### DIFF
--- a/AspNetCore.Diagnostics.HealthChecks.sln
+++ b/AspNetCore.Diagnostics.HealthChecks.sln
@@ -91,11 +91,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.RavenDB", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.Kubernetes", "src\HealthChecks.Kubernetes\HealthChecks.Kubernetes.csproj", "{AFEB2B9F-6750-4DDA-AACC-B05D899D04E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.SignalR", "src\HealthChecks.SignalR\HealthChecks.SignalR.csproj", "{6A4616DA-6471-478C-9797-D19029AD757C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.SignalR", "src\HealthChecks.SignalR\HealthChecks.SignalR.csproj", "{6A4616DA-6471-478C-9797-D19029AD757C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.CosmosDb", "src\HealthChecks.CosmosDb\HealthChecks.CosmosDb.csproj", "{08FE3B71-2C9C-459B-9943-0C141191453C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.CosmosDb", "src\HealthChecks.CosmosDb\HealthChecks.CosmosDb.csproj", "{08FE3B71-2C9C-459B-9943-0C141191453C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.Gcp.CloudFirestore", "src\HealthChecks.Gcp.CloudFirestore\HealthChecks.Gcp.CloudFirestore.csproj", "{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.Gcp.CloudFirestore", "src\HealthChecks.Gcp.CloudFirestore\HealthChecks.Gcp.CloudFirestore.csproj", "{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthChecks.Publisher.Datadog", "src\HealthChecks.Publisher.Datadog\HealthChecks.Publisher.Datadog.csproj", "{18F9E412-646D-4751-9751-30AA7A0233DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -247,18 +249,22 @@ Global
 		{AFEB2B9F-6750-4DDA-AACC-B05D899D04E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFEB2B9F-6750-4DDA-AACC-B05D899D04E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFEB2B9F-6750-4DDA-AACC-B05D899D04E1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{08FE3B71-2C9C-459B-9943-0C141191453C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{08FE3B71-2C9C-459B-9943-0C141191453C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{08FE3B71-2C9C-459B-9943-0C141191453C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{08FE3B71-2C9C-459B-9943-0C141191453C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A4616DA-6471-478C-9797-D19029AD757C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A4616DA-6471-478C-9797-D19029AD757C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A4616DA-6471-478C-9797-D19029AD757C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A4616DA-6471-478C-9797-D19029AD757C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08FE3B71-2C9C-459B-9943-0C141191453C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08FE3B71-2C9C-459B-9943-0C141191453C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08FE3B71-2C9C-459B-9943-0C141191453C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08FE3B71-2C9C-459B-9943-0C141191453C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18F9E412-646D-4751-9751-30AA7A0233DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18F9E412-646D-4751-9751-30AA7A0233DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18F9E412-646D-4751-9751-30AA7A0233DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18F9E412-646D-4751-9751-30AA7A0233DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -300,9 +306,10 @@ Global
 		{439DF9B7-5D0F-4531-BA19-F1BD01B244DB} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 		{E91924B0-BE65-4CF8-A43A-2F22EEFE53F2} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 		{AFEB2B9F-6750-4DDA-AACC-B05D899D04E1} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
-		{08FE3B71-2C9C-459B-9943-0C141191453C} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 		{6A4616DA-6471-478C-9797-D19029AD757C} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
+		{08FE3B71-2C9C-459B-9943-0C141191453C} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 		{F561CEBE-C1D4-45CC-978C-A7CAA8A1F0C4} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
+		{18F9E412-646D-4751-9751-30AA7A0233DF} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2B8C62A1-11B6-469F-874C-A02443256568}

--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ public void ConfigureServices(IServiceCollection services)
 
 ## HealthCheck push results
 
-HealthChecks include a *push model* to send HealthCheckReport results into configured consumers. The project **AspNetCore.HealthChecks.Publisher.ApplicationInsights**,**AspNetCore.HealthChecks.Publisher.Prometheus** or **AspNetCore.HealthChecks.Publisher.Seq** define a consumers to send report results to Application Insights,Prometheus or Seq.
+HealthChecks include a *push model* to send HealthCheckReport results into configured consumers. The project **AspNetCore.HealthChecks.Publisher.ApplicationInsights**, **AspNetCore.HealthChecks.Publisher.Datadog**, **AspNetCore.HealthChecks.Publisher.Prometheus** or **AspNetCore.HealthChecks.Publisher.Seq** define a consumers to send report results to Application Insights, Datadog, Prometheus or Seq.
 
 Include the package in your project:
 
 ```powershell
 install-package AspNetcore.HealthChecks.Publisher.ApplicationInsights
+install-package AspNetcore.HealthChecks.Publisher.Datadog
 install-package AspNetcore.HealthChecks.Publisher.Prometheus
 install-package AspNetcore.HealthChecks.Publisher.Seq
 ```
@@ -117,6 +118,7 @@ services.AddHealthChecks()
         .AddSqlServer(connectionString: Configuration["Data:ConnectionStrings:Sample"])
         .AddCheck<RandomHealthCheck>("random")
         .AddApplicationInsightsPublisher()
+        .AddDatadogPublisher("myservice.healthchecks")
         .AddPrometheusGatewayPublisher();
 ```
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,6 +93,7 @@ if ($suffix -eq "") {
     exec { & dotnet pack .\src\HealthChecks.UI\HealthChecks.UI.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
     exec { & dotnet pack .\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
     exec { & dotnet pack .\src\HealthChecks.Publisher.ApplicationInsights\HealthChecks.Publisher.ApplicationInsights.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
+    exec { & dotnet pack .\src\HealthChecks.Publisher.Datadog\HealthChecks.Publisher.Datadog.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
     exec { & dotnet pack .\src\HealthChecks.Publisher.Prometheus\HealthChecks.Publisher.Prometheus.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
     exec { & dotnet pack .\src\HealthChecks.Publisher.Seq\HealthChecks.Publisher.Seq.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
     exec { & dotnet pack .\src\HealthChecks.Consul\HealthChecks.Consul.csproj -c Release -o ..\..\artifacts --include-symbols --no-build }
@@ -129,6 +130,7 @@ else {
     exec { & dotnet pack .\src\HealthChecks.UI\HealthChecks.UI.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
     exec { & dotnet pack .\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
 	exec { & dotnet pack .\src\HealthChecks.Publisher.ApplicationInsights\HealthChecks.Publisher.ApplicationInsights.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
+	exec { & dotnet pack .\src\HealthChecks.Publisher.Datadog\HealthChecks.Publisher.Datadog.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
 	exec { & dotnet pack .\src\HealthChecks.Publisher.Prometheus\HealthChecks.Publisher.Prometheus.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
     exec { & dotnet pack .\src\HealthChecks.Publisher.Seq\HealthChecks.Publisher.Seq.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
     exec { & dotnet pack .\src\HealthChecks.Consul\HealthChecks.Consul.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
@@ -137,4 +139,3 @@ else {
     exec { & dotnet pack .\src\HealthChecks.SignalR\HealthChecks.SignalR.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
 	exec { & dotnet pack .\src\HealthChecks.Gcp.CloudFirestore\HealthChecks.Gcp.CloudFirestore.csproj -c Release -o ..\..\artifacts --include-symbols --no-build --version-suffix=$suffix }
 }
-

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -97,6 +97,7 @@
     <HealthCheckUI>2.2.32</HealthCheckUI>
     <HealthCheckUIClient>2.2.4</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>2.2.4</HealthCheckPublisherAppplicationInsights>
+    <HealthCheckPublisherDatadog>2.2.0</HealthCheckPublisherDatadog>
     <HealthCheckPublisherPrometheus>2.2.0</HealthCheckPublisherPrometheus>
     <HealthCheckAWSS3>2.2.0</HealthCheckAWSS3>
     <HealthCheckKeyVault>2.2.2</HealthCheckKeyVault>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -64,6 +64,7 @@
     <KubernetesClient>1.2.0</KubernetesClient>
     <MicrosoftAspNetCoreSignalRClient>1.1.0</MicrosoftAspNetCoreSignalRClient>
     <MicrosoftAspNetCoreSignalR>1.1.0</MicrosoftAspNetCoreSignalR>
+    <DogStatsDCSharpClient>3.3.0</DogStatsDCSharpClient>
   </PropertyGroup>
 
   <PropertyGroup Label="CLI Tools Versions">

--- a/src/HealthChecks.Publisher.Datadog/DatadogPublisher.cs
+++ b/src/HealthChecks.Publisher.Datadog/DatadogPublisher.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StatsdClient;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.Publisher.Datadog
+{
+    class DatadogPublisher
+        : IHealthCheckPublisher
+    {
+        private readonly IDogStatsd _dogStatsd;
+        private readonly string _serviceCheckName;
+        private readonly string[] _defaultTags;
+
+        public DatadogPublisher(IDogStatsd dogStatsd, string serviceCheckName, string[] defaultTags)
+        {
+            _dogStatsd = dogStatsd ?? throw new ArgumentNullException(nameof(dogStatsd));
+            _serviceCheckName = serviceCheckName ?? throw new ArgumentNullException(nameof(serviceCheckName));
+            _defaultTags = defaultTags ?? throw new ArgumentNullException(nameof(defaultTags));
+        }
+
+        public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+        {
+            foreach (var keyedEntry in report.Entries)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                var key = keyedEntry.Key;
+                var entry = keyedEntry.Value;
+                Status dataDogStatus;
+
+                switch (entry.Status)
+                {
+                    case HealthStatus.Healthy:
+                        dataDogStatus = Status.OK;
+                        break;
+                    case HealthStatus.Degraded:
+                        dataDogStatus = Status.WARNING;
+                        break;
+                    case HealthStatus.Unhealthy:
+                        dataDogStatus = Status.CRITICAL;
+                        break;
+                    default:
+                        dataDogStatus = Status.UNKNOWN;
+                        break;
+                }
+
+                var tags = (_defaultTags ?? new string[0]).Concat(new[]
+                {
+                    $"check:{key}"
+                }).ToArray();
+
+                var message = entry.Description ?? entry.Status.ToString();
+                _dogStatsd.ServiceCheck(_serviceCheckName, dataDogStatus, null, Environment.MachineName, tags, message);
+                _dogStatsd.Timer(_serviceCheckName, entry.Duration.TotalMilliseconds, 1, tags);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/HealthChecks.Publisher.Datadog/DatadogPublisher.cs
+++ b/src/HealthChecks.Publisher.Datadog/DatadogPublisher.cs
@@ -18,7 +18,7 @@ namespace HealthChecks.Publisher.Datadog
         {
             _dogStatsd = dogStatsd ?? throw new ArgumentNullException(nameof(dogStatsd));
             _serviceCheckName = serviceCheckName ?? throw new ArgumentNullException(nameof(serviceCheckName));
-            _defaultTags = defaultTags ?? throw new ArgumentNullException(nameof(defaultTags));
+            _defaultTags = defaultTags ?? new string[0];
         }
 
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
@@ -48,7 +48,7 @@ namespace HealthChecks.Publisher.Datadog
                         break;
                 }
 
-                var tags = (_defaultTags ?? new string[0]).Concat(new[]
+                var tags = _defaultTags.Concat(new[]
                 {
                     $"check:{key}"
                 }).ToArray();

--- a/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
@@ -1,0 +1,39 @@
+﻿using HealthChecks.Publisher.Datadog;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StatsdClient;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DatadogHealthCheckBuilderExtensions
+    {
+        /// <summary>
+        /// Add a health check publisher for Datadog.
+        /// </summary>
+        /// <remarks>
+        /// For each <see cref="HealthReport"/> published a custom service check indicating the health check status (OK - Healthy, WARNING - Degraded, CRITICAL - Unhealthy)
+        /// and a metric indicating the total time the health check took to execute on milliseconds is sent to Datadog./>
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to datadog. Example: "myservice.healthchecks".</param>
+        /// <param name="datadogAgentName">Specified Datadog agent server name. Defaults to localhost address 127.0.0.1.</param>
+        /// <param name="defaultTags">Specifies a collection of tags to send with the custom check and metric.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddDatadogPublisher(this IHealthChecksBuilder builder, string serviceCheckName, string datadogAgentName = "127.0.0.1", string[] defaultTags = default)
+        {
+            builder.Services
+                .AddSingleton<IHealthCheckPublisher>(sp =>
+                {
+                    var dogStatsdService = new DogStatsdService();
+
+                    dogStatsdService.Configure(new StatsdConfig
+                    {
+                        StatsdServerName = datadogAgentName
+                    });
+
+                    return new DatadogPublisher(dogStatsdService, serviceCheckName, defaultTags);
+                });
+
+            return builder;
+        }
+    }
+}

--- a/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
+++ b/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetStandardTargetVersion)</TargetFramework>
+    <PackageLicenseUrl>$(PackageLicenseUrl)</PackageLicenseUrl>
+    <PackageProjectUrl>$(PackageProjectUrl)</PackageProjectUrl>
+    <PackageTags>HealthCheck;Publisher;Datadog</PackageTags>
+    <Description>HealthChecks.Publisher.Datadog is the health check publisher for Datadog.</Description>
+    <Version>$(HealthCheckPublisherDatadog)</Version>
+    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
+    <Company>$(Company)</Company>
+    <Authors>$(Authors)</Authors>
+    <PackageId>AspNetCore.HealthChecks.Publisher.Datadog</PackageId>
+    <PublishRepositoryUrl>$(PublishRepositoryUrl)</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
+++ b/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
+    <PackageReference Include="DogStatsD-CSharp-Client" Version="$(DogStatsDCSharpClient)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Implementing #239: Creating a new Datadog publisher package.

The new package uses the official Datadog DogStatsD library: https://github.com/DataDog/dogstatsd-csharp-client.
The recommended Datadog strategy is to send custom metrics to the agent and let the agent handle communication with Datadog APIs.
The assumption here is that the datadog agent is running locally, either as a process or a sidecar container. If that's not the case, agent server name is configurable.