### PR TITLE
#251 Enhancements to UI for refresh interval

### DIFF
--- a/samples/HealthChecks.UIAndApi/Startup.cs
+++ b/samples/HealthChecks.UIAndApi/Startup.cs
@@ -74,6 +74,12 @@ namespace HealthChecks.UIAndApi
         {
             app
                 .UseRouting()
+                .UseHealthChecksUI(o =>
+                {
+                    o.ClientOptions.DefaultPollingIntervalSeconds = 5;
+                    o.ClientOptions.MinimumPollingIntervalSeconds = 2;
+                    //o.ClientOptions.HidePollingIntervalControl = true;
+                })
                 .UseEndpoints(config =>
                 {
                     config.MapHealthChecks("healthz", new HealthCheckOptions()

--- a/src/HealthChecks.UI/Configuration/Options.cs
+++ b/src/HealthChecks.UI/Configuration/Options.cs
@@ -15,6 +15,7 @@ namespace HealthChecks.UI.Configuration
         public string ResourcesPath { get; set; } = "/ui/resources";
         public bool UseRelativeResourcesPath = true;
         public bool AsideMenuOpened { get; set; } = true;
+        public ClientOptions ClientOptions { get; set; } = new ClientOptions();
 
         public Options AddCustomStylesheet(string path)
         {
@@ -34,5 +35,12 @@ namespace HealthChecks.UI.Configuration
 
             return this;
         }
+    }
+
+    public class ClientOptions
+    {
+        public int DefaultPollingIntervalSeconds { get; set; } = 10;
+        public int MinimumPollingIntervalSeconds { get; set; } = 1;
+        public bool HidePollingIntervalControl { get; set; }
     }
 }

--- a/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using HealthChecks.UI.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,12 +19,19 @@ namespace HealthChecks.UI.Core
             resource.Content = resource.Content
                 .Replace(Keys.HEALTHCHECKSUI_MAIN_UI_API_TARGET, apiPath);
 
+            var clientOptions = JsonConvert.SerializeObject(options.ClientOptions,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver()
+                });
+
+            resource.Content = resource.Content
+                .Replace(Keys.HEALTHCHECKSUI_CLIENT_OPTIONS_TARGET, clientOptions);
 
             var webhooksPath = options.UseRelativeWebhookPath ? options.WebhookPath.AsRelativeResource() : options.WebhookPath;
 
             resource.Content = resource.Content
                 .Replace(Keys.HEALTHCHECKSUI_WEBHOOKS_API_TARGET, webhooksPath);
-
             
             var resourcePath = options.UseRelativeResourcesPath ? options.ResourcesPath.AsRelativeResource() : options.ResourcesPath;
             

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -14,6 +14,7 @@
         internal const string HEALTHCHECKSUI_MAIN_UI_API_TARGET = "#apiPath#";
         internal const string HEALTHCHECKSUI_WEBHOOKS_API_TARGET = "#webhookPath#";
         internal const string HEALTHCHECKSUI_RESOURCES_TARGET = "#uiResourcePath#";
+        internal const string HEALTHCHECKSUI_CLIENT_OPTIONS_TARGET = "#clientOptions#";
         internal const string HEALTHCHECKSUI_STYLESHEETS_TARGET = "#customstylesheets#";
         internal const string HEALTHCHECKSUI_ASIDEMENUEOPENED_TARGET = "#asideMenuOpened#";
         internal const string DEFAULT_RESPONSE_CONTENT_TYPE = "application/json";

--- a/src/HealthChecks.UI/assets/healthchecksui.css
+++ b/src/HealthChecks.UI/assets/healthchecksui.css
@@ -120,6 +120,15 @@ h4 {
   height: 100%;
 }
 
+.polling-save {
+    margin-left: 0.5em;
+}
+
+.polling-save:not(:disabled) {
+    background-color: #0ca34e;
+    color: white;
+}
+
 .discovery-icon {
   width: 1.25rem;
   min-width: 1.25rem;

--- a/src/HealthChecks.UI/assets/healthchecksui.css
+++ b/src/HealthChecks.UI/assets/healthchecksui.css
@@ -120,15 +120,6 @@ h4 {
   height: 100%;
 }
 
-.polling-save {
-    margin-left: 0.5em;
-}
-
-.polling-save:not(:disabled) {
-    background-color: #0ca34e;
-    color: white;
-}
-
 .discovery-icon {
   width: 1.25rem;
   min-width: 1.25rem;
@@ -347,6 +338,12 @@ h4 {
 .hc-button:hover {
   background-image: var(--bgImageDarken);
 }
+
+    .hc-button:disabled,
+    .hc-button[disabled] {
+        background-color: var(--grayColor);
+        cursor: not-allowed;
+    }
 
 .hc-liveness {
   display: flex;

--- a/src/HealthChecks.UI/assets/index.html
+++ b/src/HealthChecks.UI/assets/index.html
@@ -16,6 +16,7 @@
     <script type="text/javascript">
         var uiEndpoint = "#apiPath#";
         var webhookEndpoint = "#webhookPath#";
+        var clientOptions = #clientOptions#;
         var asideMenuOpened = #asideMenuOpened#;
     </script>
     <script type="text/javascript" src="#uiResourcePath#/vendors-dll.js"></script>

--- a/src/HealthChecks.UI/client/components/LivenessPage.tsx
+++ b/src/HealthChecks.UI/client/components/LivenessPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { HealthChecksClient } from '../healthChecksClient';
+import { PollingInterval, getConfiguredInterval } from "./PollingInterval";
 import moment from 'moment';
 import { Liveness } from '../typings/models';
 import { LivenessTable } from './LivenessTable';
@@ -9,12 +10,9 @@ const CollapseIcon = require('../../assets/svg/collapse.svg');
 const PlusIcon = require('../../assets/svg/plus.svg');
 const MinusIcon = require('../../assets/svg/minus.svg');
 
-const healthChecksIntervalStorageKey = 'healthchecks-ui-polling';
-
 interface LivenessState {
-    error: Nullable<string>;
-    pollingIntervalSetting: string | number;
-    livenessData: Array<Liveness>;
+  error: Nullable<string>;
+  livenessData: Array<Liveness>;
 }
 
 interface LivenessProps {
@@ -22,28 +20,22 @@ interface LivenessProps {
 }
 
 export class LivenessPage extends React.Component<
-    LivenessProps,
-    LivenessState
-    > {
-    private _healthChecksClient: HealthChecksClient;
-    private _lifenessTable: any;
-    constructor(props: LivenessProps) {
-        super(props);
-        this._healthChecksClient = new HealthChecksClient(this.props.endpoint);
-        this.initPolling = this.initPolling.bind(this);
-        this.onPollinIntervalChange = this.onPollinIntervalChange.bind(this);
-        this.expandAll = this.expandAll.bind(this);
-        this.collapseAll = this.collapseAll.bind(this);
+  LivenessProps,
+  LivenessState
+> {
+  private _healthChecksClient: HealthChecksClient;
+  private _lifenessTable: any;
+  constructor(props: LivenessProps) {
+    super(props);
+    this._healthChecksClient = new HealthChecksClient(this.props.endpoint);
+    this.expandAll = this.expandAll.bind(this);
+    this.collapseAll = this.collapseAll.bind(this);
 
-        const pollingIntervalSetting =
-            localStorage.getItem(healthChecksIntervalStorageKey) || 10;
-
-        this.state = {
-            error: '',
-            livenessData: [],
-            pollingIntervalSetting
-        };
-    }
+    this.state = {
+      error: '',
+      livenessData: []
+      };
+  }
 
     componentDidMount() {
         this.load();
@@ -74,38 +66,16 @@ export class LivenessPage extends React.Component<
         }
     }
 
-    initPolling() {
-        localStorage.setItem(
-            healthChecksIntervalStorageKey,
-            this.state.pollingIntervalSetting.toString()
-        );
-        this._healthChecksClient.startPolling(
-            this.configuredInterval(),
-            this.onPollingElapsed.bind(this)
-        );
-    }
+  initPolling = () => this._healthChecksClient.startPolling(getConfiguredInterval() * 1000, this.onPollingElapsed);
 
-    configuredInterval(): string | number {
-        let configuredInterval =
-            localStorage.getItem(healthChecksIntervalStorageKey) ||
-            this.state.pollingIntervalSetting;
-        return (configuredInterval as any) * 1000;
-    }
+  onPollingElapsed = () => {
+    this.setState({ error: '' });
+    this.load();
+  }
 
-    onPollingElapsed() {
-        this.setState({ error: '' });
-        this.load();
-    }
-
-    onPollinIntervalChange(event: any) {
-        this.setState({
-            pollingIntervalSetting: event.target.value
-        });
-    }
-
-    componentWillUnmount() {
-        this._healthChecksClient.stopPolling();
-    }
+  componentWillUnmount() {
+    this._healthChecksClient.stopPolling();
+  }
 
     expandAll(event: any) {
         var tableElement = this._lifenessTable;
@@ -135,45 +105,32 @@ export class LivenessPage extends React.Component<
         );
     }
 
-    render() {
-        return (
-            <article className="hc-liveness">
-                <header className="hc-liveness__header">
-                    <h1>Health Checks status</h1>
-                    <div className="hc-refesh-group">
-                        <span>Refresh every</span>
-                        <input
-                            value={this.state.pollingIntervalSetting}
-                            onChange={this.onPollinIntervalChange}
-                            type="number"
-                            data-oninput="validity.valid && value > 0 ||(value=10)"
-                        />
-                        <span>seconds</span>
-                        <button
-                            onClick={this.initPolling}
-                            type="button"
-                            className="hc-button">
-                            Change
-            </button>
-                    </div>
-                </header>
-                <div className="hc-liveness__container">
-                    <div
-                        className="hc-table-container"
-                        ref={lt => (this._lifenessTable = lt)}>
-                        <LivenessTable
-                            expandAll={this.expandAll}
-                            collapseAll={this.collapseAll}
-                            livenessData={this.state.livenessData}
-                        />
-                        {this.state.error ? (
-                            <div className="w-100 alert alert-danger" role="alert">
-                                {this.state.error}
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-            </article>
-        );
-    }
+  render() {
+    return (
+      <article className="hc-liveness">
+        <header className="hc-liveness__header">
+          <h1>Health Checks status</h1>
+          <div className="hc-refesh-group">
+            <PollingInterval onChange={this.initPolling} />
+          </div>
+        </header>
+        <div className="hc-liveness__container">
+          <div
+            className="hc-table-container"
+            ref={lt => (this._lifenessTable = lt)}>
+            <LivenessTable
+              expandAll={this.expandAll}
+              collapseAll={this.collapseAll}
+              livenessData={this.state.livenessData}
+            />
+            {this.state.error ? (
+              <div className="w-100 alert alert-danger" role="alert">
+                {this.state.error}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </article>
+    );
+  }
 }

--- a/src/HealthChecks.UI/client/components/PollingInterval.tsx
+++ b/src/HealthChecks.UI/client/components/PollingInterval.tsx
@@ -86,14 +86,14 @@ export class PollingInterval extends React.Component<PollingIntervalProps, Polli
                         value={this.state.editing}
                         onChange={this.onPollingIntervalChange}
                         type="number"
-                        className="polling-input"
+                        data-oninput="validity.valid && value > 0 ||(value=10)"
                         title={`Miminum value: ${clientOptions.minimumPollingIntervalSeconds}`}
                     />
                     <label>seconds</label>
                     <button
                         onClick={this.configurePolling}
                         type="button"
-                        className="btn btn-light btn-sm polling-save"
+                        className="hc-button"                        
                         disabled={!this.state.canSave}
                     >Change</button>
                 </>

--- a/src/HealthChecks.UI/client/components/PollingInterval.tsx
+++ b/src/HealthChecks.UI/client/components/PollingInterval.tsx
@@ -1,0 +1,103 @@
+﻿import * as React from "react";
+
+export interface PollingIntervalState {
+    active: number;
+    editing: string;
+    canSave: boolean;
+}
+
+export interface PollingIntervalProps {
+    onChange(): void;
+}
+
+const healthChecksIntervalStorageKey = "healthchecks-ui-polling";
+
+function validateInterval(raw: string | number | null | undefined) {
+    if (raw !== null && raw !== undefined) {
+        const numeric = typeof raw === "number" ? raw : parseInt(raw, 10);
+        if (!isNaN(numeric)) {
+            return {
+                valid: numeric >= clientOptions.minimumPollingIntervalSeconds,
+                normalized: Math.max(numeric, clientOptions.minimumPollingIntervalSeconds)
+            };
+        }
+    }
+
+    return {
+        valid: false,
+        normalized: Math.max(clientOptions.defaultPollingIntervalSeconds,
+            clientOptions.minimumPollingIntervalSeconds)
+    };
+}
+
+export function getConfiguredInterval() {
+    return clientOptions.hidePollingIntervalControl
+        ? clientOptions.defaultPollingIntervalSeconds
+        : validateInterval(localStorage.getItem(healthChecksIntervalStorageKey)).normalized;
+}
+
+export class PollingInterval extends React.Component<PollingIntervalProps, PollingIntervalState> {
+
+    constructor(props: PollingIntervalProps) {
+        super(props);
+
+        const active = getConfiguredInterval();
+
+        this.state = {
+            active,
+            editing: active + "",
+            canSave: false
+        }
+    }
+
+    configurePolling = () => {
+        if (!this.state.canSave) {
+            return;
+        }
+
+        const newInterval = validateInterval(this.state.editing).normalized;
+        const newInput = newInterval + "";
+
+        this.setState({
+            active: newInterval,
+            editing: newInput,
+            canSave: false,
+        })
+
+        localStorage.setItem(healthChecksIntervalStorageKey, newInput);
+        this.props.onChange();
+    }
+
+    onPollingIntervalChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const validation = validateInterval(event.target.value);
+        this.setState({
+            editing: event.target.value,
+            canSave: validation.valid &&
+                validation.normalized !== this.state.active
+        });
+    }
+
+    render() {
+        return (
+            clientOptions.hidePollingIntervalControl ? <div /> : (
+                <>
+                    <label>Refresh every</label>
+                    <input
+                        value={this.state.editing}
+                        onChange={this.onPollingIntervalChange}
+                        type="number"
+                        className="polling-input"
+                        title={`Miminum value: ${clientOptions.minimumPollingIntervalSeconds}`}
+                    />
+                    <label>seconds</label>
+                    <button
+                        onClick={this.configurePolling}
+                        type="button"
+                        className="btn btn-light btn-sm polling-save"
+                        disabled={!this.state.canSave}
+                    >Change</button>
+                </>
+            )
+        );
+    }
+}

--- a/src/HealthChecks.UI/client/healthChecksClient.ts
+++ b/src/HealthChecks.UI/client/healthChecksClient.ts
@@ -16,9 +16,9 @@ export class HealthChecksClient {
         });
     }
 
-    startPolling(interval: string | number, onTimeElapsedCallback: () => void) {
+    startPolling(interval: number, onTimeElapsedCallback: () => void) {
         this.stopPolling();
-        this._pollingInterval = setInterval(onTimeElapsedCallback, interval);
+        this._pollingInterval = window.setInterval(onTimeElapsedCallback, interval);
     }
 
     stopPolling() {

--- a/src/HealthChecks.UI/client/typings/global.d.ts
+++ b/src/HealthChecks.UI/client/typings/global.d.ts
@@ -1,1 +1,9 @@
 type Nullable<T> = T | null;
+
+interface ClientOptions {
+    defaultPollingIntervalSeconds: number;
+    minimumPollingIntervalSeconds: number;
+    hidePollingIntervalControl: boolean;
+}
+
+declare const clientOptions: Readonly<ClientOptions>;


### PR DESCRIPTION
- configuration now includes `ClientOptions`, whole object injected into UI via variable replacement in `index.html`
- separate component `PollingInterval` takes care of appearance and validation for this feature. 'Change' button enables/highlights when there is something valid/different for it to apply, makes it a bit more intuitive.
- `ClientOptions` includes `HidePollingIntervalControl` - if set the polling interval controls don't appear and `DefaultPollingIntervalSeconds` is used.
- using `window.setInterval` avoids type error as TS gets confused between browser and node return types for global `setInterval`