### PR TITLE
[UI] Add support for custom Api HttpClient Delegating Handlers

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -47,6 +47,7 @@
     <MicrosoftSourceLinkGithub>1.0.0</MicrosoftSourceLinkGithub>
     <FluentAssertions>5.9.0</FluentAssertions>
     <xunit>2.4.1</xunit>
+    <NSubstitute>4.2.1</NSubstitute>
     <xunitrunnervisualstudio>2.4.1</xunitrunnervisualstudio>
     <StackExchangeRedis>2.0.601</StackExchangeRedis>
     <RabbitMQClient>5.1.1</RabbitMQClient>

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -72,7 +72,7 @@ namespace HealthChecks.UI.Configuration
         {
             var delegatingHandlerType = typeof(T);
 
-            if(!DelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
+            if (!DelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
             {
                 DelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType); 
             }

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -16,6 +16,7 @@ namespace HealthChecks.UI.Configuration
         internal Func<IServiceProvider, HttpMessageHandler> ApiEndpointHttpHandler { get; private set; }
         internal Action<IServiceProvider, HttpClient> ApiEndpointHttpClientConfig { get; private set; }
         internal Func<IServiceProvider, HttpMessageHandler> WebHooksEndpointHttpHandler { get; private set; }
+        internal Dictionary<string, Type> DelegatingHandlerTypes { get; set; } = new Dictionary<string, Type>();
         internal Action<IServiceProvider, HttpClient> WebHooksEndpointHttpClientConfig { get; private set; }
 
         public Settings AddHealthCheckEndpoint(string name, string uri)
@@ -64,6 +65,18 @@ namespace HealthChecks.UI.Configuration
         public Settings UseApiEndpointHttpMessageHandler(Func<IServiceProvider, HttpClientHandler> apiEndpointHttpHandler)
         {
             ApiEndpointHttpHandler = apiEndpointHttpHandler;
+            return this;
+        }
+
+        public Settings UseApiEndpointDelegatingHandler<T>() where T : DelegatingHandler
+        {
+            var delegatingHandlerType = typeof(T);
+
+            if(!DelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
+            {
+                DelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType); 
+            }
+            
             return this;
         }
 

--- a/test/FunctionalTests/Base/TestCollectorInterceptor.cs
+++ b/test/FunctionalTests/Base/TestCollectorInterceptor.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FunctionalTests.HealthChecks.UI.DatabaseProviders
+namespace FunctionalTests.Base
 {
     internal class TestCollectorInterceptor : IHealthCheckCollectorInterceptor
     {

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -9,7 +9,8 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertions)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHost)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJson)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstitute)" />    
     <PackageReference Include="xunit" Version="$(xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudio)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />

