### PR TITLE
Add option to configure Azure Service Token Provider for Key Vault check

### DIFF
--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -28,6 +28,7 @@ namespace HealthChecks.AzureKeyVault
                         await client.GetSecretAsync(_options.KeyVaultUrlBase, item, cancellationToken);
                     }
                 }
+
                 return HealthCheckResult.Healthy();
             }
             catch (Exception ex)
@@ -40,7 +41,7 @@ namespace HealthChecks.AzureKeyVault
         {
             if (_options.UseManagedServiceIdentity)
             {
-                var azureServiceTokenProvider = new AzureServiceTokenProvider(connectionString: _options.TokenProviderConnectionString);
+                var azureServiceTokenProvider = new AzureServiceTokenProvider(_options.TokenProviderOptions.ConnectionString, _options.TokenProviderOptions.AzureAdInstance);
                 return new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
             }
             else
@@ -59,6 +60,7 @@ namespace HealthChecks.AzureKeyVault
             {
                 throw new InvalidOperationException($"[{nameof(AzureKeyVaultHealthCheck)}] - Failed to obtain the JWT token");
             }
+            
             return result.AccessToken;
         }
     }

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -20,6 +20,8 @@ namespace HealthChecks.AzureKeyVault
         internal string ClientId { get; private set; }
         internal string ClientSecret { get; private set; }
         internal bool UseManagedServiceIdentity { get; private set; } = true;
+        internal AzureServiceTokenProviderOptions TokenProviderOptions = new AzureServiceTokenProviderOptions();
+
 
         /// <summary>
         /// Configures remote Azure Key Vault Url service
@@ -38,20 +40,8 @@ namespace HealthChecks.AzureKeyVault
         }
 
         /// <summary>
-        /// Configures the connection string for the Azure Service Token Provider
-        /// </summary>
-        /// <param name="connectionString">The token provider connection string like "RunAs=App;AppId=...".</param>
-        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
-        public AzureKeyVaultOptions UseTokenProviderConnectionString(string connectionString)
-        {
-            TokenProviderConnectionString = connectionString;
-            return this;
-        }
-
-        /// <summary>
         /// Azure key vault connection is performed using provided Client Id and Client Secret.
         /// </summary>
-        /// <param name="keyVaultUrlBase">Azure Key Vault base url - https://[vaultname].vault.azure.net/ </param>
         /// <param name="clientId">Registered application Id</param>
         /// <param name="clientSecret">Registered application secret</param>
         /// <returns><see cref="AzureKeyVaultOptions"/></returns>
@@ -71,12 +61,14 @@ namespace HealthChecks.AzureKeyVault
         /// <summary>
         /// Azure key vault connection is performed using Azure Managed Service Identity.
         /// </summary>
+        /// <param name="setup">Optional action to configure the Azure Service Token Provider.</param>
         /// <returns><see cref="AzureKeyVaultOptions"/></returns>
-        public AzureKeyVaultOptions UseAzureManagedServiceIdentity()
+        public AzureKeyVaultOptions UseAzureManagedServiceIdentity(Action<AzureServiceTokenProviderOptions> setup = null)
         {
             ClientId = string.Empty;
             ClientSecret = string.Empty;
-            UseManagedServiceIdentity = true;
+            UseManagedServiceIdentity = true;            
+            setup?.Invoke(TokenProviderOptions);
             return this;
         }
 

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -16,7 +16,6 @@ namespace HealthChecks.AzureKeyVault
         }
 
         internal string KeyVaultUrlBase { get; private set; }
-        internal string TokenProviderConnectionString { get; private set; }
         internal string ClientId { get; private set; }
         internal string ClientSecret { get; private set; }
         internal bool UseManagedServiceIdentity { get; private set; } = true;

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -16,6 +16,7 @@ namespace HealthChecks.AzureKeyVault
         }
 
         internal string KeyVaultUrlBase { get; private set; }
+        internal string TokenProviderConnectionString { get; private set; }
         internal string ClientId { get; private set; }
         internal string ClientSecret { get; private set; }
         internal bool UseManagedServiceIdentity { get; private set; } = true;
@@ -33,6 +34,17 @@ namespace HealthChecks.AzureKeyVault
             }
 
             KeyVaultUrlBase = keyVaultUrlBase;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the connection string for the Azure Service Token Provider
+        /// </summary>
+        /// <param name="connectionString">The token provider connection string like "RunAs=App;AppId=...".</param>
+        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
+        public AzureKeyVaultOptions UseTokenProviderConnectionString(string connectionString)
+        {
+            TokenProviderConnectionString = connectionString;
             return this;
         }
 

