### PR TITLE
[Docker image] Allow disabling relative paths for resources

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
@@ -12,5 +12,6 @@ namespace HealthChecks.UI.Image.Configuration
         public const string UI_PATH = "ui_path";
         public const string UI_RESOURCES_PATH = "ui_resources_path";
         public const string UI_WEBHOOKS_PATH = "ui_webhooks_path";
+        public const string UI_NO_RELATIVE_PATHS = "ui_no_relative_paths";
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
@@ -25,11 +25,26 @@ namespace HealthChecks.UI.Image.Extensions
             var apiPath = configuration[UIKeys.UI_API_PATH];
             var resourcesPath = configuration[UIKeys.UI_RESOURCES_PATH];
             var webhooksPath = configuration[UIKeys.UI_WEBHOOKS_PATH];
+            var relativePaths = configuration[UIKeys.UI_NO_RELATIVE_PATHS];
+
+            bool disableRelativePaths = false;
+
+            if(!string.IsNullOrEmpty(relativePaths))
+            {
+                bool.TryParse(relativePaths, out disableRelativePaths);
+            }
 
             if (!string.IsNullOrEmpty(uiPath)) options.UIPath = uiPath;
             if (!string.IsNullOrEmpty(apiPath)) options.ApiPath = apiPath;
             if (!string.IsNullOrEmpty(resourcesPath)) options.ResourcesPath = resourcesPath;
             if (!string.IsNullOrEmpty(webhooksPath)) options.WebhookPath = webhooksPath;
+
+            if(disableRelativePaths)
+            {
+                options.UseRelativeApiPath = false;
+                options.UseRelativeResourcesPath = false;
+                options.UseRelativeWebhookPath = false;
+            }
         }
     }
 }

--- a/samples/HealthChecks.UI.Branding/HealthChecks.UI.Branding.csproj
+++ b/samples/HealthChecks.UI.Branding/HealthChecks.UI.Branding.csproj
@@ -9,6 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\src\HealthChecks.Publisher.ApplicationInsights\HealthChecks.Publisher.ApplicationInsights.csproj" />
         <ProjectReference Include="..\..\src\HealthChecks.System\HealthChecks.System.csproj" />
         <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
         <ProjectReference Include="..\..\src\HealthChecks.UI\HealthChecks.UI.csproj" />

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using HealthChecks.UI.Client;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -29,6 +30,7 @@ namespace HealthChecks.UI.Branding
                 .AddProcessAllocatedMemoryHealthCheck(maximumMegabytesAllocated: 100, tags: new[] { "process" })
                 .AddCheck<RandomHealthCheck>("random1", tags: new[] { "random" })
                 .AddCheck<RandomHealthCheck>("random2", tags: new[] { "random" })
+                .AddApplicationInsightsPublisher("e88332d4-624d-4c8a-883a-a5121e7faa7b", saveDetailedReport: true)
                 .Services
                 .AddHealthChecksUI(setupSettings: setup =>
                 {

--- a/samples/HealthChecks.UI.Branding/appsettings.json
+++ b/samples/HealthChecks.UI.Branding/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ApplicationInsights": {
+    "InstrumentationKey": "e88332d4-624d-4c8a-883a-a5121e7faa7b"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning"

--- a/src/HealthChecks.UI/package-lock.json
+++ b/src/HealthChecks.UI/package-lock.json
@@ -1679,7 +1679,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1700,12 +1701,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1720,17 +1723,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1847,7 +1853,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1859,6 +1866,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1873,6 +1881,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1880,12 +1889,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1904,6 +1915,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1984,7 +1996,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1996,6 +2009,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2081,7 +2095,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2117,6 +2132,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2136,6 +2152,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2179,12 +2196,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Added **ui_no_relative_paths** environment variable to disable Api, Webhooks and Resources relatives paths to be able to configure absolute paths when using a reverse proxy.

