### PR TITLE
[K8s operator] Expose UI paths to CRD and operator #619

### DIFF
--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -33,6 +33,18 @@ spec:
               type: number
             uiPath:
               type: string
+              pattern: "^/"
+            uiApiPath:
+              type: string
+              pattern: "^/"
+            uiResourcesPath:
+              type: string
+              pattern: "^/"
+            uiWebhooksPath:
+              type: string
+              pattern: "^/"
+            uiNoRelativePaths:
+              type: boolean
             servicesLabel:
               type: string
             healthChecksPath:

--- a/doc/k8s-operator.md
+++ b/doc/k8s-operator.md
@@ -47,6 +47,10 @@ The [HealthCheck operator definition](https://github.com/Xabaril/AspNetCore.Diag
 | serviceType           | How the UI should be published (ClusterIP, LoadBalancer or NodePort) | ClusterIP                                            |
 | portNumber            | What port will be used to expose the UI service                      | 80                                                   |
 | uiPath                | Location where the UI frontend will be served                        | /healthchecks                                        |
+| uiApiPath             | Location where the UI backend API will be served                     | UI defaults                                          |
+| uiResourcesPath       | Location where the UI static files resources will be served          | UI defaults                                          |
+| uiWebhooksPath        | Location where the Webhooks api                                      | UI defaults                                          |
+| uiNoRelativePaths     | Disable UI front-end relative paths                                  | false                                                | 
 | healthChecksPath      | Path where the UI will collect health from endpoints                 | /health (Can be overriden with a service annotation) |
 | healthChecksScheme    | Scheme to be used to collect health from endpoints                   | http (Can be overriden with a service annotation)    |
 | image                 | Image to be used by the UI                                           | xabarilcoding/healthchecksui:latest                  |

--- a/src/HealthChecks.UI.K8s.Operator/Constants.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Constants.cs
@@ -20,5 +20,15 @@
         public const string PushServiceAuthKey = "key";
         public const string StylesPath = "css";
         public const string StyleSheetName = "styles";
+
+        internal class Deployment
+        {
+            internal class Operation
+            {
+                public const string Add = "Add";
+                public const string Delete = "Delete";
+                public const string Patch = "Patch";
+            }
+        }
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -9,6 +9,10 @@ namespace HealthChecks.UI.K8s.Operator
         public string PortNumber { get; set; }
         public string ServiceType { get; set; }
         public string UiPath { get; set; }
+        public string UiApiPath {get;set;}
+        public string UiResourcesPath {get;set;}
+        public string UiWebhooksPath {get;set;}
+        public bool? UiNoRelativePaths {get;set;}
         public string ServicesLabel { get; set; }
         public string HealthChecksPath { get; set; }
         public string HealthChecksScheme { get; set; }

--- a/src/HealthChecks.UI.K8s.Operator/Diagnostics/OperatorDiagnostics.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Diagnostics/OperatorDiagnostics.cs
@@ -22,7 +22,8 @@ namespace HealthChecks.UI.K8s.Operator.Diagnostics
             _logger.LogInformation("The operator is shutting down");
         }
 
