### PR TITLE
[Network healthcheck] respect timeouts in underlying operations #571

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -107,7 +107,7 @@
     <HealthCheckMySql>3.1.1</HealthCheckMySql>
     <HealthCheckKafka>3.1.2</HealthCheckKafka>
     <HealthCheckSystem>3.1.2</HealthCheckSystem>
-    <HealthCheckNetwork>3.1.2</HealthCheckNetwork>
+    <HealthCheckNetwork>3.1.3</HealthCheckNetwork>
     <HealthCheckDynamoDb>3.1.1</HealthCheckDynamoDb>
     <HealthCheckCosmosDb>3.1.2</HealthCheckCosmosDb>
     <HealthCheckDocumentDb>3.1.1</HealthCheckDocumentDb>

--- a/src/HealthChecks.Network/DnsResolveHealthCheck.cs
+++ b/src/HealthChecks.Network/DnsResolveHealthCheck.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+﻿using HealthChecks.Network.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Linq;
 using System.Net;
@@ -21,7 +22,7 @@ namespace HealthChecks.Network
             {
                 foreach (var item in _options.ConfigureHosts.Values)
                 {
-                    var ipAddresses = await Dns.GetHostAddressesAsync(item.Host);
+                    var ipAddresses = await Dns.GetHostAddressesAsync(item.Host).WithCancellationTokenAsync(cancellationToken);
 
                     foreach (var ipAddress in ipAddresses)
                     {

--- a/src/HealthChecks.Network/Extensions/TaskExtensions.cs
+++ b/src/HealthChecks.Network/Extensions/TaskExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.Network.Extensions
+{
+    public static class TaskExtensions
+    {
+        public static async Task WithCancellationTokenAsync(this Task task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            
+            cancellationToken.Register(() =>
+            {
+                tcs.SetResult(true);
+            });
+
+            if (task != await Task.WhenAny(task, tcs.Task))
+            {
+                throw new OperationCanceledException("The operation has timed out", cancellationToken);
+            }
+
+            await task;
+        }
+        
+        public static async Task<T> WithCancellationTokenAsync<T>(this Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            
+            cancellationToken.Register(() =>
+            {
+                tcs.SetResult(default(T));
+            });
+
+            if (task != await Task.WhenAny(task, tcs.Task))
+            {
+                throw new OperationCanceledException("The operation has timed out", cancellationToken);
+            }
+            else
+            {
+                return await task;    
+            }
+        }
+    }
+}

--- a/src/HealthChecks.Network/FtpHealthCheck.cs
+++ b/src/HealthChecks.Network/FtpHealthCheck.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
 
 namespace HealthChecks.Network
 {
@@ -22,7 +23,7 @@ namespace HealthChecks.Network
                 {
                     var ftpRequest = CreateFtpWebRequest(host, createFile, credentials);
 
-                    using (var ftpResponse = (FtpWebResponse)await ftpRequest.GetResponseAsync())
+                    using (var ftpResponse = (FtpWebResponse)await ftpRequest.GetResponseAsync().WithCancellationTokenAsync(cancellationToken))
                     {
                         if (ftpResponse.StatusCode != FtpStatusCode.PathnameCreated
                             && ftpResponse.StatusCode != FtpStatusCode.ClosingData)

--- a/src/HealthChecks.Network/ImapHealthCheck.cs
+++ b/src/HealthChecks.Network/ImapHealthCheck.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
 
 namespace HealthChecks.Network
 {
@@ -30,7 +31,7 @@ namespace HealthChecks.Network
             {
                 using (var imapConnection = new ImapConnection(_options))
                 {
-                    if (await imapConnection.ConnectAsync())
+                    if (await imapConnection.ConnectAsync().WithCancellationTokenAsync(cancellationToken))
                     {
                         if (_options.AccountOptions.Login)
                         {

--- a/src/HealthChecks.Network/PingHealthCheck.cs
+++ b/src/HealthChecks.Network/PingHealthCheck.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
 
 namespace HealthChecks.Network
 {

--- a/src/HealthChecks.Network/SftpHealthCheck.cs
+++ b/src/HealthChecks.Network/SftpHealthCheck.cs
@@ -25,9 +25,14 @@ namespace HealthChecks.Network
                 {
                     var connectionInfo = new ConnectionInfo(item.Host, item.Port, item.UserName, item.AuthenticationMethods.ToArray());
 
+                    if(context.Registration.Timeout > TimeSpan.Zero)
+                    {                        
+                        connectionInfo.Timeout = context.Registration.Timeout;
+                    }                    
+
                     using (var sftpClient = new SftpClient(connectionInfo))
                     {
-                        sftpClient.Connect();
+                        sftpClient.Connect();                        
 
                         var connectionSuccess = sftpClient.IsConnected && sftpClient.ConnectionInfo.IsAuthenticated;
                         if (connectionSuccess)

--- a/src/HealthChecks.Network/SftpHealthCheck.cs
+++ b/src/HealthChecks.Network/SftpHealthCheck.cs
@@ -32,7 +32,7 @@ namespace HealthChecks.Network
 
                     using (var sftpClient = new SftpClient(connectionInfo))
                     {
-                        sftpClient.Connect();                        
+                        sftpClient.Connect();
 
                         var connectionSuccess = sftpClient.IsConnected && sftpClient.ConnectionInfo.IsAuthenticated;
                         if (connectionSuccess)

--- a/src/HealthChecks.Network/SmtpHealthCheck.cs
+++ b/src/HealthChecks.Network/SmtpHealthCheck.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
 
 namespace HealthChecks.Network
 {
@@ -26,7 +27,7 @@ namespace HealthChecks.Network
                         {
                             var (user, password) = _options.AccountOptions.Account;
 
-                            if (!await smtpConnection.AuthenticateAsync(user, password))
+                            if (!await smtpConnection.AuthenticateAsync(user, password).WithCancellationTokenAsync(cancellationToken))
                             {
                                 return new HealthCheckResult(context.Registration.FailureStatus, description: $"Error login to smtp server{_options.Host}:{_options.Port} with configured credentials");
                             }

--- a/src/HealthChecks.Network/TcpHealthCheck.cs
+++ b/src/HealthChecks.Network/TcpHealthCheck.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
 
 namespace HealthChecks.Network
 {
@@ -22,7 +23,7 @@ namespace HealthChecks.Network
                 {
                     using (var tcpClient = new TcpClient())
                     {
-                        await tcpClient.ConnectAsync(host, port);
+                        await tcpClient.ConnectAsync(host, port).WithCancellationTokenAsync(cancellationToken);
 
                         if (!tcpClient.Connected)
                         {

--- a/test/FunctionalTests/HealthCheck.Network/DnsLHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/DnsLHealthCheckTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using FunctionalTests.Base;
+using HealthChecks.Network;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;

--- a/test/FunctionalTests/HealthCheck.Network/FtpHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/FtpHealthCheckTests.cs
@@ -8,7 +8,11 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
+using HealthChecks.Network;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Raven.Client.Documents.Operations;
 using Xunit;
 
 namespace FunctionalTests.HealthChecks.Network
@@ -27,24 +31,24 @@ namespace FunctionalTests.HealthChecks.Network
         public async Task be_healthy_when_connection_is_successful()
         {
             var webHostBuilder = new WebHostBuilder()
-               .UseStartup<DefaultStartup>()
-               .ConfigureServices(services =>
-               {
-                   services.AddHealthChecks()
-                    .AddFtpHealthCheck(setup =>
-                    {
-                        setup.AddHost("ftp://localhost:21",
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                        .AddFtpHealthCheck(setup =>
+                        {
+                            setup.AddHost("ftp://localhost:21",
                                 createFile: false,
                                 credentials: new NetworkCredential("bob", "12345"));
-                    }, tags: new string[] { "ftp" });
-               })
-               .Configure(app =>
-               {
-                   app.UseHealthChecks("/health", new HealthCheckOptions()
-                   {
-                       Predicate = r => r.Tags.Contains("ftp")
-                   });
-               });
+                        }, tags: new string[] { "ftp" });
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ftp")
+                    });
+                });
 
             var server = new TestServer(webHostBuilder);
             var response = await server.CreateRequest("/health")
@@ -57,30 +61,46 @@ namespace FunctionalTests.HealthChecks.Network
         public async Task be_healthy_when_connection_is_successful_and_file_is_created()
         {
             var webHostBuilder = new WebHostBuilder()
-              .UseStartup<DefaultStartup>()
-              .ConfigureServices(services =>
-              {
-                  services.AddHealthChecks()
-                   .AddFtpHealthCheck(setup =>
-                   {
-                       setup.AddHost("ftp://localhost:21",
-                               createFile: true,
-                               credentials: new NetworkCredential("bob", "12345"));
-                   }, tags: new string[] { "ftp" });
-              })
-              .Configure(app =>
-              {
-                  app.UseHealthChecks("/health", new HealthCheckOptions()
-                  {
-                      Predicate = r => r.Tags.Contains("ftp")
-                  });
-              });
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                        .AddFtpHealthCheck(setup =>
+                        {
+                            setup.AddHost("ftp://localhost:21",
+                                createFile: true,
+                                credentials: new NetworkCredential("bob", "12345"));
+                        }, tags: new string[] { "ftp" });
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("ftp")
+                    });
+                });
 
             var server = new TestServer(webHostBuilder);
             var response = await server.CreateRequest("/health")
                 .GetAsync();
 
             response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task respect_configured_timeout_and_throw_operation_cancelled_exception()
+        {
+            var options = new FtpHealthCheckOptions();
+            options.AddHost("ftp://invalid:21");
+            var ftpHealthCheck = new FtpHealthCheck(options);
+
+            var result = await ftpHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = new HealthCheckRegistration("ftp", instance: ftpHealthCheck, failureStatus: HealthStatus.Degraded,
+                    null, timeout: null)
+            }, new CancellationTokenSource(TimeSpan.FromSeconds(2)).Token);
+
+            result.Exception.Should().BeOfType<OperationCanceledException>();
         }
     }
 }

--- a/test/FunctionalTests/HealthCheck.Network/PingHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/PingHealthCheckTests.cs
@@ -81,6 +81,6 @@ namespace FunctionalTests.HealthChecks.Network
               .GetAsync();
 
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        }     
+        }
     }
 }

--- a/test/FunctionalTests/HealthCheck.Network/PingHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/PingHealthCheckTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using FunctionalTests.Base;
+using HealthChecks.Network;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -80,6 +81,6 @@ namespace FunctionalTests.HealthChecks.Network
               .GetAsync();
 
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        }
+        }     
     }
 }

--- a/test/FunctionalTests/HealthCheck.Network/SftpHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/SftpHealthCheckTests.cs
@@ -39,7 +39,7 @@ namespace FunctionalTests.HealthChecks.Network
                                         .Build();
 
                         setup.AddHost(cfg);
-                    }, tags: new string[] { "sftp" });
+                    }, tags: new string[] { "sftp" }, timeout: TimeSpan.FromSeconds(5));
                })
                .Configure(app =>
                {

--- a/test/FunctionalTests/HealthCheck.Network/TcpHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/TcpHealthCheckTests.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using HealthChecks.Network;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthCheck.Network
+{
+    [Collection("execution")]
+    public class tcp_healthcheck_should
+    {
+        [Fact]
+        public async Task respect_configured_timeout_and_throw_operation_cancelled_exception()
+        {
+            var options = new TcpHealthCheckOptions();
+            options.AddHost("invalid", 5555);
+
+            var tcpHealthCheck = new TcpHealthCheck(options);
+
+            var result = await tcpHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = new HealthCheckRegistration("tcp", instance: tcpHealthCheck, failureStatus: HealthStatus.Degraded,
+                    null, timeout: null)
+            }, new CancellationTokenSource(TimeSpan.FromSeconds(2)).Token);
+
+            result.Exception.Should().BeOfType<OperationCanceledException>();
+        }
+    }
+}


### PR DESCRIPTION

**What this PR does / why we need it**: #571 

Network healthchecks don't respect timeouts configured in healthchecks registrations

**Which issue(s) this PR fixes**: #571 

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing

