### PR TITLE
[UI] Api request limitting middleware and initial UI settings middleware

### DIFF
--- a/src/HealthChecks.UI.InMemory.Storage/HealthChecksUIBuilderExtensions.cs
+++ b/src/HealthChecks.UI.InMemory.Storage/HealthChecksUIBuilderExtensions.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class HealthChecksUIBuilderExtensions
     {
-        public static HealthChecksUIBuilder AddInMemoryStorage(this HealthChecksUIBuilder builder, Action<DbContextOptionsBuilder> configureOptions = null)
+        public static HealthChecksUIBuilder AddInMemoryStorage(this HealthChecksUIBuilder builder, Action<DbContextOptionsBuilder> configureOptions = null, string databaseName = "HealthChecksUI")
         {
             builder.Services.AddDbContext<HealthChecksDb>(options =>
             {
                 configureOptions?.Invoke(options);
-                options.UseInMemoryDatabase("HealthChecksUI");
+                options.UseInMemoryDatabase(databaseName);
             });
 
             return builder;

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -12,12 +12,14 @@ namespace HealthChecks.UI.Configuration
         internal bool DisableMigrations { get; set; } = false;
         internal int MaximumExecutionHistoriesPerEndpoint { get; private set; } = 100;
         internal int EvaluationTimeInSeconds { get; set; } = 10;
-        internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;        
+        internal int ApiMaxActiveRequests { get; private set; } = 3;
+        internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
         internal Func<IServiceProvider, HttpMessageHandler> ApiEndpointHttpHandler { get; private set; }
         internal Action<IServiceProvider, HttpClient> ApiEndpointHttpClientConfig { get; private set; }
         internal Func<IServiceProvider, HttpMessageHandler> WebHooksEndpointHttpHandler { get; private set; }
         internal Dictionary<string, Type> DelegatingHandlerTypes { get; set; } = new Dictionary<string, Type>();
         internal Action<IServiceProvider, HttpClient> WebHooksEndpointHttpClientConfig { get; private set; }
+
 
         public Settings AddHealthCheckEndpoint(string name, string uri)
         {
@@ -30,7 +32,7 @@ namespace HealthChecks.UI.Configuration
             return this;
         }
 
-        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "", Func<UIHealthReport, bool> shouldNotifyFunc = null, Func<UIHealthReport,string> customMessageFunc = null, Func<UIHealthReport, string> customDescriptionFunc = null)
+        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "", Func<UIHealthReport, bool> shouldNotifyFunc = null, Func<UIHealthReport, string> customMessageFunc = null, Func<UIHealthReport, string> customDescriptionFunc = null)
         {
             Webhooks.Add(new WebHookNotification
             {
@@ -56,6 +58,12 @@ namespace HealthChecks.UI.Configuration
             return this;
         }
 
+        public Settings SetApiMaxActiveRequests(int apiMaxActiveRequests)
+        {
+            ApiMaxActiveRequests = apiMaxActiveRequests;
+            return this;
+        }
+
         public Settings SetMinimumSecondsBetweenFailureNotifications(int seconds)
         {
             MinimumSecondsBetweenFailureNotifications = seconds;
@@ -74,9 +82,9 @@ namespace HealthChecks.UI.Configuration
 
             if (!DelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
             {
-                DelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType); 
+                DelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType);
             }
-            
+
             return this;
         }
 
@@ -117,7 +125,7 @@ namespace HealthChecks.UI.Configuration
         public string Uri { get; set; }
         public string Payload { get; set; }
         public string RestoredPayload { get; set; }
-        internal Func<UIHealthReport, bool> ShouldNotifyFunc { get; set; } 
+        internal Func<UIHealthReport, bool> ShouldNotifyFunc { get; set; }
         internal Func<UIHealthReport, string> CustomMessageFunc { get; set; }
         internal Func<UIHealthReport, string> CustomDescriptionFunc { get; set; }
     }

--- a/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using HealthChecks.UI.Configuration;
+﻿using HealthChecks.UI;
+using HealthChecks.UI.Configuration;
 using HealthChecks.UI.Core;
 using HealthChecks.UI.Middleware;
 using System;
@@ -25,7 +26,14 @@ namespace Microsoft.AspNetCore.Builder
             var embeddedResourcesAssembly = typeof(UIResource).Assembly;
 
             app.Map(options.ApiPath, appBuilder => appBuilder.UseMiddleware<UIApiEndpointMiddleware>());
