### PR TITLE
[Azure key vault] Add certificates with configurable expiry check

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -68,7 +68,7 @@
     <MicrosoftApplicationInsights>2.10.0</MicrosoftApplicationInsights>
     <PrometheusNet>2.1.3</PrometheusNet>
     <AWSSKDS3>3.3.29</AWSSKDS3> 
-    <MicrosoftAzureKeyVault>3.0.4</MicrosoftAzureKeyVault>
+    <MicrosoftAzureKeyVault>3.0.5</MicrosoftAzureKeyVault>
     <KubernetesClient>1.5.25</KubernetesClient>
     <DogStatsDCSharpClient>3.3.0</DogStatsDCSharpClient>
     <MicrosoftAzureDevices>1.18.1</MicrosoftAzureDevices>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -68,7 +68,7 @@
     <MicrosoftApplicationInsights>2.10.0</MicrosoftApplicationInsights>
     <PrometheusNet>2.1.3</PrometheusNet>
     <AWSSKDS3>3.3.29</AWSSKDS3> 
-    <MicrosoftAzureKeyVault>3.0.5</MicrosoftAzureKeyVault>
+    <MicrosoftAzureKeyVault>3.0.4</MicrosoftAzureKeyVault>
     <KubernetesClient>1.5.25</KubernetesClient>
     <DogStatsDCSharpClient>3.3.0</DogStatsDCSharpClient>
     <MicrosoftAzureDevices>1.18.1</MicrosoftAzureDevices>
@@ -108,7 +108,7 @@
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>
     <HealthCheckPublisherPrometheus>3.0.0</HealthCheckPublisherPrometheus>
     <HealthCheckAWSS3>3.0.0</HealthCheckAWSS3>
-    <HealthCheckKeyVault>3.0.0</HealthCheckKeyVault>
+    <HealthCheckKeyVault>3.0.1</HealthCheckKeyVault>
     <HealthCheckPublisherSeq>3.0.0</HealthCheckPublisherSeq>
     <HealthCheckRavenDB>3.0.0</HealthCheckRavenDB>
     <HealthCheckKubernetes>3.0.0</HealthCheckKubernetes>

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -31,7 +31,7 @@ namespace HealthChecks.AzureKeyVault
                         await client.GetKeyAsync(_options.KeyVaultUrlBase, key, cancellationToken);
                     }
 
-                    foreach (var (key, checkExpired) in _options._certificates)
+                    foreach (var (key, checkExpired) in _options.Certificates)
                     {
                         var certificate = await client.GetCertificateAsync(_options.KeyVaultUrlBase, key, cancellationToken);
 

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -37,11 +37,11 @@ namespace HealthChecks.AzureKeyVault
 
                         if (checkExpired && certificate.Attributes.Expires.HasValue)
                         {
-                            var expiralDate = certificate.Attributes.Expires.Value;
+                            var expirationDate = certificate.Attributes.Expires.Value;
 
-                            if (expiralDate < DateTime.UtcNow)
+                            if (expirationDate < DateTime.UtcNow)
                             {
-                                throw new Exception($"The certificate with key {key} has expired with date {expiralDate}");
+                                throw new Exception($"The certificate with key {key} has expired with date {expirationDate}");
                             }
                         }
                     }

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultHealthCheck.cs
@@ -30,6 +30,21 @@ namespace HealthChecks.AzureKeyVault
                     {
                         await client.GetKeyAsync(_options.KeyVaultUrlBase, key, cancellationToken);
                     }
+
+                    foreach (var (key, checkExpired) in _options._certificates)
+                    {
+                        var certificate = await client.GetCertificateAsync(_options.KeyVaultUrlBase, key, cancellationToken);
+
+                        if (checkExpired && certificate.Attributes.Expires.HasValue)
+                        {
+                            var expiralDate = certificate.Attributes.Expires.Value;
+
+                            if (expiralDate < DateTime.UtcNow)
+                            {
+                                throw new Exception($"The certificate with key {key} has expired with date {expiralDate}");
+                            }
+                        }
+                    }
                 }
                 return HealthCheckResult.Healthy();
             }

--- a/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/HealthChecks.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -22,6 +22,13 @@ namespace HealthChecks.AzureKeyVault
             get { return _keys; }
         }
 
+        internal List<(string, bool)> _certificates = new List<(string key, bool checkExpired)>();
+
+        internal List<(string, bool)> Certificates
+        {
+            get { return _certificates; }
+        }
+
         internal string KeyVaultUrlBase { get; private set; }
         internal string ClientId { get; private set; }
         internal string ClientSecret { get; private set; }
@@ -95,6 +102,19 @@ namespace HealthChecks.AzureKeyVault
         public AzureKeyVaultOptions AddKey(string keyIdentifier)
         {
             _keys.Add(keyIdentifier);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add a Azure Key Vault certificate key to be checked
+        /// </summary>
+        /// <param name="certificateIdentifier">The certificate key to be checked</param>
+        /// /// <param name="checkExpired">Certificate expiration date should be checked. It the certificate is expired a exception will be thrown</param>
+        /// <returns><see cref="AzureKeyVaultOptions"/></returns>
+        public AzureKeyVaultOptions AddCertificate(string certificateIdentifier, bool checkExpired = false)
+        {
+            _certificates.Add((certificateIdentifier, checkExpired));
 
             return this;
         }


### PR DESCRIPTION
This PR adds the ability to configure azure key vault certificates with an optional "checkExpired" parameter that will throw an expection when the remote certificate has expired.

Sample:

```csharp

services
  .AddHealthChecks()
  .AddAzureKeyVault(setup =>
   {
     setup
        .UseKeyVaultUrl("https://landevault.vault.azure.net")
        .AddSecret("cosmos-key")
        .AddKey("Key1")
        .AddCertificate("landecert")
        .AddCertificate("Cert2", checkExpired: true)
        .UseClientSecrets("client", "secret");
   }
```