### PR TITLE
[UI] Protect all assembly resources endpoints and add Authn and Authz demo

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -20,6 +20,7 @@
 
   <PropertyGroup Label="Package Versions">
     <MicrosoftExtensionsDiagnosticsHealthChecks>3.0.0</MicrosoftExtensionsDiagnosticsHealthChecks>
+    <MicrosoftAspNetCoreJwtBearer>3.0.0</MicrosoftAspNetCoreJwtBearer>
     <MicrosoftExtensionsHttp>3.0.0</MicrosoftExtensionsHttp>
     <MicrosoftExtensionsDependencyInjection>3.0.0</MicrosoftExtensionsDependencyInjection>
     <MicrosoftAspNetCoreTestHost>3.0.0</MicrosoftAspNetCoreTestHost>
@@ -101,7 +102,7 @@
     <HealthCheckHangfire>3.0.0</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
-    <HealthCheckUI>3.0.5</HealthCheckUI>
+    <HealthCheckUI>3.0.6</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.1</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -102,7 +102,7 @@
     <HealthCheckHangfire>3.0.0</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
-    <HealthCheckUI>3.0.6</HealthCheckUI>
+    <HealthCheckUI>3.0.5</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.1</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>

--- a/samples/HealthChecks.UI.Branding/HealthChecks.UI.Branding.csproj
+++ b/samples/HealthChecks.UI.Branding/HealthChecks.UI.Branding.csproj
@@ -5,6 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreJwtBearer)" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\HealthChecks.System\HealthChecks.System.csproj" />
         <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
         <ProjectReference Include="..\..\src\HealthChecks.UI\HealthChecks.UI.csproj" />

--- a/samples/HealthChecks.UI.Branding/IServiceCollectionExtensions.cs
+++ b/samples/HealthChecks.UI.Branding/IServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class IServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDemoAuthentication(this IServiceCollection services)
+        {
+            return services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = "https://demo.identityserver.io";
+                    options.Audience = "api";
+
+                }).Services
+                  .AddAuthorization(configure =>
+                  {
+                      configure.AddPolicy("AuthUserPolicy", config => config.RequireAuthenticatedUser());
+                  });
+        }
+    }
+}

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -20,7 +20,11 @@ namespace HealthChecks.UI.Branding
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+
+            //To add authentication and authorization using demo identityserver uncomment AddDemoAuthentication and RequireAuthorization lines
+
             services
+                //.AddDemoAuthentication()
                 .AddHealthChecks()
                 .AddProcessAllocatedMemoryHealthCheck(maximumMegabytesAllocated: 100, tags: new[] { "process" })
                 .AddCheck<RandomHealthCheck>("random1", tags: new[] { "random" })
@@ -47,6 +51,8 @@ namespace HealthChecks.UI.Branding
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseRouting()
+               .UseAuthentication()
+               .UseAuthorization()
                .UseEndpoints(config =>
                {
                    config.MapHealthChecks("/health-random", new HealthCheckOptions
@@ -64,7 +70,10 @@ namespace HealthChecks.UI.Branding
                    config.MapHealthChecksUI(setup =>
                    {
                        setup.AddCustomStylesheet("dotnet.css");
-                   });
+
+                   })
+                   //.RequireAuthorization("AuthUserPolicy")
+                   ;
 
                    config.MapDefaultControllerRoute();
                });

--- a/src/HealthChecks.UI/EndpointRouteBuilderExtensions.cs
+++ b/src/HealthChecks.UI/EndpointRouteBuilderExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -32,7 +34,8 @@ namespace Microsoft.AspNetCore.Builder
 
 
             var embeddedResourcesAssembly = typeof(UIResource).Assembly;
-            new UIEndpointsResourceMapper(new UIEmbeddedResourcesReader(embeddedResourcesAssembly))
+
+            var resourcesEndpoints = new UIEndpointsResourceMapper(new UIEmbeddedResourcesReader(embeddedResourcesAssembly))
                 .Map(builder, options);
 
 
@@ -42,8 +45,9 @@ namespace Microsoft.AspNetCore.Builder
             var webhooksEndpoint = builder.Map(options.WebhookPath, webhooksDelegate)
                                 .WithDisplayName("HealthChecks UI Webhooks");
 
-            return new HealthCheckUIConventionBuilder(apiEndpoint, webhooksEndpoint);
+            var endpointConventionBuilders = new List<IEndpointConventionBuilder>(new[] { apiEndpoint, webhooksEndpoint }.Union(resourcesEndpoints));
 
+            return new HealthCheckUIConventionBuilder(endpointConventionBuilders);
         }
 
         private static void EnsureValidApiOptions(Options options)

--- a/src/HealthChecks.UI/HealthChecksUIConventionBuilder.cs
+++ b/src/HealthChecks.UI/HealthChecksUIConventionBuilder.cs
@@ -7,19 +7,19 @@ namespace HealthChecks.UI
 {
     class HealthCheckUIConventionBuilder : IEndpointConventionBuilder
     {
-        private readonly IEndpointConventionBuilder ApiEndpoint;
-        private readonly IEndpointConventionBuilder WebhooksEndpoint;
+        private readonly IEnumerable<IEndpointConventionBuilder> _endpoints;
 
-        public HealthCheckUIConventionBuilder(IEndpointConventionBuilder apiEndpoint, IEndpointConventionBuilder webhooksEndpoint)
+        public HealthCheckUIConventionBuilder(IEnumerable<IEndpointConventionBuilder> endpoints)
         {
-            ApiEndpoint = apiEndpoint ?? throw new ArgumentNullException(nameof(apiEndpoint));
-            WebhooksEndpoint = webhooksEndpoint ?? throw new ArgumentNullException(nameof(webhooksEndpoint));
+            _endpoints = endpoints ?? throw new ArgumentNullException(nameof(endpoints));
         }
 
         public void Add(Action<EndpointBuilder> convention)
         {
-            ApiEndpoint.Add(convention);
-            WebhooksEndpoint.Add(convention);
+            foreach(var endpoint in _endpoints)
+            {
+                endpoint.Add(convention);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #305 
Right now, the composite IEndpointConventionBuilder returned in MapHealthChecksUI was only adding configured metadata to Api and Webhook endpoints.

With this PR, all assembly embedded resources as html, css, js and custom stylesheets will be protected as well.