-            app.Map(options.WebhookPath, appBuilder => appBuilder.UseMiddleware<UIWebHooksApiMiddleware>());
+
+            app.Map(options.WebhookPath, appBuilder => {
+                appBuilder
+                .UseMiddleware<UIApiRequestLimitingMidleware>()
+                .UseMiddleware<UIWebHooksApiMiddleware>();
+            });
+
+            app.Map($"{options.ApiPath}/{Keys.HEALTHCHECKSUI_SETTINGS_PATH}", appBuilder => appBuilder.UseMiddleware<UISettingsMiddleware>());
 
             new UIResourcesMapper(
                 new UIEmbeddedResourcesReader(embeddedResourcesAssembly))

--- a/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
@@ -25,13 +25,14 @@ namespace Microsoft.AspNetCore.Builder
 
             var embeddedResourcesAssembly = typeof(UIResource).Assembly;
 
-            app.Map(options.ApiPath, appBuilder => appBuilder.UseMiddleware<UIApiEndpointMiddleware>());
-
-            app.Map(options.WebhookPath, appBuilder => {
+            app.Map(options.ApiPath, appBuilder =>
+            {
                 appBuilder
                 .UseMiddleware<UIApiRequestLimitingMidleware>()
-                .UseMiddleware<UIWebHooksApiMiddleware>();
+                .UseMiddleware<UIApiEndpointMiddleware>();
             });
+
+            app.Map(options.WebhookPath, appBuilder => appBuilder.UseMiddleware<UIWebHooksApiMiddleware>());
 
             app.Map($"{options.ApiPath}/{Keys.HEALTHCHECKSUI_SETTINGS_PATH}", appBuilder => appBuilder.UseMiddleware<UISettingsMiddleware>());
 

--- a/src/HealthChecks.UI/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/EndpointRouteBuilderExtensions.cs
@@ -22,8 +22,13 @@ namespace Microsoft.AspNetCore.Builder
 
             var apiDelegate =
                 builder.CreateApplicationBuilder()
+                    .UseMiddleware<UIApiRequestLimitingMidleware>()
                     .UseMiddleware<UIApiEndpointMiddleware>()
                     .Build();
+
+            var settingsDelegate = builder.CreateApplicationBuilder()
+                .UseMiddleware<UISettingsMiddleware>()
+                .Build();
 
             var webhooksDelegate =
                 builder.CreateApplicationBuilder()
@@ -36,14 +41,15 @@ namespace Microsoft.AspNetCore.Builder
             var resourcesEndpoints = new UIEndpointsResourceMapper(new UIEmbeddedResourcesReader(embeddedResourcesAssembly))
                 .Map(builder, options);
 
-
             var apiEndpoint = builder.Map(options.ApiPath, apiDelegate)
                                 .WithDisplayName("HealthChecks UI Api");
+
+            var settingsEndpoint = builder.Map($"{options.ApiPath}/{Keys.HEALTHCHECKSUI_SETTINGS_PATH}", settingsDelegate);
 
             var webhooksEndpoint = builder.Map(options.WebhookPath, webhooksDelegate)
                                 .WithDisplayName("HealthChecks UI Webhooks");
 
-            var endpointConventionBuilders = new List<IEndpointConventionBuilder>(new[] { apiEndpoint, webhooksEndpoint }.Union(resourcesEndpoints));
+            var endpointConventionBuilders = new List<IEndpointConventionBuilder>(new[] { apiEndpoint, webhooksEndpoint, settingsEndpoint }.Union(resourcesEndpoints));
 
             return new HealthCheckUIConventionBuilder(endpointConventionBuilders);
         }

--- a/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddScoped<IHealthCheckFailureNotifier, WebHookFailureNotifier>();
             services.TryAddScoped<IHealthCheckReportCollector, HealthCheckReportCollector>();
 
-            services                
+            services
                 .AddHostedService<UIInitializationHostedService>()
                 .AddHostedService<HealthCheckCollectorHostedService>()
                 .AddKubernetesDiscoveryService()

--- a/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddScoped<IHealthCheckFailureNotifier, WebHookFailureNotifier>();
             services.TryAddScoped<IHealthCheckReportCollector, HealthCheckReportCollector>();
 
-            services
+            services                
                 .AddHostedService<UIInitializationHostedService>()
                 .AddHostedService<HealthCheckCollectorHostedService>()
                 .AddKubernetesDiscoveryService()

--- a/src/HealthChecks.UI/Keys.cs
+++ b/src/HealthChecks.UI/Keys.cs
@@ -23,5 +23,7 @@
         internal const string HEALTH_CHECK_HTTP_CLIENT_NAME = "health-checks";
         internal const string HEALTH_CHECK_WEBHOOK_HTTP_CLIENT_NAME = "health-checks-webhooks";
         internal const string K8S_CLUSTER_SERVICE_HTTP_CLIENT_NAME = "k8s-cluster-service";
+        internal const string HEALTHCHECKSUI_SETTINGS_TARGET = "#uiSettingsPath";
+        internal const string HEALTHCHECKSUI_SETTINGS_PATH = "ui-settings";
     }
 }

