### PR TITLE
Allow configuring Elastic Search Request Timeout #317

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -90,7 +90,7 @@
     <HealthCheckRedis>3.0.0</HealthCheckRedis>
     <HealthCheckRabbitMQ>3.0.5</HealthCheckRabbitMQ>
     <HealthCheckEventStore>3.0.0</HealthCheckEventStore>
-    <HealthCheckElasticsearch>3.0.0</HealthCheckElasticsearch>
+    <HealthCheckElasticsearch>3.0.1</HealthCheckElasticsearch>
     <HealthCheckSolr>3.0.0</HealthCheckSolr>
     <HealthCheckOracle>3.0.0</HealthCheckOracle>
     <HealthCheckNpgSql>3.0.0</HealthCheckNpgSql>

--- a/src/HealthChecks.Elasticsearch/DependencyInjection/ElasticsearchHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Elasticsearch/DependencyInjection/ElasticsearchHealthCheckBuilderExtensions.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Extensions.DependencyInjection
             var options = new ElasticsearchOptions();
             setup?.Invoke(options);
 
+            options.RequestTimeout ??= timeout;
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
                 sp => new ElasticsearchHealthCheck(options),

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -26,6 +26,11 @@ namespace HealthChecks.Elasticsearch
                 {
                     var settings = new ConnectionSettings(new Uri(_options.Uri));
 
+                    if (_options.RequestTimeout.HasValue)
+                    {
+                        settings.RequestTimeout(_options.RequestTimeout.Value);
+                    }
+
                     if (_options.AuthenticateWithBasicCredentials)
                     {
                         settings = settings.BasicAuthentication(_options.UserName, _options.Password);

--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -28,7 +28,7 @@ namespace HealthChecks.Elasticsearch
 
                     if (_options.RequestTimeout.HasValue)
                     {
-                        settings.RequestTimeout(_options.RequestTimeout.Value);
+                        settings = settings.RequestTimeout(_options.RequestTimeout.Value);
                     }
 
                     if (_options.AuthenticateWithBasicCredentials)

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -13,6 +13,7 @@ namespace HealthChecks.Elasticsearch
         public bool AuthenticateWithBasicCredentials { get; private set; } = false;
         public bool AuthenticateWithCertificate { get; private set; } = false;
         public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; private set; }
+        public TimeSpan? RequestTimeout { get; set; }
         public ElasticsearchOptions UseBasicAuthentication(string name, string password)
         {
             UserName = name ?? throw new ArgumentNullException(nameof(name));

--- a/test/UnitTests/ElasticSearchUnitTests.cs
+++ b/test/UnitTests/ElasticSearchUnitTests.cs
@@ -51,7 +51,6 @@ namespace UnitTests
             });
 
             settings.RequestTimeout.Should().NotHaveValue();
-
         }
     }
 }

--- a/test/UnitTests/ElasticSearchUnitTests.cs
+++ b/test/UnitTests/ElasticSearchUnitTests.cs
@@ -1,0 +1,57 @@
+﻿using FluentAssertions;
+using HealthChecks.Elasticsearch;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace UnitTests
+{
+    public class elastic_search_healthcheck_should
+    {
+        [Fact]
+        public void create_client_with_user_configured_request_timeout()
+        {
+            var services = new ServiceCollection();
+            var settings = new ElasticsearchOptions();
+            services.AddHealthChecks().AddElasticsearch(setup =>
+            {
+                setup = settings;
+                setup.RequestTimeout = new TimeSpan(0, 0, 6);
+            });
+
+            //Ensure no further modifications were carried by extension method
+            settings.RequestTimeout.Should().HaveValue();
+            settings.RequestTimeout.Should().Be(new TimeSpan(0, 0, 6));
+        }
+
+        [Fact]
+        public void create_client_with_configured_healthcheck_timeout_when_no_request_timeout_is_configured()
+        {
+            var services = new ServiceCollection();
+            var settings = new ElasticsearchOptions();
+            services.AddHealthChecks().AddElasticsearch(setup =>
+            {
+                settings = setup;
+            }, timeout: new TimeSpan(0,0,7));
+
+            settings.RequestTimeout.Should().HaveValue();
+            settings.RequestTimeout.Should().Be(new TimeSpan(0, 0, 7));
+        }
+
+        [Fact]
+        public void create_client_with_no_timeout_when_no_option_is_configured()
+        {
+            var services = new ServiceCollection();
+            var settings = new ElasticsearchOptions();
+            services.AddHealthChecks().AddElasticsearch(setup =>
+            {
+                settings = setup;
+            });
+
+            settings.RequestTimeout.Should().NotHaveValue();
+
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>    
     <ProjectReference Include="..\..\src\HealthChecks.Azure.IoTHub\HealthChecks.Azure.IoTHub.csproj" />    
+    <ProjectReference Include="..\..\src\HealthChecks.Elasticsearch\HealthChecks.Elasticsearch.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.Gcp.CloudFirestore\HealthChecks.Gcp.CloudFirestore.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.AzureKeyVault\HealthChecks.AzureKeyVault.csproj" />    
     <ProjectReference Include="..\..\src\HealthChecks.AzureServiceBus\HealthChecks.AzureServiceBus.csproj" />    


### PR DESCRIPTION

**What this PR does / why we need it**:

Allow configuring ElasticSearch client timeout. 

We can use setup.RequestTimeout to configure the request timeout timespan:
```csharp
            services.AddHealthChecks().AddElasticsearch(setup =>
            {
                setup.RequestTimeout = new TimeSpan(0, 0, 6);
            });
```

If no setup.RequestTimeout is configured but the user configured the global healthcheck timeout, we pass this value to the RequestTimeout so the connection times out when the healthcheck does.

```csharp
            services.AddHealthChecks().AddElasticsearch(setup =>
            {
                
            }, timeout: new TimeSpan(0,0,7));
```

If no option is configured, the HealthCheck will stay with it's current behaviour. No client request timeout would be configured.

**Which issue(s) this PR fixes**: #317

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
