### PR TITLE
Fix for health check exceptions not parsing correctly

### DIFF
--- a/src/HealthChecks.UI.Core/UIHealthReport.cs
+++ b/src/HealthChecks.UI.Core/UIHealthReport.cs
@@ -81,7 +81,7 @@ namespace HealthChecks.UI.Core
         public IReadOnlyDictionary<string, object> Data { get; set; }
         public string Description { get; set; }
         public TimeSpan Duration { get; set; }
-        public string Exception { get; set; }
+        public dynamic Exception { get; set; }
         public UIHealthStatus Status { get; set; }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed UIHealthReportEntry.Exception property to be dynamic type.

In HealthCheckReportCollector.cs (line 103) the collector tries to parse the response from a healthz endpoint to a UIHealthReport but if any of the Entries have an exception present (which will be an object) it fails to parse because the Exception property on UIHealthReportEntry is a string. 

The result is that you lose the individual entries for the different checks and the whole endpoint reports unhealthy with a parsing exception (e.g. "Unexpected character encountered while parsing value: {. Path 'entries.mongoDb.exception', line 1, position 76.").

By changing this to a dynamic the healthreport will parse correctly and the exception (as a dynamic) will be reported out correctly in the description.

**Which issue(s) this PR fixes**:
#598 "Unexpected character encountered while parsing value..."

**Does this PR introduce a user-facing change?**:
No
