### PR TITLE
Allow dynamodb health check when credentials are not provided in options

### DIFF
--- a/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddDynamoDb(this IHealthChecksBuilder builder, Action<DynamoDBOptions> setup, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default,TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddDynamoDb(this IHealthChecksBuilder builder, Action<DynamoDBOptions> setup = default, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default,TimeSpan? timeout = default)
         {
             var options = new DynamoDBOptions();
             setup?.Invoke(options);

--- a/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
@@ -29,7 +29,8 @@ namespace HealthChecks.DynamoDb
                     var credentials = new BasicAWSCredentials(_options.AccessKey, _options.SecretKey);
                     client = regionProvided ? new AmazonDynamoDBClient(credentials, _options.RegionEndpoint) : new AmazonDynamoDBClient(credentials);
                 }
-                else if(regionProvided)
+                else if (regionProvided)
+
                 {
                     client = new AmazonDynamoDBClient( _options.RegionEndpoint);
                 }

--- a/test/UnitTests/DependencyInjection/DynamoDb/DynamoDbUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/DynamoDb/DynamoDbUnitTests.cs
@@ -43,5 +43,37 @@ namespace UnitTests.HealthChecks.DependencyInjection.DynamoDb
             registration.Name.Should().Be("my-dynamodb-group");
             check.GetType().Should().Be(typeof(DynamoDbHealthCheck));
         }
+        [Fact]
+        public void add_health_check_when_no_credentials_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddDynamoDb(_ => { _.RegionEndpoint = RegionEndpoint.CNNorth1; });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("dynamodb");
+            check.GetType().Should().Be(typeof(DynamoDbHealthCheck));
+        }
+        [Fact]
+        public void add_health_check_when_no_option_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddDynamoDb();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("dynamodb");
+            check.GetType().Should().Be(typeof(DynamoDbHealthCheck));
+        }
     }
 }


### PR DESCRIPTION
Make the options and the credentials of dynamo db check optional.
The AWS credentials and region in my project were set in the env params, it will be better to allow the user to leave the options empty. Unit test added and fully tested.