### PR TITLE
Upgrade UI 3.1.1 preview and providers to final version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -115,14 +115,14 @@
     <HealthCheckHangfire>3.1.1</HealthCheckHangfire>
     <HealthCheckAzureServiceBus>3.2.1</HealthCheckAzureServiceBus>
     <HealthCheckConsul>3.1.1</HealthCheckConsul>
-    <HealthCheckUI>3.1.1-preview7</HealthCheckUI>
-    <HealthCheckUICore>3.1.1-preview3</HealthCheckUICore>
-    <HealthCheckUIClient>3.1.1-preview3</HealthCheckUIClient>
-    <HealthCheckUISqlServerStorage>3.1.1-preview3</HealthCheckUISqlServerStorage>
-    <HealthCheckUISQLiteStorage>3.1.1-preview3</HealthCheckUISQLiteStorage>
-    <HealthChecksUIPostgreSQLStorage>3.1.1-preview3</HealthChecksUIPostgreSQLStorage>
-    <HealthCheckUIInMemoryStorage>3.1.1-preview3</HealthCheckUIInMemoryStorage>
-    <HealthCheckUIMySqlStorage>3.1.1-preview3</HealthCheckUIMySqlStorage>
+    <HealthCheckUI>3.1.1</HealthCheckUI>
+    <HealthCheckUICore>3.1.1</HealthCheckUICore>
+    <HealthCheckUIClient>3.1.1</HealthCheckUIClient>
+    <HealthCheckUISqlServerStorage>3.1.1</HealthCheckUISqlServerStorage>
+    <HealthCheckUISQLiteStorage>3.1.1</HealthCheckUISQLiteStorage>
+    <HealthChecksUIPostgreSQLStorage>3.1.1</HealthChecksUIPostgreSQLStorage>
+    <HealthCheckUIInMemoryStorage>3.1.1</HealthCheckUIInMemoryStorage>
+    <HealthCheckUIMySqlStorage>3.1.1</HealthCheckUIMySqlStorage>
     <HealthCheckPublisherAppplicationInsights>3.1.1</HealthCheckPublisherAppplicationInsights>
     <HealthCheckPublisherDatadog>3.1.1</HealthCheckPublisherDatadog>
     <HealthCheckPublisherPrometheus>3.1.3</HealthCheckPublisherPrometheus>
@@ -136,7 +136,7 @@
     <HealthCheckCloudFirestore>3.1.1</HealthCheckCloudFirestore>
     <HealthCheckIoTHub>3.1.1</HealthCheckIoTHub>
     <HealthCheckIbmMQ>3.1.1</HealthCheckIbmMQ>
-    <HealthChecksUIK8sOperator>3.1.0-beta.8</HealthChecksUIK8sOperator>
+    <HealthChecksUIK8sOperator>3.1.0</HealthChecksUIK8sOperator>
     <HealthCheckSendGrid>3.1.1-preview1</HealthCheckSendGrid>
     <HealthCheckArangoDb>3.1.1-preview1</HealthCheckArangoDb>
   </PropertyGroup>


### PR DESCRIPTION
**What this PR does / why we need it**:  After some preview versions, we are bumping UI 3.1.1 and all storage providers to final.