--- a/src/HealthChecks.UI/Middleware/UIApiRequestLimitingMidleware.cs
+++ b/src/HealthChecks.UI/Middleware/UIApiRequestLimitingMidleware.cs
@@ -1,0 +1,59 @@
+﻿using HealthChecks.UI.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Org.BouncyCastle.Utilities.Net;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using IPAddress = System.Net.IPAddress;
+namespace HealthChecks.UI.Middleware
+{
+    internal class UIApiRequestLimitingMidleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IOptions<Settings> _settings;
+        private readonly ILogger<UIApiEndpointMiddleware> _logger;
+        private readonly SemaphoreSlim _semaphore;
+        
+        public UIApiRequestLimitingMidleware(RequestDelegate next, IOptions<Settings> settings, ILogger<UIApiEndpointMiddleware> logger)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            var maxActiveRequests = _settings.Value.ApiMaxActiveRequests;
+
+            if (maxActiveRequests <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxActiveRequests));
+            }
+
+            _semaphore = new SemaphoreSlim(maxActiveRequests, maxActiveRequests);
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if(!await _semaphore.WaitAsync(TimeSpan.Zero)) {
+                context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                return;
+            }
+
+            try
+            {
+                _logger.LogDebug("Executing api middleware for client {client}, remaining slots: {slots}",
+                    context.Connection.RemoteIpAddress, 
+                    _semaphore.CurrentCount);
+
+                await _next(context);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}

--- a/src/HealthChecks.UI/Middleware/UISettingsMiddleware.cs
+++ b/src/HealthChecks.UI/Middleware/UISettingsMiddleware.cs
@@ -1,0 +1,44 @@
+﻿using HealthChecks.UI.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.Middleware
+{
+    internal class UISettingsMiddleware
+    {
+        private static Settings Settings { get; set; }
+        private readonly JsonSerializerSettings _jsonSerializationSettings;
+        private Lazy<dynamic> _uiOutputSettings = new Lazy<dynamic>(GetUIOutputSettings);
+
+        public UISettingsMiddleware(RequestDelegate next, IOptions<Settings> settings)
+        {
+            _ =  settings ?? throw new ArgumentNullException(nameof(settings));
+            Settings = settings.Value;
+
+            _jsonSerializationSettings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+        }
+        public async Task InvokeAsync(HttpContext context)
+        {
+            string content = JsonConvert.SerializeObject(_uiOutputSettings.Value, _jsonSerializationSettings);
+            context.Response.ContentType = Keys.DEFAULT_RESPONSE_CONTENT_TYPE;
+
+            await context.Response.WriteAsync(content);
+        }
+
+        private static dynamic GetUIOutputSettings()
+        {
+            return new
+            {
+                PollinInterval = Settings.EvaluationTimeInSeconds
+            };
+        }
+    }
+}

--- a/src/HealthChecks.UI/Middleware/UISettingsMiddleware.cs
+++ b/src/HealthChecks.UI/Middleware/UISettingsMiddleware.cs
@@ -37,7 +37,7 @@ namespace HealthChecks.UI.Middleware
         {
             return new
             {
-                PollinInterval = Settings.EvaluationTimeInSeconds
+                PollingInterval = Settings.EvaluationTimeInSeconds
             };
         }
     }

