### PR TITLE
#552 RabbitMQ Use single connection when making use of IConnectionFactory

### DIFF
--- a/src/HealthChecks.RabbitMQ/README.md
+++ b/src/HealthChecks.RabbitMQ/README.md
@@ -78,3 +78,20 @@ public void ConfigureServices(IServiceCollection services)
         });
 }
 ```
+
+Or you register IConnectionFactory and then the healthcheck will create a single connection for that one.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+   services
+        .AddSingleton<IConnectionFactory>(sp=>
+            new ConnectionFactory()
+            {
+                Uri = new Uri("amqps://user:pass@host/vhost"),
+                AutomaticRecoveryEnabled = true
+            })
+        .AddHealthChecks()
+        .AddRabbitMQ();
+}
+```

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHost)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJson)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="NSubstitute" Version="$(NSubstitute)" />    
     <PackageReference Include="xunit" Version="$(xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudio)" />

--- a/test/FunctionalTests/HealthChecks.RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using RabbitMQ.Client;
 using System;
 using System.Net;
@@ -213,6 +214,79 @@ namespace FunctionalTests.HealthChecks.RabbitMQ
 
             response.StatusCode
                 .Should().Be(HttpStatusCode.OK);
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_create_one_connection_if_calling_health_multiple_times()
+        {
+            var factoryMock = new Mock<IConnectionFactory>();
+            var connectionMock = new Mock<IConnection>();
+            factoryMock.Setup(m => m.CreateConnection()).Returns(connectionMock.Object);
+
+            var webHostBuilder = new WebHostBuilder()
+            .UseStartup<DefaultStartup>()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddSingleton<IConnectionFactory>(factoryMock.Object)
+                    .AddHealthChecks()
+                    .AddRabbitMQ(tags: new string[] { "rabbitmq" });
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions()
+                {
+                    Predicate = r => r.Tags.Contains("rabbitmq")
+                });
+            });
+
+            var server = new TestServer(webHostBuilder);
+
+            await server.CreateRequest($"/health").GetAsync();
+            await server.CreateRequest($"/health").GetAsync();
+            await server.CreateRequest($"/health").GetAsync();
+
+            factoryMock.Verify(m => m.CreateConnection(), Times.Exactly(1), "expected one connection to be created");
+        }
+
+        [SkipOnAppVeyor]
+        public async Task be_not_crash_on_startup_when_rabbitmq_is_down_at_startup()
+        {
+            var factoryMock = new Mock<IConnectionFactory>();
+            var connectionMock = new Mock<IConnection>();
+            
+            // Given rabbitMQ is not ready yet at the first attempt of calling /health
+            factoryMock.SetupSequence(m => m.CreateConnection())
+                .Throws(new Exception("RabbitMQ is not ready yet"))
+                .Returns(connectionMock.Object);
+
+            var webHostBuilder = new WebHostBuilder()
+            .UseStartup<DefaultStartup>()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddSingleton<IConnectionFactory>(factoryMock.Object)
+                    //.AddSingleton<IConnection>(ci => factoryMock.Object.CreateConnection()) // uncomment this and the test will fail
+                    .AddHealthChecks()
+                    .AddRabbitMQ(tags: new string[] { "rabbitmq" });
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions()
+                {
+                    Predicate = r => r.Tags.Contains("rabbitmq")
+                });
+            });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response1 = await server.CreateRequest($"/health").GetAsync();
+            response1.StatusCode
+               .Should().Be(HttpStatusCode.ServiceUnavailable);
+
+            var response2 = await server.CreateRequest($"/health").GetAsync();
+            response2.StatusCode
+               .Should().Be(HttpStatusCode.OK);
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

**Current problem**
Using this library via IConnectionFactory leads to new connections everytime the healthcheck url is called.

**Why register via IConnectionFactory?**
Because registering via IConnection leads to startup exception when rabbitMQ is not ready yet. Registering via IConnectionFactory solves this problem.

Timeline when registering via IConnection
-------- Start website> ----CRASH in DI container->----------------
---------------------------------------------------------Start RabbitMQ

Timeline when registering via IConnectionFactory
-------- Start website ---->HealthCheck 503_---->DoOtherStuff-------->HealthCheck 200----
-------------------------------------------------------Start RabbitMQ------------------------------

**Which issue(s) this PR fixes**:
#552 #578 #563 #480

**Special notes for your reviewer**:
I did't find a mocking framework so i have addes MOQ. Maybey i overlooked it?

**Does this PR introduce a user-facing change?**:
i don't think so

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [x] Provided sample for the feature
