### PR TITLE
Upgrade prometheus-net to v3.x

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -70,7 +70,7 @@
     <NewtonsoftJson>12.0.2</NewtonsoftJson>
     <EventStoreClient>5.0.2</EventStoreClient>
     <MicrosoftApplicationInsights>2.10.0</MicrosoftApplicationInsights>
-    <PrometheusNet>2.1.3</PrometheusNet>
+    <PrometheusNet>3.5.0</PrometheusNet>
     <AWSSKDS3>3.3.29</AWSSKDS3>
     <MicrosoftAzureKeyVault>3.0.4</MicrosoftAzureKeyVault>
     <DogStatsDCSharpClient>3.3.0</DogStatsDCSharpClient>

--- a/samples/HealthChecks.Sample/HealthChecks.Sample.csproj
+++ b/samples/HealthChecks.Sample/HealthChecks.Sample.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\HealthChecks.AzureServiceBus\HealthChecks.AzureServiceBus.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.DocumentDb\HealthChecks.DocumentDb.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.IdSvr\HealthChecks.IdSvr.csproj" />
+    <ProjectReference Include="..\..\src\HealthChecks.Prometheus.Metrics\HealthChecks.Prometheus.Metrics.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.Publisher.ApplicationInsights\HealthChecks.Publisher.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.RabbitMQ\HealthChecks.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.Redis\HealthChecks.Redis.csproj" />

--- a/samples/HealthChecks.Sample/Startup.cs
+++ b/samples/HealthChecks.Sample/Startup.cs
@@ -57,6 +57,7 @@ namespace HealthChecks.Sample
                     Predicate = _ => true,
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
                 })
+                .UseHealthChecksPrometheusExporter("/metrics")
                 .UseRouting()
                 .UseEndpoints(config => config.MapDefaultControllerRoute());
         }

--- a/src/HealthChecks.Prometheus.Metrics/PrometheusResponseWriter.cs
+++ b/src/HealthChecks.Prometheus.Metrics/PrometheusResponseWriter.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -13,15 +11,8 @@ namespace HealthChecks.Prometheus.Metrics
             var instance = new PrometheusResponseWriter();
             instance.WriteMetricsFromHealthReport(report);
 
-            using (var resultStream = CollectionToStreamWriter(instance.Registry))
-            {
-                var content = await new StreamContent(resultStream)
-                   .ReadAsStringAsync();
-
-                context.Response.ContentType = ContentType;
-
-                await context.Response.WriteAsync(content, Encoding.UTF8);
-            }
+            context.Response.ContentType = ContentType;
+            await instance.Registry.CollectAndExportAsTextAsync(context.Response.Body, context.RequestAborted);
         }
     }
 }

--- a/src/HealthChecks.Publisher.Prometheus/LivenessPrometheusMetrics.cs
+++ b/src/HealthChecks.Publisher.Prometheus/LivenessPrometheusMetrics.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Prometheus;
-using Prometheus.Advanced;
-using System.IO;
 
 namespace HealthChecks.Publisher.Prometheus
 {
@@ -11,46 +9,39 @@ namespace HealthChecks.Publisher.Prometheus
         private const string HealthCheckLabelName = "healthcheck";
         private readonly Gauge _healthChecksDuration;
         private readonly Gauge _healthChecksResult;
-        protected readonly ICollectorRegistry Registry;
+        protected readonly CollectorRegistry Registry;
 
         internal LivenessPrometheusMetrics()
         {
-            _healthChecksResult = Metrics.CreateGauge("healthcheck",
+            // TODO: Allow injecting a custom registry
+            Registry = Metrics.DefaultRegistry;
+            var factory = Metrics.WithCustomRegistry(Registry);
+
+            _healthChecksResult = factory.CreateGauge("healthcheck",
                 "Shows raw health check status (0 = Unhealthy, 1 = Degraded, 2 = Healthy)", new GaugeConfiguration
                 {
                     LabelNames = new[] {HealthCheckLabelName},
                     SuppressInitialValue = false
                 });
 
-            _healthChecksDuration = Metrics.CreateGauge("healthcheck_duration_seconds",
+            _healthChecksDuration = factory.CreateGauge("healthcheck_duration_seconds",
                 "Shows duration of the health check execution in seconds",
                 new GaugeConfiguration
                 {
                     LabelNames = new[] {HealthCheckLabelName},
                     SuppressInitialValue = false
                 });
-
-            Registry = DefaultCollectorRegistry.Instance;
         }
         protected void WriteMetricsFromHealthReport(HealthReport report)
         {
             foreach (var reportEntry in report.Entries)
             {
-                _healthChecksResult.Labels(reportEntry.Key).
+                _healthChecksResult.WithLabels(reportEntry.Key).
                     Set((double)reportEntry.Value.Status);
 
-                _healthChecksDuration.Labels(reportEntry.Key)
+                _healthChecksDuration.WithLabels(reportEntry.Key)
                     .Set(reportEntry.Value.Duration.TotalSeconds);
             }
-        }
-        protected static Stream CollectionToStreamWriter(ICollectorRegistry registry)
-        {
-            var metrics = registry.CollectAll();
-            var stream = new MemoryStream();
-            ScrapeHandler.ProcessScrapeRequest(metrics, ContentType, stream);
-
-            stream.Position = 0;
-            return stream;
         }
     }
 }

--- a/src/HealthChecks.Publisher.Prometheus/PrometheusGatewayPublisher.cs
+++ b/src/HealthChecks.Publisher.Prometheus/PrometheusGatewayPublisher.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Prometheus.Advanced;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Prometheus;
 
 namespace HealthChecks.Publisher.Prometheus
 {
@@ -43,8 +44,11 @@ namespace HealthChecks.Publisher.Prometheus
         {
             try
             {
-                using (var outStream = CollectionToStreamWriter(Registry))
+                using (var outStream = new MemoryStream())
                 {
+                    await Registry.CollectAndExportAsTextAsync(outStream);
+                    outStream.Position = 0;
+
                     var response = await _httpClientFactory()
                         .PostAsync(_targetUrl, new StreamContent(outStream));
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades the Prometheus integration to use v3 of the `prometheus-net` library.

This is the smallest amount of code needed to change in order to upgrade prometheus-net and keep everything in its current state. 

To test it, I enabled the Prometheus metric endpoint in the `HealthChecks.Sample` project.

There's a bit of weirdness in this project's integration into Prometheus - Instead of having its own separate endpoint that updates the metrics and returns them in Prometheus format, it should instead rely on the standard `/metrics` Prometheus endpoint exposed by `endpoints.MapMetrics()` from `prometheus-net.AspNetCore`, and integrate into Prometheus by using `Registry.AddBeforeCollectCallback` (so that Prometheus calls this library to update the metrics, rather than going the other way around). However, that can be done in a separate PR.

Please reference the issue this PR will close: 
Fixes #419

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
This is a breaking change as v3 of prometheus-net is not API-compatible with v2. People just using `AspNetCore.Diagnostics.HealthChecks` without any customisations to Prometheus (eg. adding their own metrics) will be fine, but people that have deeper integrations into Prometheus will need to upgrade their own code to use the v3 API.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
