### PR TITLE
Removing exception handling

### DIFF
--- a/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
+++ b/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
@@ -18,24 +18,17 @@ namespace HealthChecks.SqlServer
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            try
+            using (var connection = new SqlConnection(_connectionString))
             {
-                using (var connection = new SqlConnection(_connectionString))
+                await connection.OpenAsync(cancellationToken);
+
+                using (var command = connection.CreateCommand())
                 {
-                    await connection.OpenAsync(cancellationToken);
-
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText = _sql;
-                        await command.ExecuteScalarAsync(cancellationToken);
-                    }
-
-                    return HealthCheckResult.Healthy();
+                    command.CommandText = _sql;
+                    await command.ExecuteScalarAsync(cancellationToken);
                 }
-            }
-            catch (Exception ex)
-            {
-                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+
+                return HealthCheckResult.Healthy();
             }
         }
     }


### PR DESCRIPTION
Exception returned by CheckHealthAsync in HealthCheckResult is not logged by DefaultHealthCheckService. It is perfectly fine for CheckHealthAsync to throw exception. It results in HealthCheckResult.Unhealthy and exception is logged too
 
For more information check:
https://github.com/aspnet/Extensions/blob/1dfe8bc2af511822677789c29a0c800f7cca1d7b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs#L137