### PR TITLE
Issue #566:Customize HTTP status codes for Prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ app.UseHealthChecksPrometheusExporter()
 
 // You could customize the endpoint
 app.UseHealthChecksPrometheusExporter("/my-health-metrics")
+
+// Customize HTTP status code returned(prometheus will not read health metrics when a default HTTP 503 is returned)
+app.UseHealthChecksPrometheusExporter("/my-health-metrics", options => options.ResultStatusCodes[HealthStatus.Unhealthy] = (int)HttpStatusCode.OK)
 ```
 
 ## HealthCheckUI

--- a/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
@@ -7,7 +7,13 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PrometheusHealthCheckMiddleware 
     {
-        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint, Action<HealthCheckOptions> configure = null)
+        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder,
+            PathString endpoint)
+        {
+            return applicationBuilder.UseHealthChecksPrometheusExporter(endpoint, null);
+        }
+
+        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint, Action<HealthCheckOptions> configure)
         {
             var options = new HealthCheckOptions
             {

--- a/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using HealthChecks.Prometheus.Metrics;
+﻿using System;
+using HealthChecks.Prometheus.Metrics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 
@@ -6,12 +7,14 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PrometheusHealthCheckMiddleware 
     {
-        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint) 
+        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint, Action<HealthCheckOptions> configure = null)
         {
-            applicationBuilder.UseHealthChecks(endpoint, new HealthCheckOptions 
+            var options = new HealthCheckOptions
             {
                 ResponseWriter = PrometheusResponseWriter.WritePrometheusResultText
-            });
+            };
+            configure?.Invoke(options);
+            applicationBuilder.UseHealthChecks(endpoint, options);
             return applicationBuilder;
         }
     }

--- a/test/FunctionalTests/HealthChecks.Prometheus.Metrics/PrometheusResponseWriterTests.cs
+++ b/test/FunctionalTests/HealthChecks.Prometheus.Metrics/PrometheusResponseWriterTests.cs
@@ -67,5 +67,28 @@ namespace FunctionalTests.HealthChecks.Prometheus.Metrics
             var resultAsString = await response.Content.ReadAsStringAsync();
             resultAsString.Should().ContainCheckAndResult("fake", HealthStatus.Unhealthy);
         }
+
+        [SkipOnAppVeyor]
+        public async Task be_unhealthy_and_return_configured_status_code_when_health_checks_are()
+        {
+            var sut = new TestServer(new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                        .AddCheck("fake", check => HealthCheckResult.Unhealthy());
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecksPrometheusExporter("/health",options=>options.ResultStatusCodes[HealthStatus.Unhealthy] = (int)HttpStatusCode.OK);
+                }));
+
+            var response = await sut.CreateRequest("/health")
+                .GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var resultAsString = await response.Content.ReadAsStringAsync();
+            resultAsString.Should().ContainCheckAndResult("fake", HealthStatus.Unhealthy);
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

This is needed in order to have prometheus read metrics when health check status is failing.

**Which issue(s) this PR fixes**: #566 

Please reference the issue this PR will close: #566 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [X] Extended the documentation
- [ ] Provided sample for the feature
