### PR TITLE
[K8s operator] Cluster and Namespaced services support

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -78,7 +78,7 @@
     <MicrosoftAzureKeyVault>4.1.0</MicrosoftAzureKeyVault>
     <DogStatsDCSharpClient>3.3.0</DogStatsDCSharpClient>
     <MicrosoftAzureDevices>1.18.1</MicrosoftAzureDevices>
-    <KubernetesClient>1.6.10</KubernetesClient>
+    <KubernetesClient>2.0.29</KubernetesClient>
     <SolrNetCore>1.0.19</SolrNetCore>
     <IBMMQDotnetClient>9.1.4</IBMMQDotnetClient>
     <PomeloEntityFrameworkCoreMySql>3.1.2</PomeloEntityFrameworkCoreMySql>

--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -23,6 +23,11 @@ spec:
           properties:
             name:
               type: string
+            scope:
+             type: string
+             enum:
+               - Cluster
+               - Namespaced
             serviceType:
               type: string
               enum:
@@ -99,4 +104,5 @@ spec:
 
           required:
             - name
+            - scope
             - servicesLabel

--- a/doc/k8s-operator.md
+++ b/doc/k8s-operator.md
@@ -38,7 +38,20 @@ The [HealthCheck operator definition](https://github.com/Xabaril/AspNetCore.Diag
 | Field         | Description                                                                        |
 | ------------- | :--------------------------------------------------------------------------------- |
 | name          | Name of the healthcheck resource                                                   |
+| scope         | Cluster / Namespaced                                                               |
 | servicesLabel | The label the operator service watcher will use to detected healthchecks endpoints |
+
+
+### Scope definition (Cluster or Namespaced)
+
+The scope field (Cluster or Namespaced) is mandatory and will specify to the operator whether it should watch for healthchecks services in the
+same namespace where the UI resource is created or watch to all services in all namespaces.
+
+If you wan't to have different UI's for different namespaced services you should use **Namespaced**
+
+If you wan't to have a single UI that monitors all the healthchecks from the cluster you should use **Cluster**
+
+Note: The UI resources created by the operator (deployment, service, configmap, secret, etc) will always be created in the metadata specified namespace.
 
 ### Optional fields
 
@@ -76,6 +89,8 @@ metadata:
   namespace: demo
 spec:
   name: healthchecks-ui
+  scope: Namespaced #The UI will be created at specified namespace (demo) and will watch healthchecks services in demo namespace only
+  #scope: Cluster The UI will be created at specified namespace (demo) but will watch healthcheck services across all namespaces
   servicesLabel: HealthChecks
   serviceType: LoadBalancer
   stylesheetContent: >

--- a/src/HealthChecks.UI.K8s.Operator/Constants.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Constants.cs
@@ -29,6 +29,12 @@
                 public const string Delete = "Delete";
                 public const string Patch = "Patch";
             }
