### PR TITLE
Publisher ApplicationInsights to use active TmetryConfiguration

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -115,11 +115,11 @@ namespace HealthChecks.Publisher.ApplicationInsights
                 {
                     if (_client == null)
                     {
-                        //override instrumentation key or use default instrumentation 
-                        //key active on the project.
+                        //override instrumentation key or use default telemetry
+                        //configuration active on the project.
 
                         var configuration = string.IsNullOrWhiteSpace(_instrumentationKey)
-                            ? new TelemetryConfiguration(_telemetryConfiguration?.InstrumentationKey)
+                            ? _telemetryConfiguration
                             : new TelemetryConfiguration(_instrumentationKey);
 
                         _client = new TelemetryClient(configuration);


### PR DESCRIPTION
**What this PR does / why we need it**:
As discused in #426 this PR changes HealthChecks.Publisher.ApplicationInsights to use the active TelemetryConfiguration instead of just the active instrumentation key. This change means that ITelemetryInitializers (and other changes to the active configuration) that are add are used for AI events as well.

**Which issue(s) this PR fixes**:
#426 

**Does this PR introduce a user-facing change?**:
Yes, if for some reason a user don't want the extra configurations they have done for AI then they would now need to manually supply the instrumentation key.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [x] Provided sample for the feature
