### PR TITLE
AsideMenuOpened feature

### DIFF
--- a/src/HealthChecks.UI/Configuration/Options.cs
+++ b/src/HealthChecks.UI/Configuration/Options.cs
@@ -15,6 +15,7 @@ namespace HealthChecks.UI.Configuration
         public bool UseRelativeWebhookPath = true;
         public string ResourcesPath { get; set; } = "/ui/resources";
         public bool UseRelativeResourcesPath = true;
+        public bool AsideMenuOpened { get; set; } = true;
 
         public Options AddCustomStylesheet(string path)
         {

--- a/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
@@ -32,7 +32,7 @@ namespace HealthChecks.UI.Core
                 .Replace(Keys.HEALTHCHECKSUI_RESOURCES_TARGET, resourcePath);
 
             resource.Content = resource.Content
-                .Replace(Keys.HEALTHCHECKSUI_ASIDEMENUEOPENED_TARGET, options.AsideMenuOpened.ToString());
+                .Replace(Keys.HEALTHCHECKSUI_ASIDEMENUEOPENED_TARGET, options.AsideMenuOpened.ToString().ToLower());
 
             return resource;
         }

--- a/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
@@ -31,6 +31,9 @@ namespace HealthChecks.UI.Core
             resource.Content = resource.Content
                 .Replace(Keys.HEALTHCHECKSUI_RESOURCES_TARGET, resourcePath);
 
+            resource.Content = resource.Content
+                .Replace(Keys.HEALTHCHECKSUI_ASIDEMENUEOPENED_TARGET, options.AsideMenuOpened.ToString());
+
             return resource;
         }
 

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -14,6 +14,7 @@ namespace HealthChecks.UI
         internal const string HEALTHCHECKSUI_WEBHOOKS_API_TARGET = "#webhookPath#";
         internal const string HEALTHCHECKSUI_RESOURCES_TARGET = "#uiResourcePath#";
         internal const string HEALTHCHECKSUI_STYLESHEETS_TARGET = "#customstylesheets#";
+        internal const string HEALTHCHECKSUI_ASIDEMENUEOPENED_TARGET = "#asideMenuOpened#";
         internal const string DEFAULT_RESPONSE_CONTENT_TYPE = "application/json";
         internal const string LIVENESS_BOOKMARK = "[[LIVENESS]]";
         internal const string FAILURE_BOOKMARK = "[[FAILURE]]";

--- a/src/HealthChecks.UI/assets/index.html
+++ b/src/HealthChecks.UI/assets/index.html
@@ -16,7 +16,7 @@
     <script type="text/javascript">
         var uiEndpoint = "#apiPath#";
         var webhookEndpoint = "#webhookPath#";
-        var asideMenuOpened = "#asideMenuOpened#";
+        var asideMenuOpened = #asideMenuOpened#;
     </script>
     <script type="text/javascript" src="#uiResourcePath#/vendors-dll.js"></script>
     <script type="text/javascript" src="#uiResourcePath#/healthchecks-bundle.js"></script>

--- a/src/HealthChecks.UI/assets/index.html
+++ b/src/HealthChecks.UI/assets/index.html
@@ -16,6 +16,7 @@
     <script type="text/javascript">
         var uiEndpoint = "#apiPath#";
         var webhookEndpoint = "#webhookPath#";
+        var asideMenuOpened = "#asideMenuOpened#";
     </script>
     <script type="text/javascript" src="#uiResourcePath#/vendors-dll.js"></script>
     <script type="text/javascript" src="#uiResourcePath#/healthchecks-bundle.js"></script>

--- a/src/HealthChecks.UI/client/App.tsx
+++ b/src/HealthChecks.UI/client/App.tsx
@@ -21,7 +21,7 @@ export class App extends React.Component<AppProps, AppState> {
   constructor(props: AppProps) {
     super(props);
     this.state = {
-      menuOpen: true
+      menuOpen: false
     };
 
     this.toggleMenu = this.toggleMenu.bind(this);

--- a/src/HealthChecks.UI/client/App.tsx
+++ b/src/HealthChecks.UI/client/App.tsx
@@ -7,6 +7,7 @@ import { AsideMenu } from './components/AsideMenu';
 interface AppProps {
   apiEndpoint: string;
   webhookEndpoint: string;
+  asideMenuOpened: boolean;
 }
 
 interface AppState {
@@ -21,7 +22,7 @@ export class App extends React.Component<AppProps, AppState> {
   constructor(props: AppProps) {
     super(props);
     this.state = {
-      menuOpen: false
+      menuOpen: props.asideMenuOpened
     };
 
     this.toggleMenu = this.toggleMenu.bind(this);

--- a/src/HealthChecks.UI/client/index.tsx
+++ b/src/HealthChecks.UI/client/index.tsx
@@ -5,6 +5,7 @@ import { HashRouter } from "react-router-dom";
 
 declare var uiEndpoint: any;
 declare var webhookEndpoint: any
+declare var asideMenuOpened: any
 
 let endpoint = `${window.location.origin}${uiEndpoint}`;
 
@@ -12,5 +13,6 @@ ReactDOM.render(
     <HashRouter>
         <App apiEndpoint={uiEndpoint}
             webhookEndpoint={webhookEndpoint}
+            asideMenuOpened={asideMenuOpened}
         />
     </HashRouter>, document.getElementById("app"));


### PR DESCRIPTION
We use HealthChecksUI as a monitor (big screen in OPS) for our different environments (DEV, INT, STAGE, PROD). The left hand menu uses up a lot of space and could be closed initially. 

Would that be a big issue for you? 

Thanks! 
Best regards, David