### PR TITLE
[UI Client] Async serialization, http context writer pipeline usage and reduced allocations

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -103,7 +103,7 @@
     <HealthCheckAzureServiceBus>3.0.0</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.0.0</HealthCheckConsul>
     <HealthCheckUI>3.0.8</HealthCheckUI>
-    <HealthCheckUIClient>3.0.0</HealthCheckUIClient>
+    <HealthCheckUIClient>3.0.1</HealthCheckUIClient>
     <HealthCheckPublisherAppplicationInsights>3.0.3</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.0.0</HealthCheckPublisherDatadog>
     <HealthCheckPublisherPrometheus>3.0.0</HealthCheckPublisherPrometheus>

--- a/src/HealthChecks.UI.Client/UIResponseWriter.cs
+++ b/src/HealthChecks.UI.Client/UIResponseWriter.cs
@@ -10,14 +10,13 @@ namespace HealthChecks.UI.Client
 {
     public static class UIResponseWriter
     {
+        private static byte[] emptyResponse = new byte[] { (byte)'{', (byte)'}' };
         const string DEFAULT_CONTENT_TYPE = "application/json";
 
         public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report) => await WriteHealthCheckUIResponse(httpContext, report, null);
 
         public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report, Action<JsonSerializerOptions> jsonConfigurator)
         {
-            var emptyResponse = new byte[] { (byte)'{', (byte)'}' };
-
             if (report != null)
             {
                 var settings = new JsonSerializerOptions()


### PR DESCRIPTION
- Async json serialization to prevent thread blocking in UI Client.
- Use asp.net core 3.0 http context pipeline body writer with ` ReadOnlyMemory<byte>` implicit operator
- Reduced string allocations in empty response string and sync json serialization