### PR TITLE
Get Database Name from  connection string url

### DIFF
--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -16,6 +16,10 @@ namespace HealthChecks.MongoDb
         public MongoDbHealthCheck(string connectionString, string databaseName = default)
             : this(MongoClientSettings.FromUrl(MongoUrl.Create(connectionString)), databaseName)
         {
+            if (databaseName == default)
+            {
+                _specifiedDatabase = MongoUrl.Create(connectionString)?.DatabaseName; 
+            }
         }
         public MongoDbHealthCheck(MongoClientSettings clientSettings, string databaseName = default)
         {


### PR DESCRIPTION
On` AddMongoDb` if the connection string is in the following format:
```json
mongodb://{UserName}:{Password}@{ServerName}:{ServerPort}/{DatabaseName}?readPreference=primary
```
using the extention passing only  the connection string (like the other providers)
```csharp
 services.AddHealthChecks()
                .AddMongoDb(Configuration["mongoDbConnectionString"] )
                .AddSqlServer(Configuration["DbConnectionString"])
                .AddAzureBlobStorage(Configuration["StorageConnectionStringName"])
                .AddAzureServiceBusQueue(Configuration["BusConnectionString"],
                    Configuration["QueueName"]);
```
cause an unhealthy status, because the databaseName is null  so it's try to read all the databases  and the user dosn't have the privilegis:

```json
{"status":"Unhealthy","totalDuration":"00:00:01.3118507","entries":{"mongodb":{"data":{},"description":"Command listDatabases failed: not authorized on admin to execute command { listDatabases: 1, $db: \"admin\", $readPreference: { mode: \"primary\" },
```
Adding this  code on the costructror  we can avoid the error:

```csharp
  public MongoDbHealthCheck(string connectionString, string databaseName = default)
            : this(MongoClientSettings.FromUrl(MongoUrl.Create(connectionString)), databaseName)
        {
            if (databaseName == default)
            {
                _specifiedDatabase = MongoUrl.Create(connectionString)?.DatabaseName; 
            }
        }
```
if the `MongoUrl.Create(connectionString)?.DatabaseName; ` is null  the behaviour  remain the same 
