### PR TITLE
[K8s Operator] UI Deployment branding with extended CRD 

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -130,6 +130,6 @@
     <HealthCheckCloudFirestore>3.1.1</HealthCheckCloudFirestore>
     <HealthCheckIoTHub>3.1.1</HealthCheckIoTHub>
     <HealthCheckIbmMQ>3.1.1</HealthCheckIbmMQ>
-    <HealthChecksUIK8sOperator>3.1.0-beta.5</HealthChecksUIK8sOperator>
+    <HealthChecksUIK8sOperator>3.1.0-beta.6</HealthChecksUIK8sOperator>
   </PropertyGroup>
 </Project>

--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -43,6 +43,11 @@ spec:
               type: string
             imagePullPolicy:
               type: string
+            stylesheetPath:
+              type: string
+              pattern: ^[^\/][^.]+$
+            stylesheetContent:
+              type: string
             serviceAnnotations:
               type: array
               items:

--- a/src/HealthChecks.UI.K8s.Operator/Controller/HealthChecksController.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Controller/HealthChecksController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using HealthChecks.UI.K8s.Operator.Extensions;
 using HealthChecks.UI.K8s.Operator.Handlers;
 using k8s;
 using Microsoft.Extensions.Logging;
@@ -12,6 +13,7 @@ namespace HealthChecks.UI.K8s.Operator.Controller
         private readonly DeploymentHandler _deploymentHandler;
         private readonly ServiceHandler _serviceHandler;
         private readonly SecretHandler _secretHandler;
+        private readonly ConfigMaphandler _configMapHandler;
         private readonly ILogger<K8sOperator> _logger;
 
         public HealthChecksController(
@@ -19,12 +21,14 @@ namespace HealthChecks.UI.K8s.Operator.Controller
             DeploymentHandler deploymentHandler,
             ServiceHandler serviceHandler,
             SecretHandler secretHandler,
+            ConfigMaphandler configMapHandler,
             ILogger<K8sOperator> logger)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _deploymentHandler = deploymentHandler ?? throw new ArgumentNullException(nameof(deploymentHandler));
             _serviceHandler = serviceHandler ?? throw new ArgumentNullException(nameof(serviceHandler));
             _secretHandler = secretHandler ?? throw new ArgumentNullException(nameof(secretHandler));
+            _configMapHandler = configMapHandler ?? throw new ArgumentNullException(nameof(configMapHandler));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -32,7 +36,13 @@ namespace HealthChecks.UI.K8s.Operator.Controller
         {
             _logger.LogInformation("Creating secret for hc resource - namespace {namespace}", resource.Metadata.NamespaceProperty);
 
-            var secret = await _secretHandler.GetOrCreate(resource);
+            var secret = await _secretHandler.GetOrCreateAsync(resource);
+
+            if (resource.HasBrandingConfigured())
+            {
+                _logger.LogInformation("Creating configmap for hc resource - namespace {namespace}", resource.Metadata.NamespaceProperty);
+                await _configMapHandler.GetOrCreateAsync(resource);
+            }
 
             _logger.LogInformation("Creating deployment for hc resource - namespace {namespace}", resource.Metadata.NamespaceProperty);
 
@@ -41,7 +51,7 @@ namespace HealthChecks.UI.K8s.Operator.Controller
             _logger.LogInformation("Creating service for hc resource - namespace {namespace}", resource.Metadata.NamespaceProperty);
 
             var service = await _serviceHandler.GetOrCreateAsync(resource);
-            
+
             return DeploymentResult.Create(deployment, service, secret);
         }
 

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -14,6 +14,8 @@ namespace HealthChecks.UI.K8s.Operator
         public string HealthChecksScheme { get; set; }
         public string Image { get; set; }
         public string ImagePullPolicy { get; set; }
+        public string StylesheetPath { get; set; }
+        public string StylesheetContent { get; set; }
         public List<NameValueObject> ServiceAnnotations { get; set; } = new List<NameValueObject>();
         public List<NameValueObject> DeploymentAnnotations { get; set; } = new List<NameValueObject>();
     }

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/HealthCheckResourceExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/HealthCheckResourceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using k8s.Models;
+using System;
 
 namespace HealthChecks.UI.K8s.Operator.Extensions
 {
@@ -15,5 +16,8 @@ namespace HealthChecks.UI.K8s.Operator.Extensions
                 Controller = true
             };
         }
+
+        public static bool HasBrandingConfigured(this HealthCheckResource resource) =>
+                resource.Spec.StylesheetContent.NotEmpty() && resource.Spec.StylesheetPath.NotEmpty();
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/IKubernetesExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/IKubernetesExtensions.cs
@@ -23,5 +23,11 @@ namespace k8s
             var services = await client.ListNamespacedSecretAsync(k8sNamespace);
             return services.Items.FirstOrDefault(i => i.Metadata.OwnerReferences?.Any(or => or.Uid == ownerUniqueId) ?? false);
         }
