### PR TITLE
Fix absolute unix paths with Uri.TryCreate

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -102,7 +102,7 @@
     <HealthCheckHangfire>3.0.0</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
-    <HealthCheckUI>3.0.7</HealthCheckUI>
+    <HealthCheckUI>3.0.8</HealthCheckUI>
     <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.2</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>

--- a/src/HealthChecks.UI/Core/Extensions/UriExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/UriExtensions.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace HealthChecks.UI.Core.Extensions
+{
+    public static class UriExtensions
+    {
+        public static bool IsValidHealthCheckEndpoint(this Uri uri) =>
+            uri.IsAbsoluteUri && !uri.IsFile && (uri.Scheme == "http" || uri.Scheme == "https");
+    }
+}

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -84,7 +84,7 @@ namespace HealthChecks.UI.Core.HostedService
 
             try
             {
-              var absoluteUri = GetEndpointUri(configuration);
+                var absoluteUri = GetEndpointUri(configuration);
 
                 var response = await _httpClient.GetAsync(absoluteUri);
 
@@ -100,7 +100,7 @@ namespace HealthChecks.UI.Core.HostedService
 
         private Uri GetEndpointUri(HealthCheckConfiguration configuration)
         {
-             if (endpointAddresses.ContainsKey(configuration.Id))
+            if (endpointAddresses.ContainsKey(configuration.Id))
             {
                 return endpointAddresses[configuration.Id];
             }

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -1,6 +1,7 @@
 ﻿using HealthChecks.UI.Client;
 using HealthChecks.UI.Configuration;
 using HealthChecks.UI.Core.Data;
+using HealthChecks.UI.Core.Extensions;
 using HealthChecks.UI.Core.Notifications;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -83,7 +84,7 @@ namespace HealthChecks.UI.Core.HostedService
 
             try
             {
-                var absoluteUri = GetEndpointUri(configuration);
+              var absoluteUri = GetEndpointUri(configuration);
 
                 var response = await _httpClient.GetAsync(absoluteUri);
 
@@ -104,9 +105,9 @@ namespace HealthChecks.UI.Core.HostedService
                 return endpointAddresses[configuration.Id];
             }
 
-            var parsedUri = Uri.TryCreate(configuration.Uri, UriKind.Absolute, out var absoluteUri);
+            Uri.TryCreate(configuration.Uri, UriKind.Absolute, out var absoluteUri);
 
-            if (!parsedUri)
+            if (absoluteUri == null || !absoluteUri.IsValidHealthCheckEndpoint())
             {
                 Uri.TryCreate(_serverAddressService.AbsoluteUriFromRelative(configuration.Uri), UriKind.Absolute, out absoluteUri);
             }

--- a/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -1,6 +1,7 @@
 ﻿using HealthChecks.UI.Client;
 using HealthChecks.UI.Configuration;
 using HealthChecks.UI.Core.Data;
+using HealthChecks.UI.Core.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -62,13 +63,13 @@ namespace HealthChecks.UI.Core.Notifications
                         .Replace(Keys.DESCRIPTIONS_BOOKMARK, description);
 
 
-                    var parsedUri = Uri.TryCreate(webHook.Uri, UriKind.Absolute, out var absoluteUri);
+                    Uri.TryCreate(webHook.Uri, UriKind.Absolute, out var absoluteUri);
 
-                    if (!parsedUri)
+                    if (absoluteUri == null || !absoluteUri.IsValidHealthCheckEndpoint())
                     {
                         Uri.TryCreate(_serverAddressesService.AbsoluteUriFromRelative(webHook.Uri), UriKind.Absolute, out absoluteUri);
                     }
-                    
+
                     await SendRequest(absoluteUri, webHook.Name, payload);
                 }
             }

--- a/test/FunctionalTests/HealthChecks.UI/ServerAddressesServiceTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/ServerAddressesServiceTests.cs
@@ -50,6 +50,7 @@ namespace FunctionalTests.HealthChecks.UI
 
             var testServer = new TestServer(host, featureCollection);
         }
+        
     }
 
 }


### PR DESCRIPTION
Fix https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/38#issuecomment-567552933

Uri.TryCreate reports /path as relative in Unix and macOS (file paths)
This Pull Request follows the instructions from Microsoft from this issue:

dotnet/corefx#22098

dotnet/corefx#22098 (comment)