### PR TITLE
Add Azure KeyVault cryptographic keys check

### DIFF
--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -17,7 +17,6 @@ namespace HealthChecks.AzureKeyVault
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            var currentSecret = string.Empty;
             try
             {
                 using (var client = CreateClient())

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -22,9 +22,14 @@ namespace HealthChecks.AzureKeyVault
             {
                 using (var client = CreateClient())
                 {
-                    foreach (var item in _options.Secrets)
+                    foreach (var secret in _options.Secrets)
                     {
-                        await client.GetSecretAsync(_options.KeyVaultUrlBase, item, cancellationToken);
+                        await client.GetSecretAsync(_options.KeyVaultUrlBase, secret, cancellationToken);
+                    }
+
+                    foreach (var key in _options.Keys)
+                    {
+                        await client.GetKeyAsync(_options.KeyVaultUrlBase, key, cancellationToken);
                     }
                 }
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -15,6 +15,13 @@ namespace HealthChecks.AzureKeyVault
             get { return _secrets; }
         }
 
+        internal HashSet<string> _keys = new HashSet<string>();
+
+        internal IEnumerable<string> Keys
+        {
+            get { return _keys; }
+        }
+
         internal string KeyVaultUrlBase { get; private set; }
         internal string ClientId { get; private set; }
         internal string ClientSecret { get; private set; }
@@ -71,11 +78,23 @@ namespace HealthChecks.AzureKeyVault
         /// <summary>
         /// Add a Azure Key Vault secret to be checked
         /// </summary>
-        /// <param name="secretIdentifier"></param>
+        /// <param name="secretIdentifier">The secret to be checked</param>
         /// <returns><see cref="AzureKeyVaultOptions"/></returns>
         public AzureKeyVaultOptions AddSecret(string secretIdentifier)
         {
             _secrets.Add(secretIdentifier);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add a Azure Key Vault cryptographic key to be checked
+        /// </summary>
+        /// <param name="keyIdentifier">The cryptographic key to be checked</param>
+        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
+        public AzureKeyVaultOptions AddKey(string keyIdentifier)
+        {
+            _keys.Add(keyIdentifier);
 
             return this;
         }

--- a/test/UnitTests/DependencyInjection/AzureKeyVault/AzureKeyVaultUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureKeyVault/AzureKeyVaultUnitTests.cs
@@ -19,8 +19,9 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureKeyVault
                 .AddAzureKeyVault(setup =>
                {
                    setup
-                   .UseKeyVaultUrl("https://keyvault")
-                   .AddSecret("supercret");
+                   .UseKeyVaultUrl("https://keyvault/")
+                   .AddSecret("supersecret")
+                   .AddKey("mycryptokey");
                });
 
             var serviceProvider = services.BuildServiceProvider();
@@ -42,7 +43,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureKeyVault
                 .AddAzureKeyVault(setup =>
                 {
                     setup
-                    .UseKeyVaultUrl("https://keyvault")
+                    .UseKeyVaultUrl("https://keyvault/")
                     .UseClientSecrets("client", "secret");
 
                 }, name: "keyvaultcheck");
@@ -69,7 +70,8 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureKeyVault
                 {
                     setup
                     .UseKeyVaultUrl("invalid URI")
-                    .AddSecret("mysecret");
+                    .AddSecret("mysecret")
+                    .AddKey("mycryptokey");
                 });
             });
         }


### PR DESCRIPTION
Hi, this a proposed PR to slightly extend the already existing `HealthChecks.AzureKeyVault` created with PR #19 .
The idea is to support the check also for the cryptographic keys that can be stored in KeyVault. I noticed that another user suggested the change in the above PR, but I couldn't find any ongoing work.

Usage:

Default usage with Managed Service Identity:

```csharp
services.AddHealthChecks()
    .AddAzureKeyVault(setup =>
    {
        setup
            .UseKeyVaultUrl("https://[vaultname].vault.azure.net/")                  
            .AddKey("keyname");
    });
```

Usage usage client id and client secret:

```csharp
services.AddHealthChecks()
    .AddAzureKeyVault(setup =>
    {
        setup
            .UseKeyVaultUrl("https://[vaultname].vault.azure.net/")    
            .UseClientSecrets("clientid", "clientsecret")
            .AddKey("keyname");
    });
```

Thanks.