### PR TITLE
Adds an AddUrlGroup extension method where Uri is provided by IServiceProvider

### DIFF
--- a/samples/HealthChecks.UIAndApiCustomization/Options/RemoteOptions.cs
+++ b/samples/HealthChecks.UIAndApiCustomization/Options/RemoteOptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace HealthChecks.UIAndApi.Options
+{
+    public class RemoteOptions
+    {
+        public Uri RemoteDependency { get; set; }
+    }
+}

--- a/samples/HealthChecks.UIAndApiCustomization/appsettings.json
+++ b/samples/HealthChecks.UIAndApiCustomization/appsettings.json
@@ -14,5 +14,6 @@
     "Webhooks": [],
     "EvaluationTimeinSeconds": 10,
     "MinimumSecondsBetweenFailureNotifications": 60    
-  }
+  },
+  "RemoteDependency": "http://httpbin.org/status/200"
 }

--- a/test/UnitTests/DependencyInjection/Uri/UriUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/Uri/UriUnitTests.cs
@@ -25,8 +25,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.UriGroup
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("uri-group");
-            check.GetType().Should().Be(typeof(UriHealthCheck));
-
+            check.Should().BeOfType<UriHealthCheck>();
         }
 
         [Fact]
@@ -43,7 +42,23 @@ namespace UnitTests.HealthChecks.DependencyInjection.UriGroup
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("my-uri-group");
-            check.GetType().Should().Be(typeof(UriHealthCheck));
+            check.Should().BeOfType<UriHealthCheck>();
+        }
+
+        [Fact]
+        public void add_health_check_when_configured_through_service_provider()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddUrlGroup(sp => new Uri("http://httpbin.org/status/200"));
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+            
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            check.Should().BeOfType<UriHealthCheck>();
         }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, the `Uri` for a `UriHealthCheck` is available from configuration through an `IOptions<...>` instance. It should be possible to use this `IOptions<...>` instance by retrieving it from the `IServiceProvider` instead of pulling the `Uri` directly from config yourself.

**Which issue(s) this PR fixes**:
No issue was reported.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No, just an additional `UriHealthCheck` registration possibility.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [x] Provided sample for the feature