--- a/test/FunctionalTests/HealthChecks.UI/UIApiRequestLimitingTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/UIApiRequestLimitingTests.cs
@@ -23,7 +23,6 @@ using Xunit;
 namespace FunctionalTests.HealthChecks.UI
 {
 
-    [Collection("execution")]
     public class ui_api_request_limiting
     {
         [Fact]
@@ -37,8 +36,8 @@ namespace FunctionalTests.HealthChecks.UI
                    {
                        services
                             .AddRouting()
-                           .AddHealthChecks()                           
-                           .AddAsyncCheck("Delayed", async() =>
+                           .AddHealthChecks()
+                           .AddAsyncCheck("Delayed", async () =>
                            {
                                await Task.Delay(200);
                                return HealthCheckResult.Healthy();
@@ -49,7 +48,7 @@ namespace FunctionalTests.HealthChecks.UI
                                setup.AddHealthCheckEndpoint("endpoint1", "http://localhost/health");
                                setup.SetApiMaxActiveRequests(maxActiveRequests);
                            })
-                           .AddInMemoryStorage();
+                           .AddInMemoryStorage(databaseName: "LimitingTests");
 
                    })
                    .Configure(app =>
@@ -100,7 +99,7 @@ namespace FunctionalTests.HealthChecks.UI
                            {
                                setup.AddHealthCheckEndpoint("endpoint1", "http://localhost/health");
                            })
-                           .AddInMemoryStorage();
+                           .AddInMemoryStorage(databaseName: "LimitingTests");
 
                    })
                    .Configure(app =>

--- a/test/FunctionalTests/HealthChecks.UI/UIApiRequestLimitingTests.cs
+++ b/test/FunctionalTests/HealthChecks.UI/UIApiRequestLimitingTests.cs
@@ -1,0 +1,140 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using HealthChecks.UI.Client;
+using HealthChecks.UI.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver.Core.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthChecks.UI
+{
+
+    [Collection("execution")]
+    public class ui_api_request_limiting
+    {
+        [Fact]
+        public async Task should_return_too_many_requests_status_code_when_exceding_configured_max_active_requests()
+        {
+            int maxActiveRequests = 2;
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                   .ConfigureServices(services =>
+                   {
+                       services
+                            .AddRouting()
+                           .AddHealthChecks()                           
+                           .AddAsyncCheck("Delayed", async() =>
+                           {
+                               await Task.Delay(200);
+                               return HealthCheckResult.Healthy();
+                           })
+                           .Services
+                           .AddHealthChecksUI(setup =>
+                           {
+                               setup.AddHealthCheckEndpoint("endpoint1", "http://localhost/health");
+                               setup.SetApiMaxActiveRequests(maxActiveRequests);
+                           })
+                           .AddInMemoryStorage();
+
+                   })
+                   .Configure(app =>
+                   {
+                       app.UseRouting();
+                       app.UseEndpoints(setup =>
+                       {
+                           setup.MapHealthChecks("/health", new HealthCheckOptions
+                           {
+                               Predicate = r => true,
+                               ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                           });
+
+                           setup.MapHealthChecksUI();
+                       });
+
+                   });
+
+            var server = new TestServer(webHostBuilder);
+
+            var requests = Enumerable.Range(1, maxActiveRequests)
+                .Select(n => server.CreateRequest($"/healthchecks-api").GetAsync());
+
+            var results = await Task.WhenAll(requests);
+
+            results.Where(r => r.StatusCode == HttpStatusCode.TooManyRequests).Count().Should().Be(requests.Count() - maxActiveRequests);
+            results.Where(r => r.StatusCode == HttpStatusCode.OK).Count().Should().Be(maxActiveRequests);
+
+        }
+
+        [Fact]
+        public async Task should_return_too_many_requests_status_using_default_server_max_active_requests()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                   .ConfigureServices(services =>
+                   {
+                       services
+                            .AddRouting()
+                           .AddHealthChecks()
+                           .AddAsyncCheck("Delayed", async () =>
+                           {
+                               await Task.Delay(200);
+                               return HealthCheckResult.Healthy();
+                           })
+                           .Services
+                           .AddHealthChecksUI(setup =>
+                           {
+                               setup.AddHealthCheckEndpoint("endpoint1", "http://localhost/health");
+                           })
+                           .AddInMemoryStorage();
+
+                   })
+                   .Configure(app =>
+                   {
+                       app.UseRouting();
+                       app.UseEndpoints(setup =>
+                       {
+                           setup.MapHealthChecks("/health", new HealthCheckOptions
+                           {
+                               Predicate = r => true,
+                               ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                           });
+
+                           setup.MapHealthChecksUI();
+                       });
+
+                   });
+
+            var server = new TestServer(webHostBuilder);
+
+            var serverSettings = server.Services.GetRequiredService<IOptions<Settings>>().Value;
+
+            var requests = Enumerable.Range(1, serverSettings.ApiMaxActiveRequests)
+                .Select(n => server.CreateRequest($"/healthchecks-api").GetAsync());
+
+            var results = await Task.WhenAll(requests);
+
+            results.Where(r => r.StatusCode == HttpStatusCode.TooManyRequests)
+                .Count()
+                .Should().Be(requests.Count() - serverSettings.ApiMaxActiveRequests);
+
+            results.Where(r => r.StatusCode == HttpStatusCode.OK).Count()
+                .Should().Be(serverSettings.ApiMaxActiveRequests);
+
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

Additional security mechanisms to avoid UI api abuse by allowing the user to configure the maximum number of active requests in the backend api. When the middleware semaphore has not available slots a 429 too many requests is returned from the server.

Added the initial ui settings middleware for the next steps, that will be removing the polling interval settings in the front-end for security.



**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing

