### PR TITLE
Handle TaskCanceledException when halting

### DIFF
--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollectorHostedService.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollectorHostedService.cs
@@ -54,7 +54,19 @@ namespace HealthChecks.UI.Core.HostedService
         }
         private Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            _lifetime.ApplicationStarted.Register(async () => await Collect(cancellationToken));
+            _lifetime.ApplicationStarted.Register(async () =>
+            {
+                try
+                {
+                    await Collect(cancellationToken);
+                }
+                catch(TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // We are halting, task cancellation is expected.
+                }
+
+            });
+
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
My attempt at fixing #376.

Swallows the TaskCanceledException thrown when stopping.