+
+            internal class Scope
+            {
+                public const string Cluster = "Cluster";
+                public const string Namespaced = "Namespaced";
+            }
         }
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -6,6 +6,7 @@ namespace HealthChecks.UI.K8s.Operator
     public class HealthCheckResourceSpec
     {
         public string Name { get; set; }
+        public string Scope { get; set; }
         public string PortNumber { get; set; }
         public string ServiceType { get; set; }
         public string UiPath { get; set; }

--- a/src/HealthChecks.UI.K8s.Operator/Diagnostics/OperatorDiagnostics.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Diagnostics/OperatorDiagnostics.cs
@@ -39,7 +39,7 @@ namespace HealthChecks.UI.K8s.Operator.Diagnostics
 
         public void ServiceWatcherThrow(Exception exception)
         {
-            _logger.LogError(exception, "The operator service watcher threw an unhandled exception");
+            _logger.LogError(exception.Message, "The operator service watcher threw an unhandled exception");
         }
 
         public void UiPathConfigured(string path, string value)

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/IKubernetesClient.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/IKubernetesClient.cs
@@ -1,6 +1,0 @@
-﻿namespace HealthChecks.UI.K8s.Operator.Handlers
-{
-    public interface IKubernetesClient
-    {
-    }
-}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/IKubernetesClient.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/IKubernetesClient.cs
@@ -1,0 +1,6 @@
+﻿namespace HealthChecks.UI.K8s.Operator.Handlers
+{
+    public interface IKubernetesClient
+    {
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/NotificationHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/NotificationHandler.cs
@@ -1,0 +1,44 @@
+﻿using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.K8s.Operator.Handlers
+{
+    public class NotificationHandler
+    {
+        private readonly IKubernetes _client;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<K8sOperator> _logger;
+
+        public NotificationHandler(IKubernetes client, IHttpClientFactory httpClientFactory, ILogger<K8sOperator> logger)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+        public async Task NotifyDiscoveredServiceAsync(WatchEventType type, V1Service service, HealthCheckResource resource)
+        {
+            var uiService = await _client.ListNamespacedOwnedServiceAsync(resource.Metadata.NamespaceProperty, resource.Metadata.Uid);
+            var secret = await _client.ListNamespacedOwnedSecretAsync(resource.Metadata.NamespaceProperty, resource.Metadata.Uid);
+
+            if (!service.Metadata.Labels.ContainsKey(resource.Spec.ServicesLabel))
+            {
+                type = WatchEventType.Deleted;
+            }
+
+            await HealthChecksPushService.PushNotification(
+                type,
+                resource,
+                uiService,
+                service,
+                secret,
+                _logger,
+                _httpClientFactory);
+        }
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
@@ -1,0 +1,68 @@
+﻿using HealthChecks.UI.K8s.Operator.Diagnostics;
+using HealthChecks.UI.K8s.Operator.Handlers;
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HealthChecks.UI.K8s.Operator.Operator
+{
+    internal class ClusterServiceWatcher
+    {
+        private readonly IKubernetes _client;
+        private readonly ILogger<K8sOperator> _logger;
+        private readonly OperatorDiagnostics _diagnostics;
+        private readonly NotificationHandler _notificationHandler;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private Watcher<V1Service> _watcher;
+        public ClusterServiceWatcher(
+          IKubernetes client,
+          ILogger<K8sOperator> logger,
+          OperatorDiagnostics diagnostics,
+          NotificationHandler notificationHandler,
+          IHttpClientFactory httpClientFactory)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+            _notificationHandler = notificationHandler;
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _notificationHandler = notificationHandler ?? throw new ArgumentNullException(nameof(notificationHandler));
+        }
+
+        internal Task Watch(HealthCheckResource resource, CancellationToken token)
+        {
+            var response = _client.ListServiceForAllNamespacesWithHttpMessagesAsync(
+                labelSelector: $"{resource.Spec.ServicesLabel}",
+                watch: true,
+                cancellationToken: token);
+
+            _watcher = response.Watch<V1Service, V1ServiceList>(
+                onEvent: async (type, item) => await _notificationHandler.NotifyDiscoveredServiceAsync(type, item, resource),
+                onError: e => _diagnostics.ServiceWatcherThrow(e)
+            );
+
+            _diagnostics.ServiceWatcherStarting("All");
+
+            return Task.CompletedTask;
+        }
+
+        internal void Stopwatch(HealthCheckResource resource)
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if(_watcher != null && _watcher.Watching)
+            {
+                _watcher.Dispose();
+            }
+        }
+    }
+}

--- a/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
@@ -18,7 +18,6 @@ namespace HealthChecks.UI.K8s.Operator.Operator
         private readonly ILogger<K8sOperator> _logger;
         private readonly OperatorDiagnostics _diagnostics;
         private readonly NotificationHandler _notificationHandler;
-        private readonly IHttpClientFactory _httpClientFactory;
         private Watcher<V1Service> _watcher;
         public ClusterServiceWatcher(
           IKubernetes client,
@@ -30,8 +29,6 @@ namespace HealthChecks.UI.K8s.Operator.Operator
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
-            _notificationHandler = notificationHandler;
-            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _notificationHandler = notificationHandler ?? throw new ArgumentNullException(nameof(notificationHandler));
         }
 

--- a/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
@@ -10,7 +10,12 @@ namespace HealthChecks.UI.K8s.Operator.Operator
         {
             var defaultPort = int.Parse(resource.Spec.PortNumber ?? Constants.DefaultPort);
             var port = GetServicePort(service)?.Port ?? defaultPort;
-            var address = service.Spec.ClusterIP;
+            var address = GetLoadBalancerAddress(service);
+
+            if(string.IsNullOrEmpty(address))
+            {
+                address = service.Spec.ClusterIP;
+            }
 
             string healthScheme = resource.Spec.HealthChecksScheme;
 

--- a/src/HealthChecks.UI.K8s.Operator/Operator/NamespacedServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/NamespacedServiceWatcher.cs
@@ -41,7 +41,7 @@ namespace HealthChecks.UI.K8s.Operator
             Func<HealthCheckResource, bool> filter = (k) => k.Metadata.NamespaceProperty == resource.Metadata.NamespaceProperty;
 
             if (!_watchers.Keys.Any(filter))
-            {                
+            {
                 var response = _client.ListNamespacedServiceWithHttpMessagesAsync(
                     namespaceParameter: resource.Metadata.NamespaceProperty,
                     labelSelector: $"{resource.Spec.ServicesLabel}",

--- a/src/HealthChecks.UI.K8s.Operator/Operator/NamespacedServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/NamespacedServiceWatcher.cs
@@ -31,7 +31,6 @@ namespace HealthChecks.UI.K8s.Operator
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
-            _notificationHandler = notificationHandler;
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _notificationHandler = notificationHandler ?? throw new ArgumentNullException(nameof(notificationHandler));
         }

--- a/src/HealthChecks.UI.K8s.Operator/Program.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
 using HealthChecks.UI.K8s.Operator.Diagnostics;
+using HealthChecks.UI.K8s.Operator.Operator;
 
 namespace HealthChecks.UI.K8s.Operator
 {
@@ -49,7 +50,9 @@ namespace HealthChecks.UI.K8s.Operator
                 .AddSingleton<ServiceHandler>()
                 .AddSingleton<SecretHandler>()
                 .AddSingleton<ConfigMaphandler>()
-                .AddSingleton<HealthCheckServiceWatcher>();
+                .AddSingleton<NotificationHandler>()
+                .AddSingleton<NamespacedServiceWatcher>()
+                .AddSingleton<ClusterServiceWatcher>();
 
             }).ConfigureLogging((context, builder) =>
             {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for Cluster and Namespaced scopes.

The scope field (Cluster or Namespaced) is mandatory and will specify to the operator whether it should watch for healthchecks services in the same namespace where the UI resource is created or watch to all services in all namespaces.

If you wan't to have different UI's for different namespaced services you should use **Namespaced**

If you wan't to have a single UI that monitors all the healthchecks from the cluster you should use **Cluster**

Note: The UI resources created by the operator (deployment, service, configmap, secret, etc) will always be created in the metadata specified namespace.

```yaml
spec:
  name: healthchecks-ui
  scope: Namespaced #The UI will be created at specified namespace (demo) and will watch healthchecks services in demo namespace only
  #scope: Cluster The UI will be created at specified namespace (demo) but will watch healthcheck services across all namespaces
  servicesLabel: HealthChecks
```

**Which issue(s) this PR fixes**: #575 

