### PR TITLE
[Docker Image] Custom branding stylesheet and Paths environment variables

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -100,7 +100,7 @@
     <HealthCheckHangfire>3.0.0</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
-    <HealthCheckUI>3.0.2</HealthCheckUI>
+    <HealthCheckUI>3.0.3</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.1</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.Image.Configuration
+{
+    public class UIKeys
+    {
+        public const string UI_STYLESHEET = "ui_stylesheet";
+        public const string UI_API_PATH = "ui_api_path";
+        public const string UI_PATH = "ui_path";
+        public const string UI_RESOURCES_PATH = "ui_resources_path";
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
@@ -11,5 +11,6 @@ namespace HealthChecks.UI.Image.Configuration
         public const string UI_API_PATH = "ui_api_path";
         public const string UI_PATH = "ui_path";
         public const string UI_RESOURCES_PATH = "ui_resources_path";
+        public const string UI_WEBHOOKS_PATH = "ui_webhooks_path";
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/IEndpointRouteBuilderExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/IEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿using HealthChecks.UI.Image.Configuration;
+using HealthChecks.UI.Image.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static  class IEndpointRouteBuilderExtensions
+    {
+        public static IEndpointConventionBuilder MapDockerHealthchecksUI(this IEndpointRouteBuilder builder, IConfiguration configuration)
+       {
+            return builder.MapHealthChecksUI(setup =>
+            {
+                setup.ConfigureStylesheet(configuration);
+                setup.ConfigurePaths(configuration);
+            });
+        }
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/IEndpointRouteBuilderExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/IEndpointRouteBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class IEndpointRouteBuilderExtensions
     {
-        public static IEndpointConventionBuilder MapDockerHealthchecksUI(this IEndpointRouteBuilder builder, IConfiguration configuration)
+        public static IEndpointConventionBuilder MapHealthChecksUI(this IEndpointRouteBuilder builder, IConfiguration configuration)
        {
             return builder.MapHealthChecksUI(setup =>
             {

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
@@ -1,0 +1,33 @@
+﻿using HealthChecks.UI.Configuration;
+using HealthChecks.UI.Image.Configuration;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.Image.Extensions
+{
+    public static class OptionsExtensions
+    {
+        public static void ConfigureStylesheet(this Options options, IConfiguration configuration)
+        {
+            var uiStylesheet = configuration[UIKeys.UI_STYLESHEET];
+
+            if (!string.IsNullOrEmpty(uiStylesheet))
+            {
+                options.AddCustomStylesheet(uiStylesheet);
+            }
+        }
+        public static void ConfigurePaths(this Options options, IConfiguration configuration)
+        {
+            var uiPath = configuration[UIKeys.UI_PATH];
+            var apiPath = configuration[UIKeys.UI_API_PATH];
+            var resourcesPath = configuration[UIKeys.UI_RESOURCES_PATH];
+
+            if (!string.IsNullOrEmpty(uiPath)) options.UIPath = uiPath;
+            if (!string.IsNullOrEmpty(apiPath)) options.ApiPath = apiPath;
+            if (!string.IsNullOrEmpty(resourcesPath)) options.ResourcesPath = resourcesPath;
+        }
+    }
+}

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
@@ -24,10 +24,12 @@ namespace HealthChecks.UI.Image.Extensions
             var uiPath = configuration[UIKeys.UI_PATH];
             var apiPath = configuration[UIKeys.UI_API_PATH];
             var resourcesPath = configuration[UIKeys.UI_RESOURCES_PATH];
+            var webhooksPath = configuration[UIKeys.UI_WEBHOOKS_PATH];
 
             if (!string.IsNullOrEmpty(uiPath)) options.UIPath = uiPath;
             if (!string.IsNullOrEmpty(apiPath)) options.ApiPath = apiPath;
             if (!string.IsNullOrEmpty(resourcesPath)) options.ResourcesPath = resourcesPath;
+            if (!string.IsNullOrEmpty(webhooksPath)) options.WebhookPath = webhooksPath;
         }
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Startup.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Startup.cs
@@ -28,7 +28,7 @@ namespace HealthChecks.UI.Image
             app.UseRouting()
                 .UseEndpoints(config =>
                 {
-                    config.MapDockerHealthchecksUI(Configuration);
+                    config.MapHealthChecksUI(Configuration);
                     config.MapDefaultControllerRoute();
                 });
         }

--- a/build/docker-images/HealthChecks.UI.Image/Startup.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using HealthChecks.UI.Image.Configuration;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +28,7 @@ namespace HealthChecks.UI.Image
             app.UseRouting()
                 .UseEndpoints(config =>
                 {
-                    config.MapHealthChecksUI();
+                    config.MapDockerHealthchecksUI(Configuration);
                     config.MapDefaultControllerRoute();
                 });
         }

--- a/doc/ui-docker.md
+++ b/doc/ui-docker.md
@@ -13,6 +13,28 @@ You can use environment variables to configure all properties on *HealthChecksUI
 docker run --name ui -p 5000:80 -e 'HealthChecksUI:HealthChecks:0:Name=httpBasic' -e 'HealthChecksUI:HealthChecks:0:Uri=http://the-healthchecks-server-path' -d xabarilcoding/healthchecksui:latest
 ```
 
+## Use a custom css stylesheet for branding
+
+Since version 3.0.3 you can use an environment variable and a volume to configure your own css stylesheet and display your own branding within the UI:
+
+```bash
+docker run -v /c/temp/css:/app/css -e ui_stylesheet=/app/css/dotnet.css -p 5000:80 xabarilcoding/healthchecksui:latest
+```
+
+## Configure UI paths (UI path, Api path and resources path)
+Since version 3.0.3 you can use environment variables to configure the different paths where resources are served.
+
+The environment variables are:
+
+- **ui_path** to configure the frontend spa segment
+- **ui_api_path** to configure the path where the api middleware will be served
+- **ui_resources_path** to configure the path where static files will be server
+
+
+```bash
+docker run -e ui_path=/healthchecks-e ui_resources_path=/static -e ui_api_path=/health-api -p 5000:80 xabarilcoding/healthchecksui:latest
+```
+
 ## Azure App Configuration Service
 
 Since version 2.2.32, our docker image supports configuration by using Azure App Configuration service.

--- a/doc/ui-docker.md
+++ b/doc/ui-docker.md
@@ -28,7 +28,8 @@ The environment variables are:
 
 - **ui_path** to configure the frontend spa segment
 - **ui_api_path** to configure the path where the api middleware will be served
-- **ui_resources_path** to configure the path where static files will be server
+- **ui_webhooks_path** to configure the path where the webhooks middleware will be served
+- **ui_resources_path** to configure the path where static files will be served
 
 
 ```bash


### PR DESCRIPTION
With version 3.0.3 the UI can be configured to use a custom css stylesheet for branding using a volume and an environment variable and it can also receive different env vars to configure ui, api an resources paths