### PR TITLE
Add support for non-URI EventStore connection strings.

### DIFF
--- a/src/HealthChecks.EventStore/EventStoreHealthCheck.cs
+++ b/src/HealthChecks.EventStore/EventStoreHealthCheck.cs
@@ -1,4 +1,4 @@
-using EventStore.ClientAPI;
+﻿using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
@@ -27,30 +27,25 @@ namespace HealthChecks.EventStore
         {
             try
             {
-
-                var eventStoreUri = new Uri(_eventStoreConnection);
-
-                ConnectionSettings connectionSettings;
+                ConnectionSettingsBuilder connectionSettings;
 
                 if (string.IsNullOrEmpty(_login) || string.IsNullOrEmpty(_password))
                 {
                     connectionSettings = ConnectionSettings.Create()
                         .LimitReconnectionsTo(RECONNECTION_LIMIT)
-                        .SetReconnectionDelayTo(TimeSpan.FromMilliseconds(ELAPSED_DELAY_MILLISECONDS))
-                        .Build();
+                        .SetReconnectionDelayTo(TimeSpan.FromMilliseconds(ELAPSED_DELAY_MILLISECONDS));
                 }
                 else
                 {
                     connectionSettings = ConnectionSettings.Create()
                         .LimitReconnectionsTo(RECONNECTION_LIMIT)
                         .SetReconnectionDelayTo(TimeSpan.FromMilliseconds(ELAPSED_DELAY_MILLISECONDS))
-                        .SetDefaultUserCredentials(new UserCredentials(_login, _password))
-                        .Build();
+                        .SetDefaultUserCredentials(new UserCredentials(_login, _password));
                 }
 
                 using (var connection = EventStoreConnection.Create(
+                    _eventStoreConnection,
                     connectionSettings,
-                    eventStoreUri,
                     CONNECTION_NAME))
                 {
                     var tcs = new TaskCompletionSource<HealthCheckResult>();

--- a/test/FunctionalTests/HealthChecks.EventStore/EventStoreHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.EventStore/EventStoreHealthCheckTests.cs
@@ -23,10 +23,10 @@ namespace FunctionalTests.HealthChecks.EventStore
         }
 
         [SkipOnAppVeyor]
-        public async Task be_healthy_if_eventstore_is_available()
+        [InlineData("tcp://localhost:1113")]
+        [InlineData("ConnectTo=tcp://admin:changeit@localhost:1113; HeartBeatTimeout=500")]
+        public async Task be_healthy_if_eventstore_is_available(string connectionString)
         {
-            var connectionString = "tcp://localhost:1113";
-
             var webHostBuilder = new WebHostBuilder()
             .UseStartup<DefaultStartup>()
             .ConfigureServices(services =>


### PR DESCRIPTION
**What this PR does / why we need it**:

When attempting to health check a working EventStore connection, I was always getting an `Unhealthy` response.

After debugging, I discovered that there is an assumption in the code that the connection string must be a URI. This is not always the case, and the connection string I was using was similar to the following one taken from the EventStore documentation:

```csharp
var connectionString = "ConnectTo=tcp://admin:changeit@localhost:1113; HeartBeatTimeout=500";
```

I have added support for connection strings in the format shown above.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
