### PR TITLE
[K8s Operator] Add service and deployment annotations to custom resource definition

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -130,6 +130,6 @@
     <HealthCheckCloudFirestore>3.1.1</HealthCheckCloudFirestore>
     <HealthCheckIoTHub>3.1.1</HealthCheckIoTHub>
     <HealthCheckIbmMQ>3.1.1</HealthCheckIbmMQ>
-    <HealthChecksUIK8sOperator>3.1.0-beta.4</HealthChecksUIK8sOperator>
+    <HealthChecksUIK8sOperator>3.1.0-beta.5</HealthChecksUIK8sOperator>
   </PropertyGroup>
 </Project>

--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -43,6 +43,24 @@ spec:
               type: string
             imagePullPolicy:
               type: string
+            serviceAnnotations:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+            deployAnnotations:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
           required:
             - name
             - servicesLabel

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -1,4 +1,7 @@
-﻿namespace HealthChecks.UI.K8s.Operator
+﻿using HealthChecks.UI.K8s.Operator.Crd;
+using System.Collections.Generic;
+
+namespace HealthChecks.UI.K8s.Operator
 {
     public class HealthCheckResourceSpec
     {
@@ -11,5 +14,7 @@
         public string HealthChecksScheme { get; set; }
         public string Image { get; set; }
         public string ImagePullPolicy { get; set; }
+        public List<NameValueObject> ServiceAnnotations { get; set; } = new List<NameValueObject>();
+        public List<NameValueObject> DeploymentAnnotations { get; set; } = new List<NameValueObject>();
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Crd/NameValueObject.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/NameValueObject.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HealthChecks.UI.K8s.Operator.Crd
+{
+    public class NameValueObject
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/ServiceHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/ServiceHandler.cs
@@ -64,6 +64,7 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
                 OwnerReferences = new List<V1OwnerReference> {
                     resource.CreateOwnerReference()
                 },
+                Annotations = new Dictionary<string, string>(),
                 Labels = new Dictionary<string, string>
                 {
                     ["app"] = resource.Spec.Name
@@ -85,6 +86,12 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
                     }
                 }
             };
+
+            foreach (var annotation in resource.Spec.ServiceAnnotations)
+            {
+                _logger.LogInformation("Adding annotation {Annotation} to ui service with value {AnnotationValue}", annotation.Name, annotation.Value);
+                meta.Annotations.Add(annotation.Name, annotation.Value);
+            }
 
             return new V1Service(metadata: meta, spec: spec);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow the users to deploy healthchecks CRD with custom annotations for target service and deployment.

One clear use case is being able to configure an internal load balancer in Azure Kubernetes Service.

```yaml
apiVersion: "aspnetcore.ui/v1"
kind: HealthCheck
metadata:
  name: healthchecks-ui
  namespace: lande
spec:
  name: ui-1
  servicesLabel: HealthChecks
  serviceType: LoadBalancer
  serviceAnnotations:
    - name: service.beta.kubernetes.io/azure-load-balancer-internal
      value: "true"
  deploymentAnnotations:
    - name: ServiceType
      value: AksInternalBalancer
```

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #489


**Does this PR introduce a user-facing change?**: No
