### PR TITLE
Allow Service Bus health checks to be registered with empty connection strings &/or entity path

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureEventHubHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureEventHubHealthCheck.cs
@@ -15,21 +15,27 @@ namespace HealthChecks.AzureServiceBus
         private readonly string _eventHubConnectionString;
         public AzureEventHubHealthCheck(string connectionString, string eventHubName)
         {
-            if (string.IsNullOrEmpty(connectionString))
+            if (connectionString == null)
             {
                 throw new ArgumentNullException(nameof(connectionString));
             }
-
-            if (string.IsNullOrEmpty(eventHubName))
+            if (eventHubName == null)
             {
                 throw new ArgumentNullException(nameof(eventHubName));
             }
 
-            var builder = new EventHubsConnectionStringBuilder(connectionString)
+            if (connectionString != "" && eventHubName != "")
             {
-                EntityPath = eventHubName
-            };
-            _eventHubConnectionString = builder.ToString();
+                var builder = new EventHubsConnectionStringBuilder(connectionString)
+                {
+                    EntityPath = eventHubName
+                };
+                _eventHubConnectionString = builder.ToString();
+            }
+            else
+            {
+                _eventHubConnectionString = "";
+            }
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -20,16 +20,8 @@ namespace HealthChecks.AzureServiceBus
 
         public AzureServiceBusQueueHealthCheck(string connectionString, string queueName, Action<Message> configuringMessage = null)
         {
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (string.IsNullOrEmpty(queueName))
-            {
-                throw new ArgumentNullException(nameof(queueName));
-            }
-            _connectionString = connectionString;
-            _queueName = queueName;
+            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
             _configuringMessage = configuringMessage;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -20,18 +20,8 @@ namespace HealthChecks.AzureServiceBus
 
         public AzureServiceBusTopicHealthCheck(string connectionString, string topicName, Action<Message> configuringMessage = null)
         {
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-
-            if (string.IsNullOrEmpty(topicName))
-            {
-                throw new ArgumentNullException(nameof(topicName));
-            }
-
-            _connectionString = connectionString;
-            _topicName = topicName;
+            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            _topicName = topicName ?? throw new ArgumentNullException(nameof(topicName));
             _configuringMessage = configuringMessage;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureEventHubUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureEventHubUnitTests.cs
@@ -3,10 +3,10 @@ using HealthChecks.AzureServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.Kernel;
 using Xunit;
 
 namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
@@ -50,7 +50,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
         }
 
         [Fact]
-        public void fail_when_no_health_check_configuration_provided()
+        public void register_succeeded_when_no_health_check_configuration_provided()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
@@ -60,8 +60,29 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();
+            var healthCheck = registration.Factory(serviceProvider);
+            healthCheck.GetType().Should().Be(typeof(AzureEventHubHealthCheck));
+        }
 
-            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        [Theory]
+        [InlineData("", "test", HealthStatus.Degraded)]
+        [InlineData("test", "", HealthStatus.Degraded)]
+        [InlineData("", "", HealthStatus.Unhealthy)]
+        [InlineData("", "", HealthStatus.Healthy)]
+        public async Task empty_string_check_returns_failure_status(string connectionString, string eventHubName, HealthStatus status)
+        {
+            // Arrange
+            var healthCheck = new AzureEventHubHealthCheck(connectionString, eventHubName);
+            var fixture = new Fixture();
+            fixture.Register<IHealthCheck>(() => healthCheck);
+            var context = fixture.Create<HealthCheckContext>();
+            context.Registration.FailureStatus = status;
+
+            // Act
+            var result = await healthCheck.CheckHealthAsync(context);
+
+            // Assert
+            result.Status.Should().Be(status);
         }
     }
 }

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicUnitTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using AutoFixture;
 using Xunit;
 
 namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
@@ -49,7 +51,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
         }
 
         [Fact]
-        public void fail_when_no_health_check_configuration_provided()
+        public void register_succeeded_when_no_health_check_configuration_provided()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
@@ -59,8 +61,29 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();
+            var healthCheck = registration.Factory(serviceProvider);
+            healthCheck.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+        }
 
-            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        [Theory]
+        [InlineData("", "test", HealthStatus.Degraded)]
+        [InlineData("test", "", HealthStatus.Degraded)]
+        [InlineData("", "", HealthStatus.Unhealthy)]
+        [InlineData("", "", HealthStatus.Healthy)]
+        public async Task empty_string_check_returns_failure_status(string connectionString, string topicName, HealthStatus status)
+        {
+            // Arrange
+            var healthCheck = new AzureServiceBusTopicHealthCheck(connectionString, topicName);
+            var fixture = new Fixture();
+            fixture.Register<IHealthCheck>(() => healthCheck);
+            var context = fixture.Create<HealthCheckContext>();
+            context.Registration.FailureStatus = status;
+
+            // Act
+            var result = await healthCheck.CheckHealthAsync(context);
+
+            // Assert
+            result.Status.Should().Be(status);
         }
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />
     <PackageReference Include="xunit" Version="$(xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudio)" />


### PR DESCRIPTION
This PR comes after an issue we have faced where a service was deployed without the connection string for a queue being supplied in the configuration.

When a health check endpoint was being called, the registration for the queue's health check was being run and throwing an exception as the connection string was `""` and the health check's ctor didn't allow this.

This is not what I would expect, I would expect registration to work and the registered health check to run but return that the queue is unhealthy.

I have looked at a few other resources health checks (e.g. SQL Server & Cosmos DB) and they do not check in the ctor for `""`, but only for `null`. So this PR changes the Service Bus behaviour to match that.