### PR TITLE
Add ability to re-use single RabbitMQ Connection

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -83,7 +83,7 @@
     <HealthCheckSqlite>3.0.0</HealthCheckSqlite>
     <HealthCheckUri>3.0.0</HealthCheckUri>
     <HealthCheckRedis>3.0.0</HealthCheckRedis>
-    <HealthCheckRabbitMQ>3.0.0</HealthCheckRabbitMQ>
+    <HealthCheckRabbitMQ>3.1.0</HealthCheckRabbitMQ>
     <HealthCheckEventStore>3.0.0</HealthCheckEventStore>
     <HealthCheckElasticsearch>3.0.0</HealthCheckElasticsearch>
     <HealthCheckOracle>3.0.0</HealthCheckOracle>

--- a/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
         const string NAME = "rabbitmq";
 
         /// <summary>
-        /// Add a health check for RabbitMQ services.
+        /// Add a health check for RabbitMQ services using connection string (amqp uri).
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="rabbitMQConnectionString">The RabbitMQ connection string to be used.</param>
@@ -29,6 +29,93 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
                 sp => new RabbitMQHealthCheck(rabbitMQConnectionString, sslOption),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for RabbitMQ services using <see cref="IConnection"/> from service provider 
+        /// or <see cref="IConnectionFactory"/> from service provider if none is found. At least one must be configured.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddRabbitMQ(this IHealthChecksBuilder builder, string name = default, 
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => {
+                    var connection = sp.GetService<IConnection>();
+                    var connectionFactory = sp.GetService<IConnectionFactory>();
+                    if (connection != null)
+                    {
+                        return new RabbitMQHealthCheck(connection);
+                    }
+                    else if(connectionFactory != null)
+                    {
+                        return new RabbitMQHealthCheck(connectionFactory);
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Either an IConnection or IConnectionFactory must be registered with the service provider");
+                    }
+                },
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for RabbitMQ services using <see cref="IConnection"/> factory function
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionFactory"> A factory function to provide the rabbitMQ connection </param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddRabbitMQ(this IHealthChecksBuilder builder, Func<IServiceProvider, IConnection> connectionFactory, 
+            string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new RabbitMQHealthCheck(connectionFactory(sp)),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for RabbitMQ services using <see cref="IConnectionFactory"/> factory function
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionFactoryFactory"> A factory function to provide the rabbitMQ connection factory</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddRabbitMQ(this IHealthChecksBuilder builder, Func<IServiceProvider, IConnectionFactory> connectionFactoryFactory, 
+            string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new RabbitMQHealthCheck(connectionFactoryFactory(sp)),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.RabbitMQ/README.md
+++ b/src/HealthChecks.RabbitMQ/README.md
@@ -1,0 +1,130 @@
+# RabbitMQ Health Check
+
+This health check verifies the ability to communicate with a RabbitMQ server
+
+## Example Usage
+
+With all of the following examples, you can additionally add the following parameters:
+
+- `name`: The health check name. Default if not specified is `rabbitmq`.
+- `failureStatus`: The `HealthStatus` that should be reported when the health check fails. Default is `HealthStatus.Unhealthy`.
+- `tags`: A list of tags that can be used to filter sets of health checks.
+- `timeout`: A `System.TimeSpan` representing the timeout of the check.
+
+### Basic
+
+This will create a new `IConnectionFactory` and `IConnection` on every request to get the health check result. Use
+the extension method where you provide the `Uri` to connect with. You can optionally set the `SslOption` if needed.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    services
+        .AddHealthChecks()
+        .AddRabbitMQ("amqps://user:pass@host/vhost");
+}
+```
+
+### Dependency Injected `IConnection`
+
+As per [RabbitMQ docs](https://www.rabbitmq.com/connections.html) and its suggestions on
+[high connectivity churn](https://www.rabbitmq.com/networking.html#dealing-with-high-connection-churn), connections are meant to be long lived.
+Ideally, this should be configured as a singleton.
+If you are sharing a single connection for every time a health check is requested,
+you must ensure automatic recovery is enable so that the connection can be re-established if lost.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    var factory = new ConnectionFactory()
+    {
+        Uri = new Uri("amqps://user:pass@host/vhost"),
+        AutomaticRecoveryEnabled = true
+    };
+
+    var connection = factory.CreateConnection();
+
+    services
+        .AddSingleton<IConnection>(connection)
+        .AddHealthChecks()
+        .AddRabbitMQ();
+}
+```
+
+Alternatively, you can specify the connection to use with a factory function given the `IServiceProvider`.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    var factory = new ConnectionFactory()
+    {
+        Uri = new Uri("amqps://user:pass@host/vhost"),
+        AutomaticRecoveryEnabled = true
+    };
+
+    var connection = factory.CreateConnection();
+
+    services
+        .AddHealthChecks()
+        .AddRabbitMQ(sp => connection);
+}
+```
+
+### Dependency Injected `IConnectionFactory`
+
+This is similar to injecting the `IConnection`, but the default implementation of `IConnectionFactory`
+does not solve the high churn of connections issue.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    var factory = new ConnectionFactory()
+    {
+        Uri = new Uri("amqps://user:pass@host/vhost")
+    };
+
+    services
+        .AddSingleton<IConnectionFactory>(factory)
+        .AddHealthChecks()
+        .AddRabbitMQ();
+}
+```
+
+Alternatively, you can specify the connection factory to use with a factory function given the `IServiceProvider`.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    var factory = new ConnectionFactory()
+    {
+        Uri = new Uri("amqps://user:pass@host/vhost"),
+        AutomaticRecoveryEnabled = true
+    };
+
+    services
+        .AddHealthChecks()
+        .AddRabbitMQ(sp => factory);
+}
+```
+
+### Without Conveniece Extension Method
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    var factory = new ConnectionFactory()
+    {
+        Uri = new Uri("amqps://user:pass@host/vhost"),
+        AutomaticRecoveryEnabled = true
+    };
+
+    services
+        .AddHealthChecks()
+        .Add(new HealthCheckRegistration(
+            "rabbitmq",
+            sp => new RabbitMQHealthCheck(rabbitMQConnectionString, sslOption),
+            HealthStatus.Unhealthy,
+            tags: null,
+            timeout: null))
+}
+```