--- a/src/HealthChecks.AzureKeyVault/AzureServiceTokenProviderOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureServiceTokenProviderOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace HealthChecks.AzureKeyVault
 {
@@ -12,16 +13,26 @@ namespace HealthChecks.AzureKeyVault
         internal string AzureAdInstance { get; private set; } = "https://login.microsoftonline.com/";
 
         /// <summary>
-        /// Configures remote Azure Key Vault Url service
+        /// Configures connection string for the Azure Service Token Provider
         /// </summary>
-        /// <param name="keyVaultUrlBase">The azure KeyVault url base like  https://[vaultname].vault.azure.net/ .</param>
+        /// <param name="connectionString">The connection string for the Azure Service Token Provider</param>
         /// <returns><see cref="AzureKeyVaultOptions"/></returns>
         public AzureServiceTokenProviderOptions UseConnectionString(string connectionString)
-        {
+        {            
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }      
+
             ConnectionString = connectionString;
             return this;
         }
 
+        /// <summary>
+        /// Configures the Azure AD instance for the Azure Service Token Provider
+        /// </summary>
+        /// <param name="azureAdInstance">The Azure AD instance for the Azure Service Token Provider</param>
+        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
         public AzureServiceTokenProviderOptions UseAzureAdInstance(string azureAdInstance) 
         {
             if (string.IsNullOrEmpty(azureAdInstance))

--- a/src/HealthChecks.AzureKeyVault/AzureServiceTokenProviderOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureServiceTokenProviderOptions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace HealthChecks.AzureKeyVault
+{
+    /// <summary>
+    /// Azure KeyVault configuration options.
+    /// </summary>
+    public class AzureServiceTokenProviderOptions
+    {
+        internal string ConnectionString { get; private set; }
+        internal string AzureAdInstance { get; private set; } = "https://login.microsoftonline.com/";
+
+        /// <summary>
+        /// Configures remote Azure Key Vault Url service
+        /// </summary>
+        /// <param name="keyVaultUrlBase">The azure KeyVault url base like  https://[vaultname].vault.azure.net/ .</param>
+        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
+        public AzureServiceTokenProviderOptions UseConnectionString(string connectionString)
+        {
+            ConnectionString = connectionString;
+            return this;
+        }
+
+        public AzureServiceTokenProviderOptions UseAzureAdInstance(string azureAdInstance) 
+        {
+            if (string.IsNullOrEmpty(azureAdInstance))
+            {
+                throw new ArgumentNullException(nameof(azureAdInstance));
+            }
+
+            if (!Uri.TryCreate(azureAdInstance, UriKind.Absolute, out var _))
+            {
+                throw new ArgumentException($"azureAdInstance {azureAdInstance} must be a valid Uri");
+            }
+
+            if (!azureAdInstance.ToLower().StartsWith("https"))
+            {
+                throw new ArgumentException($"azureAdInstance {azureAdInstance} is not valid. It must use https.");
+            }
+
+            AzureAdInstance = azureAdInstance;
+            return this;
+        }
+    }
+}

--- a/src/HealthChecks.UI/package-lock.json
+++ b/src/HealthChecks.UI/package-lock.json
@@ -1649,7 +1649,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1670,12 +1671,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1690,17 +1693,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1817,7 +1823,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1829,6 +1836,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1843,6 +1851,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1850,12 +1859,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1874,6 +1885,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1954,7 +1966,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1966,6 +1979,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2051,7 +2065,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2087,6 +2102,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2106,6 +2122,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2149,12 +2166,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/UnitTests/DependencyInjection/AzureKeyVault/AzureKeyVaultUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureKeyVault/AzureKeyVaultUnitTests.cs
@@ -58,19 +58,49 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureKeyVault
         }
 
         [Fact]
-        public void fail_when_invalidad_uri_provided_in_configuration()
+        public void fail_when_invalid_uri_provided_in_configuration()
         {
             var services = new ServiceCollection();
 
             Assert.Throws<ArgumentException>(() =>
             {
                 services.AddHealthChecks()
-                .AddAzureKeyVault(setup =>
-                {
-                    setup
-                    .UseKeyVaultUrl("invalid URI")
-                    .AddSecret("mysecret");
-                });
+                    .AddAzureKeyVault(setup =>
+                    {
+                        setup
+                        .UseKeyVaultUrl("invalid URI")
+                        .AddSecret("mysecret");
+                    });
+            });
+        }
+
+        [Fact]
+        public void fail_when_invalid_AD_instance_uri_provided_for_token_provider() 
+        {
+            var services = new ServiceCollection();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                services.AddHealthChecks()
+                    .AddAzureKeyVault(setup =>
+                    {
+                        setup.UseAzureManagedServiceIdentity(tp => tp.UseAzureAdInstance("invalid URI"));
+                    });
+            });
+        }
+
+        [Fact]
+        public void fail_when_invalid_connection_string_provided_for_token_provider() 
+        {
+            var services = new ServiceCollection();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                services.AddHealthChecks()
+                    .AddAzureKeyVault(setup =>
+                    {
+                        setup.UseAzureManagedServiceIdentity(tp => tp.UseConnectionString("RunAs"));
+                    });
             });
         }
     }


### PR DESCRIPTION
Giving the developer the opportunity to provide connection string and azure AD instance parameters for the Azure Service Token Provider used by the Key Vault Client