### PR TITLE
Improve K8S discovery service null handling and logging

### DIFF
--- a/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/IKubernetesExtensions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/IKubernetesExtensions.cs
@@ -10,20 +10,18 @@ namespace HealthChecks.UI.Core.Discovery.K8S.Extensions
 {
     internal static class KubernetesHttpClientExtensions
     {
-        internal static async Task<V1ServiceList> GetServices(this IKubernetes client, string label, IEnumerable<string>? k8sNamespaces, CancellationToken cancellationToken)
+        internal static async Task<IEnumerable<V1Service>> GetServices(this IKubernetes client, string label, IEnumerable<string>? k8sNamespaces, CancellationToken cancellationToken)
         {
             if(k8sNamespaces is null || !k8sNamespaces.Any())
             {
-                return await client.ListServiceForAllNamespacesAsync(labelSelector: label, cancellationToken: cancellationToken);
+                var services = await client.ListServiceForAllNamespacesAsync(labelSelector: label, cancellationToken: cancellationToken);
+                return services?.Items ?? Enumerable.Empty<V1Service>();
             }
             else
             {
                 var responses = await Task.WhenAll(k8sNamespaces.Select(k8sNamespace => client.ListNamespacedServiceAsync(k8sNamespace, labelSelector: label, cancellationToken: cancellationToken)));
                 
-                return new V1ServiceList()
-                {
-                    Items = responses.SelectMany(r => r.Items).ToList()
-                };
+                return responses.Select(s => s?.Items).Where(s => s != null).SelectMany(s => s).ToList();
             }
         }
     }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -68,28 +68,25 @@ namespace HealthChecks.UI.Core.Discovery.K8S
                 {
                     var services = await _discoveryClient.GetServices(_discoveryOptions.ServicesLabel, _discoveryOptions.Namespaces, cancellationToken);
 
-                    if (services != null)
+                    foreach (var item in services)
                     {
-                        foreach (var item in services.Items)
+                        try
                         {
-                            try
-                            {
-                                var serviceAddress = _addressFactory.CreateAddress(item);
+                            var serviceAddress = _addressFactory.CreateAddress(item);
 
-                                if (serviceAddress != null && !IsLivenessRegistered(livenessDbContext, serviceAddress))
+                            if (serviceAddress != null && !IsLivenessRegistered(livenessDbContext, serviceAddress))
+                            {
+                                var statusCode = await CallClusterService(serviceAddress);
+                                if (IsValidHealthChecksStatusCode(statusCode))
                                 {
-                                    var statusCode = await CallClusterService(serviceAddress);
-                                    if (IsValidHealthChecksStatusCode(statusCode))
-                                    {
-                                        await RegisterDiscoveredLiveness(livenessDbContext, serviceAddress, item.Metadata.Name);
-                                        _logger.LogInformation($"Registered discovered liveness on {serviceAddress} with name {item.Metadata.Name}");
-                                    }
+                                    await RegisterDiscoveredLiveness(livenessDbContext, serviceAddress, item.Metadata.Name);
+                                    _logger.LogInformation("Registered discovered liveness service {ServiceName} in namespace {ServiceNamespace} with address {ServiceAddress}", item.Metadata.Name, item.Metadata.NamespaceProperty, serviceAddress);
                                 }
                             }
-                            catch (Exception)
-                            {
-                                _logger.LogError($"Error discovering service {item.Metadata.Name}. It might not be visible");
-                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error discovering service {ServiceName} in namespace {ServiceNamespace}. It might not be visible", item.Metadata.Name, item.Metadata.NamespaceProperty);
                         }
                     }
                 }


### PR DESCRIPTION
* Add null checks on services when namespace filtering is defined and at least one namespace has no services.
* Improve logging on `KubernetesDiscoveryHostedService`, by using structured logging and adding the service's namespace.