### PR TITLE
Fix memory leak, dispose MongoDb cursor

### DIFF
--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -41,7 +41,7 @@ namespace HealthChecks.MongoDb
                     using var cursor = await mongoClient
                         .GetDatabase(_specifiedDatabase)
                         .ListCollectionNamesAsync(cancellationToken: cancellationToken);
-                    await cursor.FirstOrDefaultAsync(cancellationToken);
+                    await cursor.FirstAsync(cancellationToken);
                 }
                 else
                 {

--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -35,17 +35,18 @@ namespace HealthChecks.MongoDb
                 if (!string.IsNullOrEmpty(_specifiedDatabase))
                 {
                     // some users can't list all databases depending on database privileges, with
-                    // this you can list only collection on specified database.
+                    // this you can list only collections on specified database.
                     // Related with issue #43
 
-                    await (await mongoClient
-                         .GetDatabase(_specifiedDatabase)
-                         .ListCollectionsAsync(cancellationToken: cancellationToken)).FirstAsync(cancellationToken);
+                    using var cursor = await mongoClient
+                        .GetDatabase(_specifiedDatabase)
+                        .ListCollectionNamesAsync(cancellationToken: cancellationToken);
+                    await cursor.FirstOrDefaultAsync(cancellationToken);
                 }
                 else
                 {
-                    await mongoClient
-                        .ListDatabasesAsync(cancellationToken);
+                    using var cursor = await mongoClient.ListDatabaseNamesAsync(cancellationToken);
+                    await cursor.FirstOrDefaultAsync(cancellationToken);
                 }
 
                 return HealthCheckResult.Healthy();


### PR DESCRIPTION
This PR fixes a memory leak that happens when you get a disposable cursor from MongoDb and don't dispose it.
Also I changed methods to return only names because if you can get the names then you can get the rest, and the name string is lighter than the whole BsonDocument with bunch of other details