### PR TITLE
Add HttpCompletionOption.ResponseHeadersRead in HttpClient requests

### DIFF
--- a/src/HealthChecks.Consul/ConsulHealthCheck.cs
+++ b/src/HealthChecks.Consul/ConsulHealthCheck.cs
@@ -31,7 +31,7 @@ namespace HealthChecks.Consul
                         .Authorization = new AuthenticationHeaderValue("Basic", authHeaderValue);
                 }
                 var result = await client
-                    .GetAsync($"{(_options.RequireHttps ? "https" : "http")}://{_options.HostName}:{_options.Port}/v1/status/leader", cancellationToken);
+                    .GetAsync($"{(_options.RequireHttps ? "https" : "http")}://{_options.HostName}:{_options.Port}/v1/status/leader", HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
                 return result.IsSuccessStatusCode ? HealthCheckResult.Healthy() : new HealthCheckResult(context.Registration.FailureStatus, description: "Consul response was not a successful HTTP status code");
             }

--- a/src/HealthChecks.IdSvr/IdSvrHealthCheck.cs
+++ b/src/HealthChecks.IdSvr/IdSvrHealthCheck.cs
@@ -21,7 +21,7 @@ namespace HealthChecks.IdSvr
             try
             {
                 var httpClient = _httpClientFactory();
-                var response = await httpClient.GetAsync(IDSVR_DISCOVER_CONFIGURATION_SEGMENT, cancellationToken);
+                var response = await httpClient.GetAsync(IDSVR_DISCOVER_CONFIGURATION_SEGMENT, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/HealthChecks.Publisher.Prometheus/PrometheusGatewayPublisher.cs
+++ b/src/HealthChecks.Publisher.Prometheus/PrometheusGatewayPublisher.cs
@@ -49,8 +49,11 @@ namespace HealthChecks.Publisher.Prometheus
                     await Registry.CollectAndExportAsTextAsync(outStream);
                     outStream.Position = 0;
 
+                    var request = new HttpRequestMessage(HttpMethod.Post, _targetUrl);
+                    request.Content = new StreamContent(outStream);
+
                     var response = await _httpClientFactory()
-                        .PostAsync(_targetUrl, new StreamContent(outStream));
+                        .SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
                     response.EnsureSuccessStatusCode();
                 }

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -70,7 +70,7 @@ namespace HealthChecks.Publisher.Seq
                 var pushMessage = new HttpRequestMessage(HttpMethod.Post, $"{_options.Endpoint}/api/events/raw?apiKey={_options.ApiKey}");
                 pushMessage.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
-                (await httpClient.SendAsync(pushMessage))
+                (await httpClient.SendAsync(pushMessage, HttpCompletionOption.ResponseHeadersRead))
                     .EnsureSuccessStatusCode();
             }
             catch (Exception ex)

--- a/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
@@ -42,13 +42,13 @@ namespace HealthChecks.UI.K8s.Operator
 
                 var key = Encoding.UTF8.GetString(endpointSecret.Data["key"]);
 
-                var response = await client.PostAsync($"{uiAddress}{Constants.PushServicePath}?{Constants.PushServiceAuthKey}={key}",
+                var request = new HttpRequestMessage(HttpMethod.Post, $"{uiAddress}{Constants.PushServicePath}?{Constants.PushServiceAuthKey}={key}");
+                request.Content = new StringContent(JsonSerializer.Serialize(healthCheck, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }), Encoding.UTF8, "application/json");
 
-                  new StringContent(JsonSerializer.Serialize(healthCheck, new JsonSerializerOptions
-                  {
-                      PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-                  }), Encoding.UTF8, "application/json"));
-
+                var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
                 logger.LogInformation("[PushService] Notification result for {name} - status code: {statuscode}", notificationService.Metadata.Name, response.StatusCode);
 

--- a/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
+++ b/src/HealthChecks.UI/Core/Discovery/K8S/KubernetesDiscoveryHostedService.cs
@@ -135,7 +135,7 @@ namespace HealthChecks.UI.Core.Discovery.K8S
         }
         async Task<HttpStatusCode> CallClusterService(string host)
         {
-            var response = await _clusterServiceClient.GetAsync(host);
+            var response = await _clusterServiceClient.GetAsync(host, HttpCompletionOption.ResponseHeadersRead);
             return response.StatusCode;
         }
         Task<int> RegisterDiscoveredLiveness(HealthChecksDb livenessDb, string host, string name)

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -98,7 +98,8 @@ namespace HealthChecks.UI.Core.HostedService
             {
                 var absoluteUri = GetEndpointUri(configuration);
 
-                var response = await _httpClient.GetAsync(absoluteUri);
+                var response = await _httpClient.GetAsync(absoluteUri, HttpCompletionOption.ResponseHeadersRead);
+                response.EnsureSuccessStatusCode();
 
                 return await response.As<UIHealthReport>();
             }

--- a/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -122,8 +122,10 @@ namespace HealthChecks.UI.Core.Notifications
         {
             try
             {
-                var payload = new StringContent(payloadContent, Encoding.UTF8, Keys.DEFAULT_RESPONSE_CONTENT_TYPE);
-                var response = await _httpClient.PostAsync(uri, payload);
+                var request = new HttpRequestMessage(HttpMethod.Post, uri);
+                request.Content = new StringContent(payloadContent, Encoding.UTF8, Keys.DEFAULT_RESPONSE_CONTENT_TYPE);
+
+                var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
                 if (!response.IsSuccessStatusCode)
                 {
                     _logger.LogError("The webhook notification has not executed successfully for {name} webhook. The error code is {statuscode}.", name, response.StatusCode);

--- a/src/HealthChecks.Uris/UriHealthCheck.cs
+++ b/src/HealthChecks.Uris/UriHealthCheck.cs
@@ -48,7 +48,7 @@ namespace HealthChecks.Uris
                     using (var timeoutSource = new CancellationTokenSource(timeout))
                     using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, cancellationToken))
                     {
-                        var response = await httpClient.SendAsync(requestMessage, linkedSource.Token);
+                        var response = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, linkedSource.Token);
 
                         if (!((int)response.StatusCode >= expectedStatusCodes.Min && (int)response.StatusCode <= expectedStatusCodes.Max))
                         {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
This PR will improve the memory consumption of some Health Checks that use HttpClient's GetAsync and SendAsync methods by using the HttpCompletionOption.ResponseContentRead parameter. 

**Which issue(s) this PR fixes**:
#530

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
