### PR TITLE
[K8s operator] Wait for available replica before watching services

### DIFF
--- a/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
@@ -38,7 +38,7 @@ namespace HealthChecks.UI.K8s.Operator
                 string name = healthCheck.Name;
                 string uri = healthCheck.Uri;
 
-                logger.LogInformation("[PushService] Sending Type: {type} - Service {name} with uri : {uri} to ui endpoint: {address}", type, name, uri, uiAddress);
+                logger.LogInformation("[PushService] Namespace {Namespace} - Sending Type: {type} - Service {name} with uri : {uri} to ui endpoint: {address}", resource.Metadata.NamespaceProperty, type, name, uri, uiAddress);
 
                 var key = Encoding.UTF8.GetString(endpointSecret.Data["key"]);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When you deploy the k8s operator using the installer tool (or manually), right now there is a race condition where the UI is being provisioned and the service watcher started. It can happen (if the cluster needs to pull the UI image for example), that the UI endpoint is not available yet and the service watcher pushes discovered services with failure result (service is ready but the pod is being provisioned). The user can re-label services and these will be automatically added but this is non desired extra-work.

With this PR, we wait for an available replica (5 secs x 10 retries max) and once the replica is up and running we start the service watcher.

The channel event is now run inside a task, so all the incoming events can run in parallel and be provisioned without having to wait for the previous deployment, that might be waiting for an available replica.

**Which issue(s) this PR fixes**:  #521 
