### PR TITLE
[Kafka] Propagate Timeout to Kafka Health Check

### DIFF
--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -34,7 +34,7 @@ namespace HealthChecks.Kafka
                     Value = $"Check Kafka healthy on {DateTime.UtcNow}"
                 };
 
-                var result = await _producer.ProduceAsync(_topic, message);
+                var result = await _producer.ProduceAsync(_topic, message, cancellationToken);
 
                 if (result.Status == PersistenceStatus.NotPersisted)
                 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the timeout property when used with `.AddKafka()` had no impact as the `cancellationToken` was never passed, producing the message would not time out in the specified time span.
