### PR TITLE
Add HttpClientFactory in HealthChecks.UI.K8s.Operator

### DIFF
--- a/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
+++ b/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClient)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/src/HealthChecks.UI.K8s.Operator/Operator/HealthCheckServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/HealthCheckServiceWatcher.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,16 +16,19 @@ namespace HealthChecks.UI.K8s.Operator
         private readonly IKubernetes _client;
         private readonly ILogger<K8sOperator> _logger;
         private readonly OperatorDiagnostics _diagnostics;
+        private readonly IHttpClientFactory _httpClientFactory;
         private Dictionary<HealthCheckResource, Watcher<V1Service>> _watchers = new Dictionary<HealthCheckResource, Watcher<V1Service>>();
 
         public HealthCheckServiceWatcher(
             IKubernetes client,
             ILogger<K8sOperator> logger,
-            OperatorDiagnostics diagnostics)
+            OperatorDiagnostics diagnostics, 
+            IHttpClientFactory httpClientFactory)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         }
 
         internal Task Watch(HealthCheckResource resource, CancellationToken token)
@@ -83,7 +87,8 @@ namespace HealthChecks.UI.K8s.Operator
                 uiService,
                 service,
                 secret,
-                _logger);
+                _logger, 
+                _httpClientFactory);
         }
 
         public void Dispose()

--- a/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/HealthChecksPushService.cs
@@ -19,7 +19,8 @@ namespace HealthChecks.UI.K8s.Operator
             V1Service uiService,
             V1Service notificationService,
             V1Secret endpointSecret,
-            ILogger<K8sOperator> logger)
+            ILogger<K8sOperator> logger, 
+            IHttpClientFactory httpClientFactory)
         {
             var address = KubernetesAddressFactory.CreateHealthAddress(notificationService, resource);
             var uiAddress = KubernetesAddressFactory.CreateAddress(uiService, resource);
@@ -31,7 +32,7 @@ namespace HealthChecks.UI.K8s.Operator
                 Uri = address
             };
 
-            using var client = new HttpClient();
+            var client = httpClientFactory.CreateClient();
             try
             {
                 string type = healthCheck.Type.ToString();

--- a/src/HealthChecks.UI.K8s.Operator/Program.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Program.cs
@@ -42,6 +42,7 @@ namespace HealthChecks.UI.K8s.Operator
 
                     return new Kubernetes(config);
                 })
+                .AddHttpClient()
                 .AddTransient<IHealthChecksController, HealthChecksController>()
                 .AddSingleton<OperatorDiagnostics>()
                 .AddSingleton<DeploymentHandler>()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
It adds the Nuget Microsoft.Extensions.Http to allow the injection of the HttpClientFactory to manage the HttpClients of the HealthChecks.UI.K8s.Operator project. 

**Which issue(s) this PR fixes**:
#532

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
