### PR TITLE
S3 to use default credentials when no keys

### DIFF
--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -16,14 +16,6 @@ namespace HealthChecks.Aws.S3
             {
                 throw new ArgumentNullException(nameof(bucketOptions));
             }
-            if (string.IsNullOrEmpty(bucketOptions.AccessKey))
-            {
-                throw new ArgumentNullException(nameof(S3BucketOptions.AccessKey));
-            }
-            if (string.IsNullOrEmpty(bucketOptions.SecretKey))
-            {
-                throw new ArgumentNullException(nameof(S3BucketOptions.SecretKey));
-            }
             if (bucketOptions.S3Config == null)
             {
                 throw new ArgumentNullException(nameof(S3BucketOptions.S3Config));
@@ -34,8 +26,14 @@ namespace HealthChecks.Aws.S3
         {
             try
             {
-                var credentials = new BasicAWSCredentials(_bucketOptions.AccessKey, _bucketOptions.SecretKey);
-                using (var client = new AmazonS3Client(credentials, _bucketOptions.S3Config))
+                bool keysProvided = !string.IsNullOrEmpty(_bucketOptions.AccessKey) &&
+                                    !string.IsNullOrEmpty(_bucketOptions.SecretKey);
+                
+                AmazonS3Client client = keysProvided
+                    ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
+                    : new AmazonS3Client(_bucketOptions.S3Config);
+                
+                using (client)
                 {
                     var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
 


### PR DESCRIPTION
A change to allow S3HealthCheck to use default credentials when no keys provided.