### PR TITLE
Track exceptions in Application Insights publisher

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -30,6 +30,7 @@ namespace HealthChecks.Publisher.ApplicationInsights
             _instrumentationKey = instrumentationKey;
             _saveDetailedReport = saveDetailedReport;
             _excludeHealthyReports = excludeHealthyReports;
+            _trackExceptions = trackExceptions;
         }
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace HealthChecks.Publisher.ApplicationInsights
 {
-    class ApplicationInsightsPublisher
+    public class ApplicationInsightsPublisher
         : IHealthCheckPublisher
     {
         const string EVENT_NAME = "AspNetCoreHealthCheck";

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HealthCheck</c></param>
         /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false)
+        public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false, bool trackExceptions = true)
         {
             builder.Services
                .AddSingleton<IHealthCheckPublisher>(sp =>
                {
-                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport, excludeHealthyReports);
+                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport, excludeHealthyReports, trackExceptions);
                });
 
             return builder;

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="instrumentationKey">Specified Application Insights instrumentation key. Optional. If <c>null</c> TelemetryConfiguration.Active is used.</param>
         /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional: If <c>true</c> saves an Application Insights event for each HealthCheck</c></param>
         /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status</param>
+        /// <param name="trackExceptions">Specifies if save an Application Insights exception report for each HealthCheck that contains an exception. Optional: If <c>true</c> saves an Application Insights exception report.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddApplicationInsightsPublisher(this IHealthChecksBuilder builder, string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false, bool trackExceptions = true)
         {

--- a/test/UnitTests/DependencyInjection/Publisher.ApplicationInsights/Publisher.ApplicationInsightsUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/Publisher.ApplicationInsights/Publisher.ApplicationInsightsUnitTests.cs
@@ -1,0 +1,23 @@
+﻿using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace UnitTests.DependencyInjection.Publisher.ApplicationInsights
+{
+    public class application_insights_publisher_registration_should
+    {
+        [Fact]
+        public void add_publisher_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddApplicationInsightsPublisher();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
+
+            Assert.IsType<ApplicationInsightsPublisher>(publisher);
+        }
+    }
+}

--- a/test/UnitTests/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisherTests.cs
+++ b/test/UnitTests/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisherTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests.HealthChecks.Publisher.ApplicationInsights
+{
+    public class application_insights_publisher_should
+    {
+        private ApplicationInsightsPublisher publisher;
+        private readonly HealthReport report;
+        private readonly CancellationToken cancellationToken = CancellationToken.None;
+        private readonly FakeTelemetryChannel telemetryChannel;
+        private ITestOutputHelper testOutputHelper;
+
+        public application_insights_publisher_should(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+
+            telemetryChannel = new FakeTelemetryChannel();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            TelemetryConfiguration.Active.TelemetryChannel = telemetryChannel;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Dictionary<string, HealthReportEntry> entries = new Dictionary<string, HealthReportEntry>();
+
+            var properties = new Dictionary<string, object>
+            {
+                { "foo", "bar" }
+            };
+
+            entries.Add("healthy", new HealthReportEntry(HealthStatus.Healthy, "healthy", TimeSpan.FromMilliseconds(25), exception: null, data: properties));
+            entries.Add("unhealthy", new HealthReportEntry(HealthStatus.Unhealthy, "unhealthy", TimeSpan.FromMilliseconds(25), exception: new ArgumentNullException(), data: properties));
+            entries.Add("degraded", new HealthReportEntry(HealthStatus.Degraded, "degraded", TimeSpan.FromMilliseconds(25), exception: null, data: properties));
+            entries.Add("degraded_with_exception", new HealthReportEntry(HealthStatus.Degraded, "degraded with exception", TimeSpan.FromMilliseconds(25), exception: new NullReferenceException(), data: properties));
+
+            report = new HealthReport(entries, TimeSpan.FromMilliseconds(100));
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task track_exceptions_by_default(bool saveDetailedReport, bool excludeHealthyReports)
+        {
+            // Arrange
+            publisher = new ApplicationInsightsPublisher(string.Empty, saveDetailedReport, excludeHealthyReports);
+
+            // Act
+            await publisher.PublishAsync(report, cancellationToken);
+
+            // Assert
+            var itemsWithException = telemetryChannel.Items.Where(i => i is ExceptionTelemetry);
+            Assert.Equal(2, itemsWithException.Count());
+
+            foreach (var item in itemsWithException.Select(i => i as ExceptionTelemetry))
+            {
+                // Assert properties
+                Assert.True(item.Properties.TryGetValue("AspNetCoreHealthCheckName", out string name));
+                Assert.Equal(Environment.MachineName, item.Properties[nameof(Environment.MachineName)]);
+                Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, item.Properties[nameof(Assembly)]);
+
+                // Assert metrics
+                Assert.Equal(0, item.Metrics["AspNetCoreHealthCheckStatus"]);
+                Assert.Equal(25, item.Metrics["AspNetCoreHealthCheckDuration"]);
+
+                // Assert proper exception is reported based on name
+                switch (name)
+                {
+                    case "unhealthy":
+                        Assert.IsType<ArgumentNullException>(item.Exception);
+                        break;
+
+                    case "degraded_with_exception":
+                        Assert.IsType<NullReferenceException>(item.Exception);
+                        break;
+
+                    default:
+                        throw new Exception($"Unrecognized AspNetCoreHealthCheckName: {name}");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task dont_track_exceptions_if_parameter_is_false(bool saveDetailedReport, bool excludeHealthyReports)
+        {
+            // Arrange
+            publisher = new ApplicationInsightsPublisher(string.Empty, saveDetailedReport, excludeHealthyReports, trackExceptions: false);
+
+            // Act
+            await publisher.PublishAsync(report, cancellationToken);
+
+            // Assert
+            var itemsWithException = telemetryChannel.Items.Where(i => i is ExceptionTelemetry);
+            Assert.Empty(itemsWithException);
+        }
+
+        private class FakeTelemetryChannel : ITelemetryChannel
+        {
+            public List<ITelemetry> Items { get; set; } = new List<ITelemetry>();
+
+            public void Send(ITelemetry item) => Items.Add(item);
+
+            // These are not used for testing purposes, so they are left as not implemented methods.
+            // The only one that is used is get DeveloperMode, which is set to a sane default.
+
+            public bool? DeveloperMode { get => true; set => throw new NotImplementedException(); }
+            public string EndpointAddress { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public void Dispose() => throw new NotImplementedException();
+            public void Flush() => throw new NotImplementedException();
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertions)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjection)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJson)" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>    
@@ -42,6 +43,7 @@
     <ProjectReference Include="..\..\src\HealthChecks.System\HealthChecks.System.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI\HealthChecks.UI.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.Uris\HealthChecks.Uris.csproj" />
+    <ProjectReference Include="..\..\src\HealthChecks.Publisher.ApplicationInsights\HealthChecks.Publisher.ApplicationInsights.csproj" />
   </ItemGroup>
  
   <ItemGroup>


### PR DESCRIPTION
This PR implements exception tracking on App Insights as described in #299. 

My initial reaction was to add this only in the detailed report, but then I realized that I wanted to have the exceptions tracked, regardless of whether it's a detailed or summarized report.

While working on this I also found that it could be possible to refactor the code to be more DRY (e.g. creating the properties dictionary could be extracted to a method), and also that by using a mock `TelemetryChannel` tests could be added for this publisher. I didn't include those changes because I think they're out of the scope of this PR description.