### PR TITLE
Fix deprecated TelemetryConfiguration.Active in App Insights Publisher

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -104,7 +104,7 @@
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
     <HealthCheckUI>3.0.5</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
-    <HealthCheckPublisherAppplicationInsights>3.0.1</HealthCheckPublisherAppplicationInsights>
+    <HealthCheckPublisherAppplicationInsights>3.0.2</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>
     <HealthCheckPublisherPrometheus>3.0.0</HealthCheckPublisherPrometheus>
     <HealthCheckAWSS3>3.0.0</HealthCheckAWSS3>

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,16 +21,26 @@ namespace HealthChecks.Publisher.ApplicationInsights
 
         private static TelemetryClient _client;
         private static readonly object sync_root = new object();
-
+        private readonly TelemetryConfiguration _telemetryConfiguration;
         private readonly string _instrumentationKey;
         private readonly bool _saveDetailedReport;
         private readonly bool _excludeHealthyReports;
 
-        public ApplicationInsightsPublisher(string instrumentationKey = default, bool saveDetailedReport = false, bool excludeHealthyReports = false)
+        public ApplicationInsightsPublisher(
+            IOptions<TelemetryConfiguration> telemetryConfiguration,
+            string instrumentationKey = default,
+            bool saveDetailedReport = false,
+            bool excludeHealthyReports = false)
         {
+            _telemetryConfiguration = telemetryConfiguration?.Value;
             _instrumentationKey = instrumentationKey;
             _saveDetailedReport = saveDetailedReport;
             _excludeHealthyReports = excludeHealthyReports;
+
+            if (string.IsNullOrEmpty(instrumentationKey) && string.IsNullOrEmpty(_telemetryConfiguration?.InstrumentationKey))
+            {
+                throw new ArgumentNullException("No instrumentation key was provided in options or constructor");
+            }
         }
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
@@ -113,7 +124,7 @@ namespace HealthChecks.Publisher.ApplicationInsights
                         //key active on the project.
 
                         var configuration = string.IsNullOrWhiteSpace(_instrumentationKey)
-                            ? TelemetryConfiguration.Active
+                            ? new TelemetryConfiguration(_telemetryConfiguration?.InstrumentationKey)
                             : new TelemetryConfiguration(_instrumentationKey);
 
                         _client = new TelemetryClient(configuration);

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -22,7 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services
                .AddSingleton<IHealthCheckPublisher>(sp =>
                {
-                   return new ApplicationInsightsPublisher(instrumentationKey, saveDetailedReport, excludeHealthyReports);
+                   var telemetryConfigurationOptions = sp.GetService<IOptions<TelemetryConfiguration>>();
+                   return new ApplicationInsightsPublisher(telemetryConfigurationOptions, instrumentationKey, saveDetailedReport, excludeHealthyReports);
                });
 
             return builder;

--- a/test/UnitTests/DependencyInjection/Publisher.ApplicationInsights/Publisher.ApplicationInsightsUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/Publisher.ApplicationInsights/Publisher.ApplicationInsightsUnitTests.cs
@@ -1,6 +1,8 @@
 ﻿using HealthChecks.Publisher.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
 using Xunit;
 
 namespace UnitTests.DependencyInjection.Publisher.ApplicationInsights
@@ -8,10 +10,42 @@ namespace UnitTests.DependencyInjection.Publisher.ApplicationInsights
     public class application_insights_publisher_registration_should
     {
         [Fact]
-        public void add_publisher_when_properly_configured()
+        public void fail_when_no_telemetry_configuration_is_configured_using_parameters_or_IOptions()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
+                .AddApplicationInsightsPublisher();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                serviceProvider.GetService<IHealthCheckPublisher>();
+            });
+        }
+
+        [Fact]
+        public void add_healthcheck_when_properly_configured_with_instrumentation_key_parameter()
+        {
+            var services = new ServiceCollection();
+            services
+                .AddHealthChecks()
+                .AddApplicationInsightsPublisher("telemetrykey");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
+
+            Assert.NotNull(publisher);
+        }
+
+        [Fact]
+        public void add_healthcheck_when_application_insights_is_properly_configured_with_IOptions()
+        {
+            var services = new ServiceCollection();
+            services.Configure<TelemetryConfiguration>(config => config.InstrumentationKey = "telemetrykey");
+
+            services
+                .AddHealthChecks()
                 .AddApplicationInsightsPublisher();
 
             var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Fixes #348 

Application Insights publisher no longer relies in static **TelemetryConfiguration.Active**

The TelemetryKey should be configured using the healthcheck parameter:

```csharp
         services
           .AddHealthChecks()
           .AddApplicationInsightsPublisher("telemetrykey");
```

Or by using

```csharp
 services.AddApplicationInsightsTelemetry()
```

that uses IConfiguration ApplicationInsights section.

https://github.com/microsoft/ApplicationInsights-aspnetcore/blob/205bcd90fa70b5afc3f8dd967035bac7b06c00ef/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs#L163
