### PR TITLE
[UI] Expose setup actions to configure Api and Webhooks http clients 

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,42 @@ To add your custom styles sheet, use the UI setup method:
 ```
 You can visit the section [custom styles and branding](./doc/styles-branding.md) to find source samples and get further information about custom css properties.
 
+## UI Configure HttpClient and HttpMessageHandler for Api and Webhooks endpoints
+
+If you need to configure a proxy, or set an authentication header, the UI allows you to configure the HttpMessageHandler and the HttpClient for the webhooks and healtheck api endpoints.
+
+```csharp
+
+services.AddHealthChecksUI(setupSettings: setup =>
+{
+    setup.ConfigureApiEndpointHttpclient((sp, client) =>
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "supertoken");
+    })
+    .UseApiEndpointHttpMessageHandler(sp =>
+        {
+            return new HttpClientHandler
+            {
+                Proxy = new WebProxy("http://proxy:8080")
+            };
+        })
+    .ConfigureWebhooksEndpointHttpclient((sp, client) =>
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "sampletoken");
+    })
+    .UseWebhookEndpointHttpMessageHandler(sp =>
+    {
+        return new HttpClientHandler()
+        {
+            Properties =
+            {
+                ["prop"] = "value"
+            }
+        };
+    });
+});
+
+```
 
 ## UI Kubernetes automatic services discovery
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -102,7 +102,7 @@
     <HealthCheckHangfire>3.0.0</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
-    <HealthCheckUI>3.0.6</HealthCheckUI>
+    <HealthCheckUI>3.0.7</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.2</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -12,7 +12,9 @@ namespace HealthChecks.UI.Configuration
         internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
         internal string HealthCheckDatabaseConnectionString { get; set; }
         internal Func<IServiceProvider, HttpMessageHandler> ApiEndpointHttpHandler { get; private set; }
+        internal Action<IServiceProvider, HttpClient> ApiEndpointHttpClientConfig { get; private set; }
         internal Func<IServiceProvider, HttpMessageHandler> WebHooksEndpointHttpHandler { get; private set; }
+        internal Action<IServiceProvider, HttpClient> WebHooksEndpointHttpClientConfig { get; private set; }
 
         public Settings AddHealthCheckEndpoint(string name, string uri)
         {
@@ -24,7 +26,7 @@ namespace HealthChecks.UI.Configuration
 
             return this;
         }
-        
+
         public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "")
         {
             Webhooks.Add(new WebHookNotification
@@ -42,7 +44,7 @@ namespace HealthChecks.UI.Configuration
             EvaluationTimeInSeconds = seconds;
             return this;
         }
-        
+
         public Settings SetMinimumSecondsBetweenFailureNotifications(int seconds)
         {
             MinimumSecondsBetweenFailureNotifications = seconds;
@@ -60,10 +62,22 @@ namespace HealthChecks.UI.Configuration
             ApiEndpointHttpHandler = apiEndpointHttpHandler;
             return this;
         }
-        
+
         public Settings UseWebhookEndpointHttpMessageHandler(Func<IServiceProvider, HttpClientHandler> webhookEndpointHttpHandler)
         {
             WebHooksEndpointHttpHandler = webhookEndpointHttpHandler;
+            return this;
+        }
+
+        public Settings ConfigureApiEndpointHttpclient(Action<IServiceProvider, HttpClient> apiEndpointHttpClientconfig)
+        {
+            ApiEndpointHttpClientConfig = apiEndpointHttpClientconfig;
+            return this;
+        }
+
+        public Settings ConfigureWebhooksEndpointHttpclient(Action<IServiceProvider, HttpClient> webhooksEndpointHttpClientconfig)
+        {
+            WebHooksEndpointHttpClientConfig = webhooksEndpointHttpClientconfig;
             return this;
         }
     }


### PR DESCRIPTION
Currently, the UI allows using custom HttpMessageHandlers for the Api and Webhooks endpoints but you can't configure the internal HttpClients because they are not exposed.

With this PR, the AddHealthChecksUI setup exposes new methods to configure the Http Clients as well, so you cant configure all Httpclient related stuff as Authentication headers

```csharp
services.AddHealthChecksUI(setupSettings: setup =>
{
    setup.ConfigureApiEndpointHttpclient((sp, client) =>
    {
        //Configure api http client
    })
    .UseApiEndpointHttpMessageHandler(sp =>
        {
            return new HttpClientHandler
            {
                Proxy = new WebProxy("http://proxy:8080")
            };
        })
    .ConfigureWebhooksEndpointHttpclient((sp, client) =>
    {
        //Configure authentication header for a remote webhook endpoint
        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "sampletoken");
    })
    .UseWebhookEndpointHttpMessageHandler(sp =>
    {
        return new HttpClientHandler()
        {
            Properties =
            {
                ["prop"] = "value"
            }
        };
    });
});
```

Implements #336 