--- a/src/HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
@@ -10,26 +10,45 @@ namespace HealthChecks.RabbitMQ
     public class RabbitMQHealthCheck
         : IHealthCheck
     {
-        private readonly string _rabbitMqConnectionString;
+        private readonly Lazy<IConnectionFactory> _lazyConnectionFactory;
+        private readonly IConnection _rmqConnection;
         private readonly SslOption _sslOption;
+
         public RabbitMQHealthCheck(string rabbitMqConnectionString, SslOption sslOption = null)
         {
-            _rabbitMqConnectionString = rabbitMqConnectionString ?? throw new ArgumentNullException(nameof(rabbitMqConnectionString));
+            if (rabbitMqConnectionString == null) throw new ArgumentNullException(nameof(rabbitMqConnectionString));
+
+            _lazyConnectionFactory = new Lazy<IConnectionFactory>(() => new ConnectionFactory()
+            {
+                Uri = new Uri(rabbitMqConnectionString)
+            });
+
             _sslOption = sslOption ?? new SslOption(serverName: "localhost", enabled: false);
         }
+
+        public RabbitMQHealthCheck(IConnection connection)
+        {
+            _rmqConnection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
+
+        public RabbitMQHealthCheck(IConnectionFactory connectionFactory)
+        {
+            _lazyConnectionFactory = new Lazy<IConnectionFactory>(() => 
+                connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory)));
+        }
+
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var factory = new ConnectionFactory()
+                if (_rmqConnection != null)
                 {
-                    Uri = new Uri(_rabbitMqConnectionString)
-                };
-                using (var connection = CreateConnection(factory, _sslOption))
-                using (var channel = connection.CreateModel())
+                    return TestConnection(_rmqConnection);
+                }
+
+                using (var connection = CreateConnection(_lazyConnectionFactory.Value, _sslOption))
                 {
-                    return Task.FromResult(
-                        HealthCheckResult.Healthy());
+                    return TestConnection(connection);
                 }
             }
             catch (Exception ex)
@@ -38,6 +57,16 @@ namespace HealthChecks.RabbitMQ
                     new HealthCheckResult(context.Registration.FailureStatus, exception: ex));
             }
         }
+
+        private static Task<HealthCheckResult> TestConnection(IConnection connection)
+        {
+            using (var channel = connection.CreateModel())
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy());
+            }
+        }
+
         private static IConnection CreateConnection(IConnectionFactory connectionFactory, SslOption sslOption)
         {
             return connectionFactory.CreateConnection(new List<AmqpTcpEndpoint> { new AmqpTcpEndpoint(connectionFactory.Uri, sslOption) });

--- a/test/UnitTests/DependencyInjection/RabbitMQ/RabbitMQUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/RabbitMQ/RabbitMQUnitTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.RabbitMQ
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddRabbitMQ("connectionstring");
+                .AddRabbitMQ(rabbitMQConnectionString: "connectionstring");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();


### PR DESCRIPTION
* Addresses https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/304
* Add many configuration options that support ability to re-use a single
connection with multiple multiplexed channels.
* Add documentation around this health check to help others follow
RabbitMQ best practices