+
+        public static async Task<V1ConfigMap> ListNamespacedOwnedConfigMapAsync(this IKubernetes client, string k8sNamespace, string ownerUniqueId)
+        {
+            var configMaps = await client.ListNamespacedConfigMapAsync(k8sNamespace);
+            return configMaps.Items.FirstOrDefault(i => i.Metadata.OwnerReferences?.Any(or => or.Uid == ownerUniqueId) ?? false);
+        }
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/StringExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/StringExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace System
+{
+    public static class StringExtensions
+    {
+        public static bool IsEmpty(this string str) => string.IsNullOrEmpty(str);
+        public static bool NotEmpty(this string str) => !IsEmpty(str);
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/ConfigMapHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/ConfigMapHandler.cs
@@ -1,0 +1,89 @@
+﻿using HealthChecks.UI.K8s.Operator.Extensions;
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings;
+using System.Text.Unicode;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.K8s.Operator.Handlers
+{
+    public class ConfigMaphandler
+    {
+        private const char SPLIT_CHAR = '/';
+        private readonly IKubernetes _client;
+        private readonly ILogger<K8sOperator> _logger;
+
+        public ConfigMaphandler(IKubernetes client, ILogger<K8sOperator> logger)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<V1ConfigMap> Get(HealthCheckResource resource)
+        {
+            return _client.ListNamespacedOwnedConfigMapAsync(resource.Metadata.NamespaceProperty, resource.Metadata.Uid);
+        }
+
+        public async Task<V1ConfigMap> GetOrCreateAsync(HealthCheckResource resource)
+        {
+            var configMap = await Get(resource);
+            if (configMap != null) return configMap;
+
+            try
+            {
+                var configMapResource = Build(resource);
+                configMap = await _client.CreateNamespacedConfigMapAsync(configMapResource, resource.Metadata.NamespaceProperty);
+                _logger.LogInformation("Config Map {name} has been created", configMap.Metadata.Name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error creating config map for hc resource {name} : {message}", resource.Spec.Name, ex.Message);
+            }
+
+            return configMap;
+        }
+
+        public async Task Delete(HealthCheckResource resource)
+        {
+            try
+            {
+                await _client.DeleteNamespacedConfigMapAsync($"{resource.Spec.Name}-config", resource.Metadata.NamespaceProperty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error deleting config map for hc resource {name} : {message}", resource.Spec.Name, ex.Message);
+            }
+        }
+        public V1ConfigMap Build(HealthCheckResource resource)
+        {
+            string path = resource.Spec.StylesheetPath;
+
+            if(path.Contains(SPLIT_CHAR))
+            {
+                path = path.Split(SPLIT_CHAR)[^1];
+            }
+
+            return new V1ConfigMap
+            {
+                BinaryData = new Dictionary<string, byte[]>
+                {
+                    [path] = Encoding.UTF8.GetBytes(resource.Spec.StylesheetContent)
+                },                
+                Metadata = new V1ObjectMeta
+                {
+                    OwnerReferences = new List<V1OwnerReference>
+                    {
+                         resource.CreateOwnerReference(),
+                    },
+                    NamespaceProperty = resource.Metadata.NamespaceProperty,
+                    Name = $"{resource.Spec.Name}-config"
+                }
+            };
+        }
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/SecretHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/SecretHandler.cs
@@ -21,7 +21,7 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<V1Secret> GetOrCreate(HealthCheckResource resource)
+        public async Task<V1Secret> GetOrCreateAsync(HealthCheckResource resource)
         {
             var secret = await Get(resource);
             if (secret != null) return secret;

--- a/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
@@ -19,7 +19,7 @@ namespace HealthChecks.UI.K8s.Operator.Operator
                 healthScheme = service.Metadata.Annotations[Constants.HealthCheckSchemeAnnotation];
             }
 
-            if (string.IsNullOrEmpty(healthScheme))
+            if (healthScheme.IsEmpty())
             {
                 healthScheme = Constants.DefaultScheme;
             }
@@ -45,7 +45,7 @@ namespace HealthChecks.UI.K8s.Operator.Operator
                 healthPath = service.Metadata.Annotations[Constants.HealthCheckPathAnnotation];
             }
 
-            if (string.IsNullOrEmpty(healthPath))
+            if (healthPath.IsEmpty())
             {
                 healthPath = Constants.DefaultHealthPath;
             }

--- a/src/HealthChecks.UI.K8s.Operator/Program.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Program.cs
@@ -49,6 +49,7 @@ namespace HealthChecks.UI.K8s.Operator
                 .AddSingleton<DeploymentHandler>()
                 .AddSingleton<ServiceHandler>()
                 .AddSingleton<SecretHandler>()
+                .AddSingleton<ConfigMaphandler>()
                 .AddSingleton<HealthCheckServiceWatcher>();
 
             }).ConfigureLogging((context, builder) =>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the HealthChecks UI CRD and Operator to allow the user configure branding in a very simple way.

The user just needs to configure `stylesheetPath` and `styleSheetContent` with  custom css in the yaml definition and the operator will configure all the UI docker image necessary environment variables and create a new `ConfigMap` with the css content stored as binary data.  This ConfigMap will be configured as a volume source so the UI application can read it's contents and server the stylesheet to the frontend.


### Sample to easily deploy a HealthChecks UI environment with World of Warcraft styling:

```yaml
apiVersion: "aspnetcore.ui/v1"
kind: HealthCheck
metadata:
  name: healthchecks-ui
  namespace: lande
spec:
  name: healthchecks-ui
  servicesLabel: HealthChecks
  serviceType: LoadBalancer
  stylesheetPath: css/dotnet
  stylesheetContent: >
    :root {    
      --primaryColor: #2a3950;
      --secondaryColor: #f4f4f4;  
      --bgMenuActive: #e1b015;
      --bgButton: #e1b015;
      --logoImageUrl: url('https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/WoW_icon.svg/1200px-WoW_icon.svg.png');
      --bgAside: var(--primaryColor);   
    }
```

### Screenshot

![image](https://user-images.githubusercontent.com/16475649/79791084-06eae800-834d-11ea-80f5-3076768a8a38.png)

**Does this PR introduce a user-facing change?**: No
