### PR TITLE
Support Kubernetes in-cluster DNS

### DIFF
--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -65,19 +65,19 @@ By default, it'll use the in-cluster pod config if running inside of a pod and t
 
 Here are all the available parameters detailed:
 
-| Parameter                | Description                                                                                                                                       | Default Value      |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| Enabled                  | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false              |
-| ClusterHost              | The uri of the kubernetes cluster                                                                                                                 |                    |
-| Token                    | The token that will be sent to the cluster for authentication                                                                                     |                    |
-| HealthPath               | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
-| ServicesLabel            | The labeled services the UI will look for in k8s                                                                                                  | HealthChecks       |
-| ServicesPathAnnotation   | The annotation on a service that can override the configured url path                                                                             | HealthChecksPath   |
-| ServicesPortAnnotation   | The annotation on a service to define which port to call. If the annotation does not exist on the service the first defined port will be used     | HealthChecksPort   |
-| ServicesSchemeAnnotation | The annotation on a service to define which URI scheme to use for healthchecks. If the annotation does not exist on the service http will be used | HealthChecksScheme |
-| RefreshTimeOnSeconds     | Healthchecks refresh time in seconds                                                                                                              | 300                |
-| Namespaces               | The namespace(s) to query services in                                                                                                             | []                 |
-| UseDNSNames              | Use Kubernetes DNS names to call services (`http(s)://service.namespace/hc`). Recommended to only set true when running in-cluster             | false              |
+| Parameter                | Description                                                                                                                                                    | Default Value      |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| Enabled                  | Establishes if the k8s discovery service is enabled of disabled                                                                                                | false              |
+| ClusterHost              | The uri of the kubernetes cluster                                                                                                                              |                    |
+| Token                    | The token that will be sent to the cluster for authentication                                                                                                  |                    |
+| HealthPath               | The default url path where the UI will call once the service is discovered                                                                                     | hc                 |
+| ServicesLabel            | The labeled services the UI will look for in k8s                                                                                                               | HealthChecks       |
+| ServicesPathAnnotation   | The annotation on a service that can override the configured url path                                                                                          | HealthChecksPath   |
+| ServicesPortAnnotation   | The annotation on a service to define which port to call. If the annotation does not exist on the service the first defined port will be used                  | HealthChecksPort   |
+| ServicesSchemeAnnotation | The annotation on a service to define which URI scheme to use for healthchecks. If the annotation does not exist on the service http will be used              | HealthChecksScheme |
+| RefreshTimeOnSeconds     | Healthchecks refresh time in seconds                                                                                                                           | 300                |
+| Namespaces               | The namespace(s) to query services in                                                                                                                          | []                 |
+| UseDNSNames              | Use Kubernetes DNS names instead of cluster IPs to call services (ex: `http(s)://service.namespace/hc`) . Recommended to only set true when running in-cluster | false              |
 
 ## Labeling Services for discovery in Kubernetes
 

--- a/doc/k8s-ui-discovery.md
+++ b/doc/k8s-ui-discovery.md
@@ -68,7 +68,6 @@ Here are all the available parameters detailed:
 | Parameter                | Description                                                                                                                                       | Default Value      |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | Enabled                  | Establishes if the k8s discovery service is enabled of disabled                                                                                   | false              |
-| InCluster                | The service discovery will try to load the cluster config as an in-cluster pod. ClusterHost and Token does not need to be defined if this is true | false              |
 | ClusterHost              | The uri of the kubernetes cluster                                                                                                                 |                    |
 | Token                    | The token that will be sent to the cluster for authentication                                                                                     |                    |
 | HealthPath               | The default url path where the UI will call once the service is discovered                                                                        | hc                 |
@@ -78,6 +77,7 @@ Here are all the available parameters detailed:
 | ServicesSchemeAnnotation | The annotation on a service to define which URI scheme to use for healthchecks. If the annotation does not exist on the service http will be used | HealthChecksScheme |
 | RefreshTimeOnSeconds     | Healthchecks refresh time in seconds                                                                                                              | 300                |
 | Namespaces               | The namespace(s) to query services in                                                                                                             | []                 |
+| UseDNSNames              | Use Kubernetes DNS names to call services (`http(s)://service.namespace/hc`). Recommended to only set true when running in-cluster             | false              |
 
 ## Labeling Services for discovery in Kubernetes
 

