### PR TITLE
let a 200 be a healthy endpoint

### DIFF
--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -88,7 +88,22 @@ namespace HealthChecks.UI.Core.HostedService
 
                 var response = await _httpClient.GetAsync(absoluteUri);
 
-                return await response.As<UIHealthReport>();
+                var healthReport = await response.As<UIHealthReport>();
+
+                if(healthReport.Entries == null && healthReport.TotalDuration.Equals(TimeSpan.Zero))
+                {
+                    var rebuiltHealthReport = new UIHealthReport(new Dictionary<string, UIHealthReportEntry>(), TimeSpan.Zero);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        rebuiltHealthReport.Status = UIHealthStatus.Healthy;
+                    }
+                    return rebuiltHealthReport;
+                }
+                else
+                {
+                    return healthReport;
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
**What this PR does / why we need it**:
when a non-conformant json payload is returned, it doesn't deserialize in a `UIHealthReport`.   Instead a default UIHealthReport is return (with the default of Status = Unhealthy)

**Which issue(s) this PR fixes**:
Please reference the issue this PR will close: #438

**Special notes for your reviewer**:
I dont have docker running locally - so my test runs looks like this
```
Test Run Failed.
Total tests: 118
     Passed: 75
     Failed: 43
 Total time: 13.6614 Minutes
```


**Does this PR introduce a user-facing change?**:
no

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
