### PR TITLE
fix  MySqlConnector 1.0.1  namespace

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -55,7 +55,7 @@
     <OracleManagedDataAccessCore>2.19.60</OracleManagedDataAccessCore>
     <Npgsql>4.0.10</Npgsql>
     <MongoDBDriver>2.9.1</MongoDBDriver>
-    <MySqlConnector>0.56.0</MySqlConnector>
+    <MySqlConnector>1.0.1</MySqlConnector>
     <ConfluentKafka>1.4.0</ConfluentKafka>
     <SSHNet>2016.1.0</SSHNet>
     <NEST>7.3.0</NEST>

--- a/src/HealthChecks.MySql/MySqlHealthCheck.cs
+++ b/src/HealthChecks.MySql/MySqlHealthCheck.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
 
**MySqlConnector 1.0.1 has modify namespace "MySql.Data.MySqlClient" to  "MySqlConnector" **:

** #609   **:
System.TypeLoadException: Could not load type 'MySql.Data.MySqlClient.MySqlConnection' from assembly 'MySqlConnector, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92'.
| at HealthChecks.MySql.MySqlHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)
at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
at HealthChecks.MySql.MySqlHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)


  Reference  issue this PR will close: #609 
 