### PR TITLE
Change default webhook message to display failing liveness names

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -111,7 +111,7 @@
     <HealthCheckHangfire>3.1.1</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.1.1</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.1.1</HealthCheckConsul>
-    <HealthCheckUI>3.1.1-preview5</HealthCheckUI>
+    <HealthCheckUI>3.1.1-preview6</HealthCheckUI>
     <HealthCheckUICore>3.1.1-preview3</HealthCheckUICore>
     <HealthCheckUIClient>3.1.1-preview3</HealthCheckUIClient>
     <HealthCheckUISqlServerStorage>3.1.1-preview3</HealthCheckUISqlServerStorage>

--- a/doc/ui-changelog.md
+++ b/doc/ui-changelog.md
@@ -6,6 +6,7 @@
 - UI now reacts to services updates (health checks path / scheme) and removals from k8s operator
 - Bugfix - The UI now refreshes correctly when the k8s operator removes last endpoint
 - UI preview5 now allows updating stored configurations in startup #516
+- UI preview6 changes default webhook description message and enumerates failing liveness names
 
   **3.1.0**
 

--- a/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -61,12 +61,13 @@ namespace HealthChecks.UI.Core.Notifications
                 {
                     bool shouldNotify = webHook.ShouldNotifyFunc?.Invoke(report) ?? true;
 
-                    if (!shouldNotify) {
+                    if (!shouldNotify)
+                    {
                         _logger.LogInformation("Webhook notification will not be sent because of user configuration");
                         continue;
                     };
 
-                    if(!isHealthy)
+                    if (!isHealthy)
                     {
                         failure = webHook.CustomMessageFunc?.Invoke(report) ?? GetFailedMessageFromContent(report);
                         description = webHook.CustomDescriptionFunc?.Invoke(report) ?? GetFailedDescriptionsFromContent(report);
@@ -138,19 +139,16 @@ namespace HealthChecks.UI.Core.Notifications
         {
             var failedChecks = healthReport.Entries.Values
                 .Count(c => c.Status != UIHealthStatus.Healthy);
+            var plural = PluralizeHealthcheck(failedChecks);
 
-            return $"There are at least {failedChecks} HealthChecks failing.";
+            return $"There {plural.plural} at least {failedChecks} {plural.noun} failing.";
         }
         private string GetFailedDescriptionsFromContent(UIHealthReport healthReport)
         {
-            const string JOIN_SYMBOL = "|";
+            var failedChecks = healthReport.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
+            var plural = PluralizeHealthcheck(failedChecks.Count());
 
-            var failedChecksDescription = healthReport.Entries.Values
-                .Where(c => c.Status != UIHealthStatus.Healthy)
-                .Select(x => x.Description)
-                .Aggregate((first, after) => $"{first} {JOIN_SYMBOL} {after}");
-
-            return failedChecksDescription;
+            return $"{string.Join(" , ", failedChecks.Select(f => f.Key))} {plural.noun} {plural.plural} failing";
         }
         public void Dispose()
         {
@@ -159,5 +157,10 @@ namespace HealthChecks.UI.Core.Notifications
                 _db.Dispose();
             }
         }
+
+        private (string plural, string noun) PluralizeHealthcheck(int count) =>
+            count > 1 ?
+            ("are", "healthchecks") :
+            ("is", "healthcheck");
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When failure descriptions bookmark is not configured by using custom functions in
`AddWebhookNotification` method, it produces a failed healthchecks error list payload that is not very comprehensive without knowing the associated services when it would be more interesting to list the liveness that are failing as default behaviour. Something like:

**identity-server, oracle and sqlserver healthchecks are failing.**
