### PR TITLE
Custom webhooks notification, failure and description user functions #415

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,13 +289,15 @@ Sample:
 
 You can also use relative urls when using IConfiguration providers like appsettings.json
 
-### Failure Notifications
+### Webhooks Failure Notifications
 
 If the **WebHooks** section is configured, HealthCheck-UI automatically posts a new notification into the webhook collection. HealthCheckUI uses a simple replace method for values in the webhook's **Payload** and **RestorePayload** properties. At this moment we support two bookmarks:
 
 [[LIVENESS]] The name of the liveness that returns _Down_.
 
 [[FAILURE]] A detail message with the failure.
+
+[[DESCRIPTIONS]] Failure descriptions
 
 The [web hooks section](./doc/webhooks.md) contains more information and webhooks samples for Microsoft Teams, Azure Functions, Slack and more.
 

--- a/README.md
+++ b/README.md
@@ -8,30 +8,33 @@ This repository offers a wide collection of **ASP.NET Core** Health Check packag
 
 **ASP.NET Core** versions supported: 2.2, 3.0
 
-
 # Sections
 
 ## HealthChecks
-  - [Health Checks](#Health-Checks)
-  - [Health Checks Push Results](#HealthCheck-push-results)
+
+- [Health Checks](#Health-Checks)
+- [Health Checks Push Results](#HealthCheck-push-results)
 
 ## HealthChecks UI
- - [UI](#HealthCheckUI)
- - [History Timeline](#Health-status-history-timeline)
- - [Configuration](#Configuration)
- - [Failure Notifications](#Failure-Notifications)
- - [HttpClient and HttpMessageHandler Configuration](#UI-Configure-HttpClient-and-HttpMessageHandler-for-Api-and-Webhooks-endpoints)
+
+- [UI](#HealthCheckUI)
+- [History Timeline](#Health-status-history-timeline)
+- [Configuration](#Configuration)
+- [Webhooks and Failure Notifications](#Webhooks-and-Failure-Notifications)
+- [HttpClient and HttpMessageHandler Configuration](#UI-Configure-HttpClient-and-HttpMessageHandler-for-Api-and-Webhooks-endpoints)
 
 ## HealthChecks UI and Kubernetes
- - Kubernetes Operator (Documentation in progress)
- - [Kubernetes automatic services discovery](#UI-Kubernetes-automatic-services-discovery)
+
+- Kubernetes Operator (Documentation in progress)
+- [Kubernetes automatic services discovery](#UI-Kubernetes-automatic-services-discovery)
 
 ## HealthChecks and Devops
- - [Releases Gates for Azure DevOps Pipelines](#HealthChecks-as-Release-Gates-for-Azure-DevOps-Pipelines)
+
+- [Releases Gates for Azure DevOps Pipelines](#HealthChecks-as-Release-Gates-for-Azure-DevOps-Pipelines)
 
 ## HealthChecks Tutorials
- - [Tutorials, Demos and walkthroughs](#Tutorials,-demos-and-walkthroughs-on-ASP.NET-Core-HealthChecks)
 
+- [Tutorials, Demos and walkthroughs](#Tutorials,-demos-and-walkthroughs-on-ASP.NET-Core-HealthChecks)
 
 ## Health Checks
 
@@ -154,7 +157,7 @@ services.AddHealthChecks()
         .AddPrometheusGatewayPublisher();
 ```
 
-## HealthCheckUI 
+## HealthCheckUI
 
 [UI Changelog](./doc/ui-changelog.md)
 
@@ -316,7 +319,7 @@ Sample:
 
 You can also use relative urls when using IConfiguration providers like appsettings.json
 
-### Webhooks Failure Notifications
+### Webhooks and Failure Notifications
 
 If the **WebHooks** section is configured, HealthCheck-UI automatically posts a new notification into the webhook collection. HealthCheckUI uses a simple replace method for values in the webhook's **Payload** and **RestorePayload** properties. At this moment we support two bookmarks:
 
@@ -325,6 +328,8 @@ If the **WebHooks** section is configured, HealthCheck-UI automatically posts a 
 [[FAILURE]] A detail message with the failure.
 
 [[DESCRIPTIONS]] Failure descriptions
+
+Webhooks can be configured with configuration providers and also by code. Using code allows greater customization as you can setup you own user functions to customize output messages or configuring if a payload should be sent to a given webhook endpoint.
 
 The [web hooks section](./doc/webhooks.md) contains more information and webhooks samples for Microsoft Teams, Azure Functions, Slack and more.
 

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -2,32 +2,11 @@
 
 ![HealthChecksUI](./images/ui-webhooks.png)
 
-## Microsoft Teams
+> HealthCheckUI replace automatically [[LIVENESS]], [[FAILURE]] and [[DESCRIPTIONS]] bookmarks.
 
-If you want to send failure notifications to Microsoft Teams the payload to be used is:
+Webhooks can be configured using configuration providers or by code.
 
-```json
-{
-  "@context": "http://schema.org/extensions",
-  "@type": "MessageCard",
-  "themeColor": "0072C6",
-  "title": "[[LIVENESS]] has failed!",
-  "text": "[[FAILURE]]. Click **Learn More** to go to BeatPulseUI!",
-  "potentialAction": [
-    {
-      "@type": "OpenUri",
-      "name": "Learn More",
-      "targets": [
-        { "os": "default", "uri": "http://localhost:52665/beatpulse-ui" }
-      ]
-    }
-  ]
-}
-```
-
-> HealthCheckUI replace automatically [[LIVENESS]] and [[FAILURE]] bookmarks.
-
-You must escape the json before setting the **Payload** property in the configuration file:
+If you are using json file configuration. you must escape the json before setting the **Payload** property in the configuration file:
 
 ```json
 {
@@ -53,7 +32,17 @@ You must escape the json before setting the **Payload** property in the configur
 
 ## Configuring Webhooks by code
 
-You can also configure webhooks by using code. This scenario allows greater customization as you can use your own user functions to configure if a payload should be notified and customize [[FAILURE]] and [[DESCRIPTIONS]] placeholders.
+You can also configure webhooks by using code. This scenario allows greater customization as you can use your own user functions to configure if a payload should be notified and customize [[FAILURE]] and [[DESCRIPTIONS]] bookmarks.
+
+**Sample with default failure message and descriptions**:
+
+```csharp
+setup.AddWebhookNotification("webhook1", uri: "https://healthchecks.requestcatcher.com/",
+            payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+            restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}");
+```
+
+**Sample with custom user functions**:
 
 ```csharp
 setup
@@ -71,6 +60,29 @@ setup
         var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
         return $"HealthChecks with names {string.Join("/", failing.Select(f => f.Key))} are failing";
     });
+```
+
+## Microsoft Teams
+
+If you want to send failure notifications to Microsoft Teams the payload to be used is:
+
+```json
+{
+  "@context": "http://schema.org/extensions",
+  "@type": "MessageCard",
+  "themeColor": "0072C6",
+  "title": "[[LIVENESS]] has failed!",
+  "text": "[[FAILURE]]. Click **Learn More** to go to BeatPulseUI!",
+  "potentialAction": [
+    {
+      "@type": "OpenUri",
+      "name": "Learn More",
+      "targets": [
+        { "os": "default", "uri": "http://localhost:52665/beatpulse-ui" }
+      ]
+    }
+  ]
+}
 ```
 
 ## Azure Functions

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -47,7 +47,7 @@ setup.AddWebhookNotification("webhook1", uri: "https://healthchecks.requestcatch
 ```csharp
 setup
 .AddWebhookNotification("webhook1",
-    uri: "status/200?code=ax3rt56s", payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]]\"}",
+    uri: "status/200?code=ax3rt56s", payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
     restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
     shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23
     customMessageFunc: (report) =>

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -51,9 +51,31 @@ You must escape the json before setting the **Payload** property in the configur
 }
 ```
 
+## Configuring Webhooks by code
+
+You can also configure webhooks by using code. This scenario allows greater customization as you can use your own user functions to configure if a payload should be notified and customize [[FAILURE]] and [[DESCRIPTIONS]] placeholders.
+
+```csharp
+setup
+.AddWebhookNotification("webhook1",
+    uri: "status/200?code=ax3rt56s", payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]]\"}",
+    restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
+    shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23
+    customMessageFunc: (report) =>
+    {
+        var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+        return $"{failing.Count()} healthchecks are failing";
+    },
+    customDescriptionFunc: report =>
+    {
+        var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+        return $"HealthChecks with names {string.Join("/", failing.Select(f => f.Key))} are failing";
+    });
+```
+
 ## Azure Functions
 
-You can use [Azure Functions](https://docs.microsoft.com/en-us/azure/azure-functions/) to receive *HealthCheckUI* notifications and perform any action. 
+You can use [Azure Functions](https://docs.microsoft.com/en-us/azure/azure-functions/) to receive _HealthCheckUI_ notifications and perform any action.
 
 Next samples show AF integration with Twilio to send SMS / SendGrid for HealthCheckUI failure notifications.
 
@@ -81,7 +103,7 @@ public static async Task Run(HttpRequestMessage req, IAsyncCollector<SMSMessage>
 
 ```
 
-```c# 
+```c#
 #r "SendGrid"
 using System;
 using SendGrid.Helpers.Mail;

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -37,18 +37,19 @@ namespace HealthChecks.UI.Branding
 
                     //Webhook endpoint with custom notification hours, and custom failure and description messages
 
-                    setup.AddWebhookNotification("webhook1", uri: "https://healthchecks2.requestcatcher.com/"
-                                                , payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
-                                                 restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}", 
-                                                 shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
-                                                 customMessageFunc : (report) =>
-                                                 {
-                                                     var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
-                                                     return $"{failing.Count()} healthchecks are failing";
-                                                 }, customDescriptionFunc: report => {
-                                                     var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
-                                                     return $"{string.Join(" - ", failing.Select(f => f.Key))} healthchecks are failing";
-                                                 });
+                    setup.AddWebhookNotification("webhook1", uri: "https://healthchecks2.requestcatcher.com/",
+                            payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+                                restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
+                                shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
+                                customMessageFunc: (report) =>
+                               {
+                                   var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+                                   return $"{failing.Count()} healthchecks are failing";
+                               }, customDescriptionFunc: report =>
+                               {
+                                   var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+                                   return $"{string.Join(" - ", failing.Select(f => f.Key))} healthchecks are failing";
+                               });
 
                     //Webhook endpoint with default failure and description messages
 

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -35,12 +35,25 @@ namespace HealthChecks.UI.Branding
                     setup.AddHealthCheckEndpoint("endpoint1", "/health-random");
                     setup.AddHealthCheckEndpoint("endpoint2", "health-process");
 
-                    setup.AddWebhookNotification("webhook1", uri: "status/200?code=ax3rt56s"
-                                                , payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]]\"}",
-                                                 restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}");
+                    //Webhook endpoint with custom notification hours, and custom failure and description messages
+
+                    setup.AddWebhookNotification("webhook1", uri: "https://healthchecks2.requestcatcher.com/"
+                                                , payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+                                                 restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}", 
+                                                 shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
+                                                 customMessageFunc : (report) =>
+                                                 {
+                                                     var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+                                                     return $"{failing.Count()} healthchecks are failing";
+                                                 }, customDescriptionFunc: report => {
+                                                     var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+                                                     return $"{string.Join(" - ", failing.Select(f => f.Key))} healthchecks are failing";
+                                                 });
+
+                    //Webhook endpoint with default failure and description messages
 
                     setup.AddWebhookNotification("webhook1", uri: "https://healthchecks.requestcatcher.com/",
-                                                 payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]]\"}",
+                                                 payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
                                                  restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}");
 
                 })

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HealthChecks.UI.Client;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 
@@ -27,14 +28,17 @@ namespace HealthChecks.UI.Configuration
             return this;
         }
 
-        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "")
+        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "", Func<UIHealthReport, bool> shouldNotifyFunc = null, Func<UIHealthReport,string> customMessageFunc = null, Func<UIHealthReport, string> customDescriptionFunc = null)
         {
             Webhooks.Add(new WebHookNotification
             {
                 Name = name,
                 Uri = uri,
                 Payload = payload,
-                RestoredPayload = restorePayload
+                RestoredPayload = restorePayload,
+                ShouldNotifyFunc = shouldNotifyFunc,
+                CustomMessageFunc = customMessageFunc,
+                CustomDescriptionFunc = customDescriptionFunc
             });
             return this;
         }
@@ -94,5 +98,8 @@ namespace HealthChecks.UI.Configuration
         public string Uri { get; set; }
         public string Payload { get; set; }
         public string RestoredPayload { get; set; }
+        internal Func<UIHealthReport, bool> ShouldNotifyFunc { get; set; } 
+        internal Func<UIHealthReport, string> CustomMessageFunc { get; set; }
+        internal Func<UIHealthReport, string> CustomDescriptionFunc { get; set; }
     }
 }

--- a/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -38,14 +38,17 @@ namespace HealthChecks.UI.Core.Notifications
         }
         public async Task NotifyDown(string name, UIHealthReport report)
         {
-            await Notify(name, failure: GetFailedMessageFromContent(report), isHealthy: false, description: GetFailedDescriptionsFromContent(report));
+            await Notify(name, report, isHealthy: false);
         }
         public async Task NotifyWakeUp(string name)
         {
-            await Notify(name, isHealthy: true);
+            await Notify(name, null, isHealthy: true);
         }
-        private async Task Notify(string name, string failure = "", bool isHealthy = false, string description = null)
+        internal async Task Notify(string name, UIHealthReport report, bool isHealthy = false)
         {
+            string failure = default;
+            string description = default;
+
             if (!await IsNotifiedOnWindowTime(name, isHealthy))
             {
                 await SaveNotification(new HealthCheckFailureNotification()
@@ -57,6 +60,19 @@ namespace HealthChecks.UI.Core.Notifications
 
                 foreach (var webHook in _settings.Webhooks)
                 {
+                    bool shouldNotify = webHook.ShouldNotifyFunc?.Invoke(report) ?? true;
+
+                    if (!shouldNotify) {
+                        _logger.LogInformation("Webhook notification will not be sent because of user configuration");
+                        continue;
+                    };
+
+                    if(!isHealthy)
+                    {
+                        failure = webHook.CustomMessageFunc?.Invoke(report) ?? GetFailedMessageFromContent(report);
+                        description = webHook.CustomDescriptionFunc?.Invoke(report) ?? GetFailedDescriptionsFromContent(report);
+                    }
+
                     var payload = isHealthy ? webHook.RestoredPayload : webHook.Payload;
                     payload = payload.Replace(Keys.LIVENESS_BOOKMARK, name)
                         .Replace(Keys.FAILURE_BOOKMARK, failure)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

Issue #415 

**What this PR does / why we need it**:  

Several users reported the need of configuring the message that is sent to Microsoft Teams, Slack or any other webhook target.

With this PR,  3 new functions are added to Webhook endpoint configuration.

**ShouldNotify**, receives the UI Report and returns a boolean to let the notifier know if the webhook should be invoked (Useful to configure working hours for example)

**CustomMessageFunc**: Configure the output of [[FAILURE]] bookmark
**CustomDescriptionFunc**: Configure the output of [[DESCRIPTION]] bookmark

Sample:

```csharp
setup
.AddWebhookNotification("webhook1",
    uri: "status/200?code=ax3rt56s", payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
    restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
    shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23
    customMessageFunc: report =>
    {
        var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
        return $"{failing.Count()} healthchecks are failing";
    }, 
    customDescriptionFunc: report =>
    {
        var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
        return $"HealthChecks with names {string.Join("/", failing.Select(f => f.Key))} are failing";
    });
```
**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Provided sample for the feature
- [x] Extended documentation