--- a/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/IKubernetesExtensions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/Extensions/IKubernetesExtensions.cs
@@ -8,22 +8,20 @@ using System.Threading.Tasks;
 #nullable enable
 namespace HealthChecks.UI.Core.Discovery.K8S.Extensions
 {
-    internal static class KubernetesHttpClientExtensions
+    internal static class IKubernetesExtensions
     {
-        internal static async Task<V1ServiceList> GetServices(this IKubernetes client, string label, List<string> k8sNamespaces, CancellationToken cancellationToken)
+        internal static async Task<IEnumerable<V1Service>> GetServices(this IKubernetes client, string label, IEnumerable<string>? k8sNamespaces, CancellationToken cancellationToken)
         {
             if(k8sNamespaces is null || !k8sNamespaces.Any())
             {
-                return await client.ListServiceForAllNamespacesAsync(labelSelector: label, cancellationToken: cancellationToken);
+                var services = await client.ListServiceForAllNamespacesAsync(labelSelector: label, cancellationToken: cancellationToken);
+                return services?.Items ?? Enumerable.Empty<V1Service>();
             }
             else
             {
                 var responses = await Task.WhenAll(k8sNamespaces.Select(k8sNamespace => client.ListNamespacedServiceAsync(k8sNamespace, labelSelector: label, cancellationToken: cancellationToken)));
                 
-                return new V1ServiceList()
-                {
-                    Items = responses.SelectMany(r => r.Items).ToList()
-                };
+                return responses.Select(s => s?.Items).Where(s => s != null).SelectMany(s => s).ToList();
             }
         }
     }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesAddressFactory.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesAddressFactory.cs
@@ -13,23 +13,16 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         }
         public string CreateAddress(V1Service service)
         {
-            string address = string.Empty;
-
             var port = GetServicePortValue(service);
 
-            switch (service.Spec.Type)
-            {
-                case ServiceType.LoadBalancer:
-                case ServiceType.NodePort:
-                    address = GetLoadBalancerAddress(service);
-                    break;
-                case ServiceType.ClusterIP:
-                    address = service.Spec.ClusterIP;
-                    break;
-                case ServiceType.ExternalName:
-                    address = service.Spec.ExternalName;
-                    break;
-            }
+            var address = (_settings.UseDNSNames, service.Spec.Type) switch {
+                (true, _) => service.Metadata.Name + "." + service.Metadata.NamespaceProperty,
+                (_, ServiceType.LoadBalancer) => GetLoadBalancerAddress(service),
+                (_, ServiceType.NodePort) => GetLoadBalancerAddress(service),
+                (_, ServiceType.ClusterIP) => service.Spec.ClusterIP,
+                (_, ServiceType.ExternalName) => service.Spec.ExternalName,
+                (_, _) => service.Spec.ClusterIP,
+            };
 
             string healthPath = _settings.HealthPath;
             if(!string.IsNullOrEmpty(_settings.ServicesPathAnnotation) && (service.Metadata.Annotations?.ContainsKey(_settings.ServicesPathAnnotation) ?? false))
@@ -44,14 +37,21 @@ namespace HealthChecks.UI.Core.Discovery.K8S
                 healthScheme = service.Metadata.Annotations![_settings.ServicesSchemeAnnotation]!.ToLower();
             }
 
+            var portStr = (port, healthScheme) switch {
+                var _ when port is null => string.Empty,
+                (80, "http") => string.Empty,
+                (443, "https") => string.Empty,
+                (_, _) => ":" + port.Value
+            };
+
             // Support IPv6 address hosts
             if(address.Contains(":"))
             {
-                return $"{healthScheme}://[{address}]{port}/{healthPath}";
+                return $"{healthScheme}://[{address}]{portStr}/{healthPath}";
             }
             else
             {
-                return $"{healthScheme}://{address}{port}/{healthPath}";
+                return $"{healthScheme}://{address}{portStr}/{healthPath}";
             }
         }
         private string GetLoadBalancerAddress(V1Service service)
@@ -64,7 +64,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
 
             return service.Spec.ClusterIP;
         }
-        private string GetServicePortValue(V1Service service)
+        private int? GetServicePortValue(V1Service service)
         {
             int? port;
             switch (service.Spec.Type)
@@ -91,7 +91,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
                     break;
             }
 
