### PR TITLE
Redis, async all the way through

### DIFF
--- a/src/HealthChecks.Redis/RedisHealthCheck.cs
+++ b/src/HealthChecks.Redis/RedisHealthCheck.cs
@@ -17,13 +17,14 @@ namespace HealthChecks.Redis
         {
             _redisConnectionString = redisConnectionString ?? throw new ArgumentNullException(nameof(redisConnectionString));
         }
-        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
                 if (!_connections.TryGetValue(_redisConnectionString, out ConnectionMultiplexer connection))
                 {
-                    connection = ConnectionMultiplexer.Connect(_redisConnectionString);
+                    connection = await ConnectionMultiplexer.ConnectAsync(_redisConnectionString);
 
                     if (!_connections.TryAdd(_redisConnectionString, connection))
                     {
@@ -33,17 +34,15 @@ namespace HealthChecks.Redis
                     }
                 }
 
-                connection.GetDatabase()
-                    .Ping();
+                await connection.GetDatabase()
+                    .PingAsync();
 
-                return Task.FromResult(
-                    HealthCheckResult.Healthy());
-            }
+				return HealthCheckResult.Healthy();
+			}
             catch (Exception ex)
             {
-                return Task.FromResult(
-                    new HealthCheckResult(context.Registration.FailureStatus, exception: ex));
-            }
+				return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+			}
         }
     }
 }


### PR DESCRIPTION
This will avoid the potential thread block from the synchronous Connect & Ping.
Tools like [Ben.BlockingDetector](https://github.com/benaadams/Ben.BlockingDetector) output the following:

```
warn: Ben.Diagnostics.BlockingMonitor[6]
     Blocking method has been invoked and blocked, this can lead to threadpool starvation.
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout)
        at StackExchange.Redis.ConnectionMultiplexer.ConnectImpl(Object configuration, TextWriter log)
        at StackExchange.Redis.ConnectionMultiplexer.Connect(String configuration, TextWriter log)
        at HealthChecks.Redis.RedisHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)
        at Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService.CheckHealthAsync(Func`2 predicate, CancellationToken cancellationToken)
        at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
        at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
        at Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService.CheckHealthAsync(Func`2 predicate, CancellationToken cancellationToken)
        at Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckService.CheckHealthAsync(CancellationToken cancellationToken)
        at ...

```