### PR TITLE
Update ConsulHealthCheckBuilderExtensions.cs to allow runtime changes

### DIFF
--- a/src/HealthChecks.Consul/DependencyInjection/ConsulHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Consul/DependencyInjection/ConsulHealthCheckBuilderExtensions.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
         public static IHealthChecksBuilder AddConsul(this IHealthChecksBuilder builder, Action<ConsulOptions> setup, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default,TimeSpan? timeout = default)
         {
-            var options = new ConsulOptions();
-            setup?.Invoke(options);
-
             builder.Services.AddHttpClient();
 
             var registrationName = name ?? NAME;
@@ -38,8 +35,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
-        private static ConsulHealthCheck CreateHealthCheck(IServiceProvider sp, ConsulOptions options, string name)
+        private static ConsulHealthCheck CreateHealthCheck(IServiceProvider sp, Action<ConsulOptions> setup, string name)
         {
+            var options = new ConsulOptions();
+            setup?.Invoke(options);
+
             var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
             return new ConsulHealthCheck(options, () => httpClientFactory.CreateClient(name));
         }

--- a/src/HealthChecks.Consul/DependencyInjection/ConsulHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Consul/DependencyInjection/ConsulHealthCheckBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrationName = name ?? NAME;
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
-                sp => CreateHealthCheck(sp, options, registrationName),
+                sp => CreateHealthCheck(sp, setup, registrationName),
                 failureStatus,
                 tags,
                 timeout));


### PR DESCRIPTION
**What this PR does / why we need it**:
Small change that will allow consul settings to be changed during runtime. Pretty similar to what happens in NpgSqlHealthCheckBuilderExtensions.AddNpgSql().

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
