### PR TITLE
Ensure only one thread deletes the database #399

### DIFF
--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -152,7 +152,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-
         private static volatile bool isDatabaseMigrated;
         private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -154,10 +154,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
 
         private static volatile bool isDatabaseMigrated;
-        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1, 1);
+        private static Mutex migrationMutex = new Mutex();
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
-            await migrationSemaphore.WaitAsync();
+            migrationMutex.WaitOne();
             try
             {
                 if (!isDatabaseMigrated)
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             finally
             {
-                migrationSemaphore.Release();
+                migrationMutex.ReleaseMutex();
             }
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -154,10 +154,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
 
         private static volatile bool isDatabaseMigrated;
-        private static Mutex migrationMutex = new Mutex();
+        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1, 1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
-            migrationMutex.WaitOne();
+            await migrationSemaphore.WaitAsync();
             try
             {
                 if (!isDatabaseMigrated)
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             finally
             {
-                migrationMutex.ReleaseMutex();
+                migrationSemaphore.Release();
             }
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
+
         private static volatile bool isDatabaseMigrated;
         private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -157,13 +157,18 @@ namespace Microsoft.Extensions.DependencyInjection
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
             await migrationSemaphore.WaitAsync();
-            if (!isDatabaseMigrated)
+            try
             {
-                await db.Database.EnsureDeletedAsync();
-                await db.Database.MigrateAsync();
-                isDatabaseMigrated = true;
+                if (!isDatabaseMigrated)
+                {
+                    await db.Database.EnsureDeletedAsync();
+                    await db.Database.MigrateAsync();
+                    isDatabaseMigrated = true;
+                }
             }
-            migrationSemaphore.Release();
+            finally {
+                migrationSemaphore.Release();
+            }
         }
     }
 }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -153,17 +153,17 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         private static volatile bool isDatabaseMigrated;
-        private static SemaphoreSlim deletionSemaphore = new SemaphoreSlim(1);
+        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
-            await deletionSemaphore.WaitAsync();
+            await migrationSemaphore.WaitAsync();
             if (!isDatabaseMigrated)
             {
                 await db.Database.EnsureDeletedAsync();
                 await db.Database.MigrateAsync();
                 isDatabaseMigrated = true;
             }
-            deletionSemaphore.Release();
+            migrationSemaphore.Release();
         }
     }
 }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
+
         private static volatile bool isDatabaseMigrated;
         private static Mutex migrationMutex = new Mutex();
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -166,7 +166,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     isDatabaseMigrated = true;
                 }
             }
-            finally {
+            finally
+            {
                 migrationSemaphore.Release();
             }
         }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -153,10 +153,10 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         private static volatile bool isDatabaseMigrated;
-        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(0, 1);
+        private static Mutex migrationMutex = new Mutex();
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
-            await migrationSemaphore.WaitAsync();
+            migrationMutex.WaitOne();
             try
             {
                 if (!isDatabaseMigrated)
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             finally
             {
-                migrationSemaphore.Release();
+                migrationMutex.ReleaseMutex();
             }
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -152,17 +152,17 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private static volatile bool isDatabaseDeleted;
+        private static volatile bool isDatabaseMigrated;
         private static SemaphoreSlim deletionSemaphore = new SemaphoreSlim(1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
             await deletionSemaphore.WaitAsync();
-            if (!isDatabaseDeleted)
+            if (!isDatabaseMigrated)
             {
                 await db.Database.EnsureDeletedAsync();
-                isDatabaseDeleted = true;
+                await db.Database.MigrateAsync();
+                isDatabaseMigrated = true;
             }
-            await db.Database.MigrateAsync();
             deletionSemaphore.Release();
         }
     }

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         private static volatile bool isDatabaseMigrated;
-        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(1);
+        private static SemaphoreSlim migrationSemaphore = new SemaphoreSlim(0, 1);
         private static async Task EnsureMigratedAsync(this HealthChecksDb db)
         {
             await migrationSemaphore.WaitAsync();

--- a/src/HealthChecks.UI/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/ServiceCollectionExtensions.cs
@@ -14,7 +14,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -116,7 +115,7 @@ namespace Microsoft.Extensions.DependencyInjection
             .Services;
         }
 
-        private static bool databaseDeleted = false;
+        private static volatile bool isDatabaseDeleted = false;
         private static Mutex deletionMutex = new Mutex();
         static async Task CreateDatabase(IServiceProvider serviceProvider)
         {
@@ -134,10 +133,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     .GetService<IOptions<Settings>>();
 
                 deletionMutex.WaitOne();
-                if (!databaseDeleted)
+                if (!isDatabaseDeleted)
                 {
                     await db.Database.EnsureDeletedAsync();
-                    databaseDeleted = true;
+                    isDatabaseDeleted = true;
                 }
                 await db.Database.MigrateAsync();
                 deletionMutex.ReleaseMutex();

--- a/test/FunctionalTests/HealthChecks.UI/ConcurrencyTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/ConcurrencyTests.cs
@@ -1,0 +1,109 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using HealthChecks.UI.Client;
+using HealthChecks.UI.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthChecks.UI
+{
+    public class UI_concurrent_startup1_should
+    {
+
+        private async Task BaseConcurrencyTest()
+        {
+            var webHostBuilder = new WebHostBuilder()
+              .UseStartup<DefaultStartup>()
+              .ConfigureServices(services =>
+              {
+                  services.AddHealthChecks();
+                  Action<Settings> setupSettings = settings => {
+                      settings.AddHealthCheckEndpoint("Base", "/health");
+                  };
+                  services.AddHealthChecksUI(setupSettings: setupSettings);
+              })
+              .Configure(app => 
+              {
+                  app.UseHealthChecks("/health", new HealthCheckOptions
+                  {
+                      Predicate = _ => true,
+                      ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                  });
+                  app.UseHealthChecksUI();
+              })
+              .ConfigureAppConfiguration(conf =>
+              {
+                  conf.Sources.Clear();
+                  conf.AddJsonFile("HealthChecks.UI/Configuration/appsettings.json", false);
+              });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                    .Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_1()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_2()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_3()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_4()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_5()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_6()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_7()
+        {
+            return BaseConcurrencyTest();
+        }
+
+        [Fact]
+        public Task start_correctly_on_thread_8()
+        {
+            return BaseConcurrencyTest();
+        }
+    }
+
+    public class UI_concurrent_startup2_should : UI_concurrent_startup1_should
+    {
+    }
+}

--- a/test/FunctionalTests/HealthChecks.UI/ConcurrencyTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/ConcurrencyTests.cs
@@ -25,7 +25,8 @@ namespace FunctionalTests.HealthChecks.UI
               .ConfigureServices(services =>
               {
                   services.AddHealthChecks();
-                  Action<Settings> setupSettings = settings => {
+                  Action<Settings> setupSettings = settings =>
+                  {
                       settings.AddHealthCheckEndpoint("Base", "/health");
                   };
                   services.AddHealthChecksUI(setupSettings: setupSettings);


### PR DESCRIPTION
Ensure the database is deleted only at the begining of the first thread initialization in order to avoid Access Denied exception.
Open issue #399