-            return port is null ? string.Empty : $":{port.Value}";
+            return port;
         }
         private V1ServicePort? GetServicePort(V1Service service)
         {

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -68,28 +68,25 @@ namespace HealthChecks.UI.Core.Discovery.K8S
                 {
                     var services = await _discoveryClient.GetServices(_discoveryOptions.ServicesLabel, _discoveryOptions.Namespaces, cancellationToken);
 
-                    if (services != null)
+                    foreach (var item in services)
                     {
-                        foreach (var item in services.Items)
+                        try
                         {
-                            try
-                            {
-                                var serviceAddress = _addressFactory.CreateAddress(item);
+                            var serviceAddress = _addressFactory.CreateAddress(item);
 
-                                if (serviceAddress != null && !IsLivenessRegistered(livenessDbContext, serviceAddress))
+                            if (serviceAddress != null && !IsLivenessRegistered(livenessDbContext, serviceAddress))
+                            {
+                                var statusCode = await CallClusterService(serviceAddress);
+                                if (IsValidHealthChecksStatusCode(statusCode))
                                 {
-                                    var statusCode = await CallClusterService(serviceAddress);
-                                    if (IsValidHealthChecksStatusCode(statusCode))
-                                    {
-                                        await RegisterDiscoveredLiveness(livenessDbContext, serviceAddress, item.Metadata.Name);
-                                        _logger.LogInformation($"Registered discovered liveness on {serviceAddress} with name {item.Metadata.Name}");
-                                    }
+                                    await RegisterDiscoveredLiveness(livenessDbContext, serviceAddress, item.Metadata.Name);
+                                    _logger.LogInformation("Registered discovered liveness service {ServiceName} in namespace {ServiceNamespace} with address {ServiceAddress}", item.Metadata.Name, item.Metadata.NamespaceProperty, serviceAddress);
                                 }
                             }
-                            catch (Exception)
-                            {
-                                _logger.LogError($"Error discovering service {item.Metadata.Name}. It might not be visible");
-                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error discovering service {ServiceName} in namespace {ServiceNamespace}. It might not be visible", item.Metadata.Name, item.Metadata.NamespaceProperty);
                         }
                     }
                 }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
@@ -15,6 +15,6 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
         public List<string> Namespaces { get; set; } = new List<string>();
-        public bool UseDNSNames { get; set;}
+        public bool UseDNSNames { get; set; }
     }
 }

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryOptions.cs
@@ -15,5 +15,6 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         public string Token { get; set; }
         public int RefreshTimeOnSeconds { get; set; } = 300;
         public List<string> Namespaces { get; set; } = new List<string>();
+        public bool UseDNSNames { get; set;}
     }
 }

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace UnitTests.UI.Kubernetes
@@ -13,13 +14,12 @@ namespace UnitTests.UI.Kubernetes
     public class kubernetes_address_factory_should
     {
         [Fact]
-        public void parse_properly_the_k8s_api_discovered_services_for_a_local_cluster()
+        public async Task parse_properly_the_k8s_api_discovered_services_for_a_local_cluster()
         {
             var healthPath = "healthz";
-            var apiResponse = File.ReadAllText("UI/Kubernetes/SampleData/local-cluster-discovery-sample.json");
+            var apiResponse = await File.ReadAllTextAsync("UI/Kubernetes/SampleData/local-cluster-discovery-sample.json");
 
             var services = JsonConvert.DeserializeObject<V1ServiceList>(apiResponse);
-
 
             var addressFactory = new KubernetesAddressFactory(new KubernetesDiscoverySettings
             {
@@ -34,17 +34,16 @@ namespace UnitTests.UI.Kubernetes
             serviceAddresses[0].Should().Be("http://localhost:10000/healthz");
             serviceAddresses[1].Should().Be("http://localhost:9000/healthz");
             serviceAddresses[2].Should().Be("http://localhost:30000/healthz");
-            serviceAddresses[3].Should().Be("http://10.97.1.153:80/healthz");
+            serviceAddresses[3].Should().Be("http://10.97.1.153/healthz");
             serviceAddresses[4].Should().Be("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:7070/custom/health/path");
-            serviceAddresses[5].Should().Be("https://some.external-site.com:443/custom/health/path");
-
+            serviceAddresses[5].Should().Be("https://some.external-site.com/custom/health/path");
         }
 
         [Fact]
-        public void parse_properly_the_k8s_api_discovered_services_for_a_remote_cluster()
+        public async Task parse_properly_the_k8s_api_discovered_services_for_a_remote_cluster()
         {
             var healthPath = "healthz";
-            var apiResponse = File.ReadAllText("UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json");
+            var apiResponse = await File.ReadAllTextAsync("UI/Kubernetes/SampleData/remote-cluster-discovery-sample.json");
 
             var services = JsonConvert.DeserializeObject<V1ServiceList>(apiResponse);
 
@@ -58,12 +57,38 @@ namespace UnitTests.UI.Kubernetes
 
             IReadOnlyList<string> serviceAddresses = services.Items.Select(service => addressFactory.CreateAddress(service)).ToList();
 
-            serviceAddresses[0].Should().Be("http://13.73.139.23:80/healthz");
+            serviceAddresses[0].Should().Be("http://13.73.139.23/healthz");
             serviceAddresses[1].Should().Be("http://13.80.181.10:51000/healthz");
             serviceAddresses[2].Should().Be("http://12.0.0.190:5672/healthz");
             serviceAddresses[3].Should().Be("http://12.0.0.168:30478/healthz");
             serviceAddresses[4].Should().Be("https://10.152.183.35:8080/custom/health/path");
+        }
 
+        [Fact]
+        public async Task parse_properly_the_k8s_api_discovered_services_for_dns_names()
+        {
+            var healthPath = "healthz";
+            var apiResponse = await File.ReadAllTextAsync("UI/Kubernetes/SampleData/local-cluster-discovery-sample.json");
+
+            var services = JsonConvert.DeserializeObject<V1ServiceList>(apiResponse);
+
+            var addressFactory = new KubernetesAddressFactory(new KubernetesDiscoverySettings
+            {
+                HealthPath = healthPath,
+                ServicesPathAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PATH_ANNOTATION,
+                ServicesPortAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_PORT_ANNOTATION,
+                ServicesSchemeAnnotation = Keys.HEALTHCHECKS_DEFAULT_DISCOVERY_SCHEME_ANNOTATION,
+                UseDNSNames = true
+            });
+
+            IReadOnlyList<string> serviceAddresses = services.Items.Select(service => addressFactory.CreateAddress(service)).ToList();
+
+            serviceAddresses[0].Should().Be("http://webapp.default:10000/healthz");
+            serviceAddresses[1].Should().Be("http://webapp2.default:9000/healthz");
+            serviceAddresses[2].Should().Be("http://webapp3.default:30000/healthz");
+            serviceAddresses[3].Should().Be("http://webapp4.default/healthz");
+            serviceAddresses[4].Should().Be("http://seq.default:7070/custom/health/path");
+            serviceAddresses[5].Should().Be("https://external-site.default/custom/health/path");
         }
 
     }

--- a/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
+++ b/test/UnitTests/UI/Kubernetes/Discovery/KubernetesAddressFactoryTests.cs
@@ -83,12 +83,12 @@ namespace UnitTests.UI.Kubernetes
 
             IReadOnlyList<string> serviceAddresses = services.Items.Select(service => addressFactory.CreateAddress(service)).ToList();
 
-            serviceAddresses[0].Should().Be("http://webapp.default:10000/healthz");
-            serviceAddresses[1].Should().Be("http://webapp2.default:9000/healthz");
-            serviceAddresses[2].Should().Be("http://webapp3.default:30000/healthz");
+            serviceAddresses[0].Should().Be("http://localhost:10000/healthz");
+            serviceAddresses[1].Should().Be("http://localhost:9000/healthz");
+            serviceAddresses[2].Should().Be("http://localhost:30000/healthz");
             serviceAddresses[3].Should().Be("http://webapp4.default/healthz");
             serviceAddresses[4].Should().Be("http://seq.default:7070/custom/health/path");
-            serviceAddresses[5].Should().Be("https://external-site.default/custom/health/path");
+            serviceAddresses[5].Should().Be("https://some.external-site.com/custom/health/path");
         }
 
     }

--- a/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
+++ b/test/UnitTests/UI/Kubernetes/SampleData/local-cluster-discovery-sample.json
@@ -175,7 +175,7 @@
         "creationTimestamp": "2019-07-12T02:42:38Z",
         "labels": {
           "HealthChecks": "true",
-          "app": "seq"
+          "app": "external-site"
         },
         "annotations": {
           "HealthChecksPath": "custom/health/path",


### PR DESCRIPTION
When using HTTPS via a tool like cert-manager, DNS names are defined in the certificate. Calling the service using their cluster IPs causes certificate validation errors.

Additionally

* Don't add ports unnecessarily (when HTTP port is 80 or HTTPS port is 443)
* Add null checks on services when namespace(s) are defined and at least one namespace has no services.
* Improve logging on KubernetesDiscoveryHostedService, by using structured logging and adding the service's namespace.