--- a/test/FunctionalTests/HealthChecks.UI/Configuration/UIHttpMessageHandlerTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/Configuration/UIHttpMessageHandlerTests.cs
@@ -1,0 +1,163 @@
+﻿using FunctionalTests.Base;
+using HealthChecks.UI.Core;
+using HealthChecks.UI.Core.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using YamlDotNet.Core.Tokens;
+
+namespace FunctionalTests.HealthChecks.UI.Configuration
+{
+
+    public class UI_configuration_should
+    {
+        [Fact]
+        public Task configure_custom_http_client_handler()
+        {
+            var keyName = "prop1";
+            var valueName = "prop1value";
+
+            var tracer = Substitute.For<MessageHandlerTracer>();
+            var handler = new ClientHandler(tracer, new Dictionary<string, string> { [keyName] = valueName });
+            var hostReset = new ManualResetEventSlim(false);
+
+            var builder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services
+                    .AddRouting()
+                    .AddSingleton<IHealthCheckCollectorInterceptor>(sp => new TestCollectorInterceptor(hostReset))
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup.AddHealthCheckEndpoint("endpoint1", "https://httpstat.us/200");
+                        setup.UseApiEndpointHttpMessageHandler(sp => handler);
+                    }).AddInMemoryStorage();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(setup =>
+                    {
+                        setup.MapHealthChecksUI();
+                    });
+                });
+
+            var server = new TestServer(builder);
+            hostReset.Wait(3000);
+
+            tracer.Received().Log(keyName, valueName);
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public Task configure_custom_delegating_handlers()
+        {
+            var hostReset = new ManualResetEventSlim(false);
+            var tracer = Substitute.For<MessageHandlerTracer>();
+
+            var builder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services
+                    .AddRouting()
+                    .AddSingleton<IHealthCheckCollectorInterceptor>(sp => new TestCollectorInterceptor(hostReset))
+                    .AddTransient(sp => new CustomDelegatingHandler(tracer))
+                    .AddTransient(sp => new CustomDelegatingHandler2(tracer))
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup.AddHealthCheckEndpoint("endpoint1", "https://httpstat.us/200");
+                        setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler>();
+                        setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler2>();
+
+                    }).AddInMemoryStorage();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(setup =>
+                    {
+                        setup.MapHealthChecksUI();
+                    });
+                });
+
+            var server = new TestServer(builder);
+
+            hostReset.Wait(3000);
+
+            tracer.Received().Log(nameof(CustomDelegatingHandler), "SendAsync");
+            tracer.Received().Log(nameof(CustomDelegatingHandler2), "SendAsync");
+
+            return Task.CompletedTask;
+        }
+
+        public class ClientHandler : HttpClientHandler
+        {
+            private readonly MessageHandlerTracer _tracer;
+
+            public ClientHandler(MessageHandlerTracer tracer, IDictionary<string, string> properties)
+            {
+                _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+                _ = properties ?? throw new ArgumentNullException(nameof(properties));
+
+                foreach (var kv in properties)
+                {
+                    Properties[kv.Key] = kv.Value;
+                }
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                foreach (var prop in Properties)
+                {
+                    _tracer.Log(prop.Key, prop.Value.ToString());
+                }
+
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        public class CustomDelegatingHandler : DelegatingHandler
+        {
+            private readonly MessageHandlerTracer _tracer;
+
+            public CustomDelegatingHandler(MessageHandlerTracer tracer)
+            {
+                _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _tracer.Log(nameof(CustomDelegatingHandler), nameof(SendAsync));
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        public class CustomDelegatingHandler2 : DelegatingHandler
+        {
+            private readonly MessageHandlerTracer _tracer;
+
+            public CustomDelegatingHandler2(MessageHandlerTracer tracer)
+            {
+                _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _tracer.Log(nameof(CustomDelegatingHandler2), nameof(SendAsync));
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        public abstract class MessageHandlerTracer
+        {
+            public abstract void Log(string key, string value);
+        }
+    }
+}

--- a/test/FunctionalTests/HealthChecks.UI/Configuration/UIHttpMessageHandlerTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/Configuration/UIHttpMessageHandlerTests.cs
@@ -17,7 +17,7 @@ using YamlDotNet.Core.Tokens;
 
 namespace FunctionalTests.HealthChecks.UI.Configuration
 {
-
+    [Collection("execution")]
     public class UI_configuration_should
     {
         [Fact]

--- a/test/FunctionalTests/HealthChecks.UI/DatabaseProviders/HostBuilderHelper.cs
+++ b/test/FunctionalTests/HealthChecks.UI/DatabaseProviders/HostBuilderHelper.cs
@@ -1,4 +1,5 @@
-﻿using HealthChecks.UI.Client;
+﻿using FunctionalTests.Base;
+using HealthChecks.UI.Client;
 using HealthChecks.UI.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;


### PR DESCRIPTION

**What this PR does / why we need it**:

Add support to register custom Http Delegating handlers into the handlers chain to mutate requests.

**Which issue(s) this PR fixes**: #536

Sample:

```csharp
services
    .AddRouting() 
    .AddTransient(sp => new CustomDelegatingHandler(tracer))
    .AddTransient(sp => new CustomDelegatingHandler2(tracer))
    .AddHealthChecksUI(setup =>
    {
        setup.AddHealthCheckEndpoint("endpoint1", "http://healthcheckurl");
        setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler>();
        setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler2>();
    })
   .AddInMemoryStorage();
```



**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [X] Provided sample for the feature
