### PR TITLE
Repect the settings used on UseRelativeApiPath when retrieving ui-settings

### DIFF
--- a/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/UIResourceExtensions.cs
@@ -17,7 +17,7 @@ namespace HealthChecks.UI.Core
             resource.Content = resource.Content
                 .Replace(Keys.HEALTHCHECKSUI_MAIN_UI_API_TARGET, apiPath);
 
-            var settingsPath = $"{options.ApiPath}/{Keys.HEALTHCHECKS_SETTINGS_ENDPOINT}";
+            var settingsPath = $"{apiPath}/{Keys.HEALTHCHECKS_SETTINGS_ENDPOINT}";
 
             resource.Content = resource.Content.Replace(Keys.HEALTHCHECKSUI_SETTINGS_ENDPOINT_TARGET, settingsPath);
 


### PR DESCRIPTION
Respect the settings used on UseRelativeApiPath when retrieving ui-settings

**What this PR does / why we need it**: Previous change broke the retrival of ui-settings on hosts requiring relative pathing.

**Which issue(s) this PR fixes**: #642 