### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -55,7 +55,7 @@
     <OracleManagedDataAccessCore>2.19.60</OracleManagedDataAccessCore>
     <Npgsql>4.0.10</Npgsql>
     <MongoDBDriver>2.9.1</MongoDBDriver>
-    <MySqlConnector>0.56.0</MySqlConnector>
+    <MySqlConnector>1.0.0</MySqlConnector>
     <ConfluentKafka>1.4.0</ConfluentKafka>
     <SSHNet>2016.1.0</SSHNet>
     <NEST>7.3.0</NEST>

--- a/src/HealthChecks.MySql/MySqlHealthCheck.cs
+++ b/src/HealthChecks.MySql/MySqlHealthCheck.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.