### PR TITLE
[Docker image] Allow disabling relative paths for resources

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Configuration/UIKeys.cs
@@ -12,5 +12,6 @@ namespace HealthChecks.UI.Image.Configuration
         public const string UI_PATH = "ui_path";
         public const string UI_RESOURCES_PATH = "ui_resources_path";
         public const string UI_WEBHOOKS_PATH = "ui_webhooks_path";
+        public const string UI_NO_RELATIVE_PATHS = "ui_no_relative_paths";
     }
 }

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
@@ -29,7 +29,7 @@ namespace HealthChecks.UI.Image.Extensions
 
             bool disableRelativePaths = false;
 
-            if(!string.IsNullOrEmpty(relativePaths))
+            if (!string.IsNullOrEmpty(relativePaths))
             {
                 bool.TryParse(relativePaths, out disableRelativePaths);
             }
@@ -39,7 +39,7 @@ namespace HealthChecks.UI.Image.Extensions
             if (!string.IsNullOrEmpty(resourcesPath)) options.ResourcesPath = resourcesPath;
             if (!string.IsNullOrEmpty(webhooksPath)) options.WebhookPath = webhooksPath;
 
-            if(disableRelativePaths)
+            if (disableRelativePaths)
             {
                 options.UseRelativeApiPath = false;
                 options.UseRelativeResourcesPath = false;

--- a/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Extensions/OptionsExtensions.cs
@@ -25,11 +25,26 @@ namespace HealthChecks.UI.Image.Extensions
             var apiPath = configuration[UIKeys.UI_API_PATH];
             var resourcesPath = configuration[UIKeys.UI_RESOURCES_PATH];
             var webhooksPath = configuration[UIKeys.UI_WEBHOOKS_PATH];
+            var relativePaths = configuration[UIKeys.UI_NO_RELATIVE_PATHS];
+
+            bool disableRelativePaths = false;
+
+            if(!string.IsNullOrEmpty(relativePaths))
+            {
+                bool.TryParse(relativePaths, out disableRelativePaths);
+            }
 
             if (!string.IsNullOrEmpty(uiPath)) options.UIPath = uiPath;
             if (!string.IsNullOrEmpty(apiPath)) options.ApiPath = apiPath;
             if (!string.IsNullOrEmpty(resourcesPath)) options.ResourcesPath = resourcesPath;
             if (!string.IsNullOrEmpty(webhooksPath)) options.WebhookPath = webhooksPath;
+
+            if(disableRelativePaths)
+            {
+                options.UseRelativeApiPath = false;
+                options.UseRelativeResourcesPath = false;
+                options.UseRelativeWebhookPath = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Added **ui_no_relative_paths** environment variable to disable Api, Webhooks and Resources relatives paths to be able to configure absolute paths when using a reverse proxy.