### PR TITLE
Be able to setup KafkaHealthCheck as singleton to re-use producer connections to broker

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -51,7 +51,7 @@
     <Npgsql>4.0.10</Npgsql>
     <MongoDBDriver>2.9.1</MongoDBDriver>
     <MySqlConnector>0.56.0</MySqlConnector>
-    <ConfluentKafka>1.2.0</ConfluentKafka>
+    <ConfluentKafka>1.3.0</ConfluentKafka>
     <SSHNet>2016.1.0</SSHNet>
     <NEST>7.3.0</NEST>
     <SystemBuffers>4.5.0</SystemBuffers>
@@ -92,7 +92,7 @@
     <HealthCheckNpgSql>3.0.0</HealthCheckNpgSql>
     <HealthCheckMongoDB>3.0.1</HealthCheckMongoDB>
     <HealthCheckMySql>3.0.0</HealthCheckMySql>
-    <HealthCheckKafka>3.0.0</HealthCheckKafka>
+    <HealthCheckKafka>3.0.1</HealthCheckKafka>
     <HealthCheckSystem>3.0.3</HealthCheckSystem>
     <HealthCheckNetwork>3.0.1</HealthCheckNetwork>
     <HealthCheckDynamoDb>3.0.0</HealthCheckDynamoDb>

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -12,7 +12,7 @@ namespace HealthChecks.Kafka
 
         public KafkaHealthCheck(ProducerConfig configuration)
         {
-            if(configuration == null) 
+            if (configuration == null) 
                 throw new ArgumentNullException(nameof(configuration));
             
             _producer = new ProducerBuilder<string, string>(configuration).Build();


### PR DESCRIPTION
My team would like to be able to register this health check as a singleton and not initiate a new connection to our broker every time the health is checked.  The following change would allow for using the health-check as-is today and allow others to register the health check as a singleton to re-use connections.