### PR TITLE
Preventing shutdown hangs while still reusing connections when possible

### DIFF
--- a/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.RabbitMQ/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -4,7 +4,6 @@ using RabbitMQ.Client;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Security.Principal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HealthChecks.RabbitMQ/InternalRabbitMQHealthCheck.cs
+++ b/src/HealthChecks.RabbitMQ/InternalRabbitMQHealthCheck.cs
@@ -1,0 +1,22 @@
+﻿using RabbitMQ.Client;
+
+namespace HealthChecks.RabbitMQ
+{
+    internal class InternalRabbitMQHealthCheck : RabbitMQHealthCheck
+    {
+        public InternalRabbitMQHealthCheck(string rabbitMqConnectionString, SslOption sslOption = null) : base(rabbitMqConnectionString, sslOption)
+        {
+            AttemptConnectionReuse = true;
+        }
+
+        public InternalRabbitMQHealthCheck(IConnection connection) : base(connection)
+        {
+            AttemptConnectionReuse = false;
+        }
+
+        public InternalRabbitMQHealthCheck(IConnectionFactory connectionFactory) : base(connectionFactory)
+        {
+            AttemptConnectionReuse = connectionFactory.UseBackgroundThreadsForIO;
+        }
+    }
+}

--- a/src/HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
@@ -83,7 +83,6 @@ namespace HealthChecks.RabbitMQ
                 // benefit from reusing the internally stored connection).
                 else
                 {
-                    
                     if (_rmqConnection == null || !_rmqConnection.IsOpen)
                     {
                         _rmqConnection?.Abort(0);

--- a/test/UnitTests/DependencyInjection/RabbitMQ/RabbitMQUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/RabbitMQ/RabbitMQUnitTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.RabbitMQ
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be(_defaultCheckName);
-            check.GetType().Should().Be(typeof(RabbitMQHealthCheck));
+            check.GetType().Should().BeAssignableTo<RabbitMQHealthCheck>();
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.RabbitMQ
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be(customCheckName);
-            check.GetType().Should().Be(typeof(RabbitMQHealthCheck));
+            check.GetType().Should().BeAssignableTo<RabbitMQHealthCheck>();
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Enables connection reuse when possible while avoiding reintroducing the shutdown hang reported in #412

**Which issue(s) this PR fixes**:
[RabbitMQ] TCP Socket churn when executing health check
 
Please reference the issue this PR will close: #445

**Special notes for your reviewer**:
Adding an InternalRabbitMQHealthCheck that is only used in cases where we know that the health check instance will be reused instead of creating a new RabbitMQHealthCheck for each health evaluation occurance.

Updating all extension methods to ensure that a single InternalRabbitMQHealthCheck instance is used for each registration instead of having a new instance created for each health evaluation.

**Does this PR introduce a user-facing change?**:
No. Attempts were made to avoid any user-facing changes in this PR.
Ideally there would be ways to prevent or mitigate doing the "wrong thing" but that would result in breaking changes from already released APIs. We won't every cause process termination to hang because of references to an IConnection using Foreground IO threads. BUT we do still have some circumstances where users can either request Foreground IO threads to be used which stops us from reusing connections (This will result in connection churn against the RabbitMQ broker and eventually ephemeral port exhaustion given sufficiently frequent health checks) as well as the ability for users to manually (outside of the extension methods) register the public RabbitMQHealthCheck in such a way that a new RabbitMQHealthCheck instance will be created for each health check evaluation which will negate any attempt to reuse a connection inside the RabbitMQHealthCheck (since it's only used once and then thrown away).

Specifically, removing (or making internal) the public RabbitMQHealthCheck would prevent usages such as the `new HealthCheckRegistration` pattern shown in #412.

Additionally, logging a warning (or even strictly preventing) when an IConnectionFactory that is configured to use Foreground IO threads would prevent that use case from being disqualified from connection reuse.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