-        public void ServiceWatcherStarting(string @namespace) {
+        public void ServiceWatcherStarting(string @namespace)
+        {
             _logger.LogInformation("Service watcher started for namespace {namespace}", @namespace);
         }
 
@@ -39,6 +40,26 @@ namespace HealthChecks.UI.K8s.Operator.Diagnostics
         public void ServiceWatcherThrow(Exception exception)
         {
             _logger.LogError(exception, "The operator service watcher threw an unhandled exception");
+        }
+
+        public void UiPathConfigured(string path, string value)
+        {
+            _logger.LogInformation("The UI Path {path} has been configured to {value}", path, value);
+        }
+
+        public void DeploymentCreated(string deployment)
+        {
+            _logger.LogInformation("Deployment {deployment} has been created", deployment);
+        }
+
+        public void DeploymentError(string deployment, string error)
+        {
+            _logger.LogError("Error creating deployment {name} : {error}", deployment, error);
+        }
+
+        public void DeploymentOperationError(string deployment, string operation, string error)
+        {
+            _logger.LogError("Error executing deployment operation: {operation} for hc resource: {name} - err: {error}", operation, deployment, error);
         }
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/ContainerExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/ContainerExtensions.cs
@@ -6,8 +6,9 @@ namespace HealthChecks.UI.K8s.Operator {
     public static class ContainerExtensions {
         internal static void MapCustomUIPaths(this V1Container container, HealthCheckResource resource, OperatorDiagnostics diagnostics) {
 
-            container.Env.Add(new V1EnvVar("ui_path", resource.Spec.UiPath ?? Constants.DefaultUIPath));
-            diagnostics.UiPathConfigured(nameof(resource.Spec.UiPath), resource.Spec.UiPath);
+            var uiPath = resource.Spec.UiPath ?? Constants.DefaultUIPath;
+            container.Env.Add(new V1EnvVar("ui_path", uiPath));
+            diagnostics.UiPathConfigured(nameof(resource.Spec.UiPath), uiPath);
 
             if (!string.IsNullOrEmpty(resource.Spec.UiApiPath))
             {

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/ContainerExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/ContainerExtensions.cs
@@ -1,0 +1,38 @@
+using HealthChecks.UI.K8s.Operator.Diagnostics;
+using k8s;
+using k8s.Models;
+
+namespace HealthChecks.UI.K8s.Operator {
+    public static class ContainerExtensions {
+        internal static void MapCustomUIPaths(this V1Container container, HealthCheckResource resource, OperatorDiagnostics diagnostics) {
+
+            container.Env.Add(new V1EnvVar("ui_path", resource.Spec.UiPath ?? Constants.DefaultUIPath));
+            diagnostics.UiPathConfigured(nameof(resource.Spec.UiPath), resource.Spec.UiPath);
+
+            if (!string.IsNullOrEmpty(resource.Spec.UiApiPath))
+            {
+                container.Env.Add(new V1EnvVar("ui_api_path", resource.Spec.UiApiPath));
+                diagnostics.UiPathConfigured(nameof(resource.Spec.UiApiPath), resource.Spec.UiApiPath);
+            }
+
+            if (!string.IsNullOrEmpty(resource.Spec.UiResourcesPath))
+            {
+                container.Env.Add(new V1EnvVar("ui_resources_path", resource.Spec.UiResourcesPath));
+                diagnostics.UiPathConfigured(nameof(resource.Spec.UiResourcesPath), resource.Spec.UiResourcesPath);
+            }
+
+            if(!string.IsNullOrEmpty(resource.Spec.UiWebhooksPath))
+            {
+                container.Env.Add(new V1EnvVar("ui_webhooks_path", resource.Spec.UiWebhooksPath));
+                diagnostics.UiPathConfigured(nameof(resource.Spec.UiWebhooksPath), resource.Spec.UiWebhooksPath);
+            }
+
+            if(resource.Spec.UiNoRelativePaths.HasValue)
+            {
+                var noRelativePaths = resource.Spec.UiNoRelativePaths.Value.ToString();
+                container.Env.Add(new V1EnvVar("ui_no_relative_paths", noRelativePaths));
+                diagnostics.UiPathConfigured(nameof(resource.Spec.UiNoRelativePaths), noRelativePaths);
+            }
+        }
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/SecretHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/SecretHandler.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace HealthChecks.UI.K8s.Operator.Handlers
 {
-    public class SecretHandler
+    internal class SecretHandler
     {
         private readonly IKubernetes _client;
         private readonly ILogger<K8sOperator> _logger;

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/ServiceHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/ServiceHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace HealthChecks.UI.K8s.Operator.Handlers
 {
-    public class ServiceHandler
+    internal class ServiceHandler
     {
         private readonly IKubernetes _client;
         private readonly ILogger<K8sOperator> _logger;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: #619 

**Which issue(s) this PR fixes**: The operator CRD now exposes already UI existing settings to configure paths. The UI path was already configurable and now you can specify the UI Api Path, Resources Path, Webhooks Path and disable relative UI resources.

Please reference the issue this PR will close: #619 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [X] Extended the documentation
- [ ] Provided sample for the feature
