### PR TITLE
Resolve dns hostname when ipv4/ipv6 hosts are reported by IServerAddressFeature #410

### DIFF
--- a/samples/HealthChecks.UI.Branding/Program.cs
+++ b/samples/HealthChecks.UI.Branding/Program.cs
@@ -19,7 +19,6 @@ namespace HealthChecks.UI.Branding
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-            .UseUrls("http://*:0")
                 .UseStartup<Startup>();
     }
 }

--- a/samples/HealthChecks.UI.Branding/Program.cs
+++ b/samples/HealthChecks.UI.Branding/Program.cs
@@ -19,6 +19,7 @@ namespace HealthChecks.UI.Branding
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+            .UseUrls("http://*:0")
                 .UseStartup<Startup>();
     }
 }

--- a/src/HealthChecks.UI/Core/ServerAddressesService.cs
+++ b/src/HealthChecks.UI/Core/ServerAddressesService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 namespace HealthChecks.UI.Core
@@ -26,6 +27,8 @@ namespace HealthChecks.UI.Core
         {
             var targetAddress = AddressesFeature.Addresses.First();
 
+            Uri.TryCreate(targetAddress, UriKind.Absolute, out var original);
+
             if (targetAddress.EndsWith("/"))
             {
                 targetAddress = targetAddress[0..^1];
@@ -34,6 +37,13 @@ namespace HealthChecks.UI.Core
             if (!relativeUrl.StartsWith("/"))
             {
                 relativeUrl = $"/{relativeUrl}";
+            }
+
+            var hostCheck = Uri.CheckHostName(original.DnsSafeHost);
+
+            if(hostCheck != UriHostNameType.Dns)
+            {
+                targetAddress = $"{original.Scheme}://{Dns.GetHostName()}:{original.Port}";
             }
 
             return $"{targetAddress}{relativeUrl}";

--- a/src/HealthChecks.UI/Core/ServerAddressesService.cs
+++ b/src/HealthChecks.UI/Core/ServerAddressesService.cs
@@ -41,7 +41,7 @@ namespace HealthChecks.UI.Core
 
             var hostCheck = Uri.CheckHostName(original.DnsSafeHost);
 
-            if(hostCheck != UriHostNameType.Dns)
+            if (hostCheck != UriHostNameType.Dns)
             {
                 targetAddress = $"{original.Scheme}://{Dns.GetHostName()}:{original.Port}";
             }


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows resolve dns host when ipv4/ipv6 address formats are reported from IServerAddressFeature.
Formats like : [::], 0.0.0.0

**Which issue(s) this PR fixes**:

#410 

