### PR TITLE
Add support to specify the database to check for existence

### DIFF
--- a/src/HealthChecks.CosmosDb/CosmosDbHealthCheck.cs
+++ b/src/HealthChecks.CosmosDb/CosmosDbHealthCheck.cs
@@ -13,9 +13,12 @@ namespace HealthChecks.CosmosDb
         private static readonly ConcurrentDictionary<string, CosmosClient> _connections = new ConcurrentDictionary<string, CosmosClient>();
 
         private readonly string _connectionString;
-        public CosmosDbHealthCheck(string connectionString)
+        private readonly string _database;
+
+        public CosmosDbHealthCheck(string connectionString, string database)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            _database = database;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
@@ -34,6 +37,13 @@ namespace HealthChecks.CosmosDb
                     }
                 }
                 await cosmosDbClient.ReadAccountAsync();
+
+                if (_database != null)
+                {
+                    var database = cosmosDbClient.GetDatabase(_database);
+                    await database.ReadAsync();
+                }
+
                 return HealthCheckResult.Healthy();
             }
             catch (Exception ex)

--- a/src/HealthChecks.CosmosDb/CosmosDbHealthCheck.cs
+++ b/src/HealthChecks.CosmosDb/CosmosDbHealthCheck.cs
@@ -15,6 +15,10 @@ namespace HealthChecks.CosmosDb
         private readonly string _connectionString;
         private readonly string _database;
 
+        public CosmosDbHealthCheck(string connectionString) : this(connectionString, default)
+        {
+        }
+
         public CosmosDbHealthCheck(string connectionString, string database)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));

--- a/src/HealthChecks.CosmosDb/DependencyInjection/CosmosDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.CosmosDb/DependencyInjection/CosmosDbHealthCheckBuilderExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="connectionString">CosmosDb full connection string.</param>
+        /// <param name="database">Database to check for existence.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'cosmosdb' will be used for the name.</param>
         /// <param name="failureStatus">
         /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -21,11 +22,18 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
-        public static IHealthChecksBuilder AddCosmosDb(this IHealthChecksBuilder builder, string connectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddCosmosDb(
+            this IHealthChecksBuilder builder,
+            string connectionString,
+            string database = default,
+            string name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default,
+            TimeSpan? timeout = default)
         {
             return builder.Add(new HealthCheckRegistration(
                name ?? NAME,
-               sp => new CosmosDbHealthCheck(connectionString),
+               sp => new CosmosDbHealthCheck(connectionString, database),
                failureStatus,
                tags,
                timeout));


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support to health check for the CosmosDB database, if specified on the health check configuration.

**Which issue(s) this PR fixes**:
#558: Add support in the CosmosDB health check to check database / collection is present 

**Special notes for your reviewer**:
I didn't encounter any functional tests for the CosmosDB health check. I see that for the other functional tests docker containers are being used, however, [the emulator is not yet available in Linux](https://feedback.azure.com/forums/263030/suggestions/18533509), and hence Docker. I've created a console app to test it (see [my other branch](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/compare/master...tiesmaster:558/add-health-checking-of-cosmosdb-database-with-temp-commits#diff-e46dec3a44f968e8ef02c389844be644R13-R17)).

**Is it valuable to add this somehow? And if so, how?**

**Does this PR introduce a user-facing change?**:
Yes, it adds a new optional parameter to the `AddCosmosDb()` DI configuration method. We might want to start using the "options pattern". I'm referring to, for example the `.AddRavenDB()` DI configuration method that allows you to pass in an [`Action<RavenDBOptions> setup`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/991b5cba1f8dfcc835cac934576fea691a2f1f6a/src/HealthChecks.RavenDB/DependencyInjection/RavenDBHealthCheckBuilderExtensions.cs#L29) to setup all the details for the health check.

We might also want to do that for the `.AddCosmosDb()` DI configuration method (and perhaps keep a backwards compatible overload for the old situation).

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
  - See above for discussion / questions to the reviewer
- [X] Unit tests passing
- [ ] End-to-end tests passing
  - Similar to point 2, see above
- [ ] Extended the documentation
  - I haven't found any pages where the CosmosDb health check is documented, so nothing extended. I'm happy to add some documentation for this, if you can give me some pointers.
- [ ] Provided sample for the feature
  - I've used a new ASP.NET Core project, and configured that to connect to the CosmosDB emulator to test this feature, see above