### PR TITLE
Use Elasticsearch cluster health for check instead of ping

### DIFF
--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -66,11 +66,9 @@ namespace HealthChecks.Elasticsearch
                         case "yellow":
                             return HealthCheckResult.Degraded();
 
-                        case "red":
+                        default:
                             return HealthCheckResult.Unhealthy();
                     }
-
-                    return HealthCheckResult.Unhealthy();
                 }
                 else
                 {

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -48,12 +48,26 @@ namespace HealthChecks.Elasticsearch
                     }
                 }
 
-                var pingResult = await lowLevelClient.PingAsync(ct: cancellationToken);
-                var isSuccess = pingResult.ApiCall.HttpStatusCode == 200;
+                var healthResult = await lowLevelClient.Cluster.HealthAsync(ct: cancellationToken);
 
-                return isSuccess
-                    ? HealthCheckResult.Healthy()
-                    : new HealthCheckResult(context.Registration.FailureStatus);
+                if (healthResult.ApiCall.HttpStatusCode != 200)
+                {
+                    return new HealthCheckResult(context.Registration.FailureStatus);
+                }
+
+                switch (healthResult.Status.ToString())
+                {
+                    case "green":
+                        return HealthCheckResult.Healthy();
+
+                    case "yellow":
+                        return HealthCheckResult.Degraded();
+
+                    case "red":
+                        return HealthCheckResult.Unhealthy();
+                }
+
+                return HealthCheckResult.Unhealthy();
             }
             catch (Exception ex)
             {

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -60,10 +60,10 @@ namespace HealthChecks.Elasticsearch
 
                     switch (healthResult.Status.ToString())
                     {
-                        case "green":
+                        case "Green":
                             return HealthCheckResult.Healthy();
 
-                        case "yellow":
+                        case "Yellow":
                             return HealthCheckResult.Degraded();
 
                         default:

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -12,6 +12,7 @@ namespace HealthChecks.Elasticsearch
         public X509Certificate Certificate { get; private set; }
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
+        public bool CheckClusterHealth { get; private set; } = false;
         public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {
@@ -42,6 +43,11 @@ namespace HealthChecks.Elasticsearch
         public ElasticsearchOptions UseCertificateValidationCallback(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> callback)
         {
             CertificateValidationCallback = callback;
+            return this;
+        }
+        public ElasticsearchOptions UseClusterHealth()
+        {
+            CheckClusterHealth = true;
             return this;
         }
     }

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -12,7 +12,7 @@ namespace HealthChecks.Elasticsearch
         public X509Certificate Certificate { get; private set; }
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
-        public bool CheckClusterHealth { get; private set; } = false;
+        public bool CheckClusterHealth { get; private set; }
         public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {

--- a/test/FunctionalTests/HealthCheck.Elasticsearch/ElasticsearchHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Elasticsearch/ElasticsearchHealthCheckTests.cs
@@ -3,6 +3,7 @@ using FunctionalTests.Base;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -76,6 +77,120 @@ namespace FunctionalTests.HealthChecks.Elasticsearch
 
             response.StatusCode
                 .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_unhealthy_if_elasticsearch_cluster_health_status_is_red()
+        {
+            await RunWithMockElasticsearch("red", async server =>
+            {
+                var response = await server.CreateRequest("/health").GetAsync();
+
+                var body = await response.Content.ReadAsStringAsync();
+
+                response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+                body.Should().Be("Unhealthy");
+            });
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_healthy_if_elasticsearch_cluster_health_status_is_green()
+        {
+            await RunWithMockElasticsearch("green", async server =>
+            {
+                var response = await server.CreateRequest("/health").GetAsync();
+
+                var body = await response.Content.ReadAsStringAsync();
+
+                body.Should().Be("Healthy");
+
+                response.StatusCode.Should().Be(HttpStatusCode.OK);
+            });
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_degraded_if_elasticsearch_cluster_health_status_is_yellow()
+        {
+            await RunWithMockElasticsearch("yellow", async server =>
+            {
+                var response = await server.CreateRequest("/health").GetAsync();
+
+                var body = await response.Content.ReadAsStringAsync();
+
+                body.Should().Be("Degraded");
+
+                response.StatusCode.Should().Be(HttpStatusCode.OK);
+            });
+        }
+
+        private async Task RunWithMockElasticsearch(string clusterStatus, Func<TestServer, Task> action)
+        {
+            string clusterHealthJsonResponse = @"{{
+  ""cluster_name"" : ""docker-cluster"",
+  ""status"" : ""{0}"",
+  ""timed_out"" : false,
+  ""number_of_nodes"" : 1,
+  ""number_of_data_nodes"" : 1,
+  ""active_primary_shards"" : 12,
+  ""active_shards"" : 12,
+  ""relocating_shards"" : 0,
+  ""initializing_shards"" : 0,
+  ""unassigned_shards"" : 0,
+  ""delayed_unassigned_shards"" : 0,
+  ""number_of_pending_tasks"" : 0,
+  ""number_of_in_flight_fetch"" : 0,
+  ""task_max_waiting_in_queue_millis"" : 0,
+  ""active_shards_percent_as_number"" : 100.00
+}}";
+            var port = new Random().Next(19200, 19299);
+
+            var elasticsearchUrl = $"http://localhost:{port}";
+
+            var elasticsearchHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .UseKestrel()
+                .UseUrls(elasticsearchUrl)
+                .Configure(app =>
+                {
+                    var response = string.Format(clusterHealthJsonResponse, clusterStatus);
+                    app.Map("/_cluster/health", c => c.Run(async ctx =>
+                    {
+                        ctx.Response.StatusCode = (int)HttpStatusCode.OK; // Elasticsearch always return 200 OK for this API
+                        ctx.Response.ContentType = "application/json";
+                        await ctx.Response.WriteAsync(response);
+                    }));
+                });
+
+            using (var elastichsearchHost = elasticsearchHostBuilder.Build())
+            {
+                await elastichsearchHost.StartAsync();
+
+                var webHostBuilder = new WebHostBuilder()
+                    .UseStartup<DefaultStartup>()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddHealthChecks()
+                            .AddElasticsearch(setup =>
+                            {
+                                setup.UseServer(elasticsearchUrl)
+                                    .UseClusterHealth();
+                            }, tags: new string[] { "elasticsearch" });
+                    })
+                    .Configure(app =>
+                               app.UseHealthChecks("/health", new HealthCheckOptions()
+                               {
+                                   Predicate = r => r.Tags.Contains("elasticsearch")
+                               }));
+
+                using (var server = new TestServer(webHostBuilder))
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(3));
+                    await action(server);
+                }
+
+                await elastichsearchHost.StopAsync();
+            }
         }
     }
 }

--- a/test/FunctionalTests/HealthCheck.Elasticsearch/ElasticsearchHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Elasticsearch/ElasticsearchHealthCheckTests.cs
@@ -185,7 +185,6 @@ namespace FunctionalTests.HealthChecks.Elasticsearch
 
                 using (var server = new TestServer(webHostBuilder))
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(3));
                     await action(server);
                 }
 


### PR DESCRIPTION
As stated in #287, using ping will only allow returning healthy or unhealthy statuses. By using
[Elasticsearch Cluster Health API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html) we can also return degraded if the cluster is in the yellow state.

While implementing this I realized that for some use cases users won't need to check for degraded, so to keep backwards dependency I've added a new option method `ElasticsearchOptions` to enable using cluster health check:

```csharp
var options = new ElasticsearchOptions()
    .UseClusterHealth();
```

By default, it will use the original ping check.