### PR TITLE
Accept a AWSCredentials object for S3 and DynamoDb Health checks

### DIFF
--- a/src/HealthChecks.Aws.S3/S3BucketOptions.cs
+++ b/src/HealthChecks.Aws.S3/S3BucketOptions.cs
@@ -1,13 +1,12 @@
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.Runtime;
-using System;
 
 namespace HealthChecks.Aws.S3
 {
     public class S3BucketOptions
     {
-        public AWSCredentials Credentials { get; set; } = null!;
+        public AWSCredentials? Credentials { get; set; } = null;
 
         [Obsolete("Specify access key and secret as a BasicCredential to AWSCredentials instead")]
         public string? AccessKey { get; set; }

--- a/src/HealthChecks.Aws.S3/S3BucketOptions.cs
+++ b/src/HealthChecks.Aws.S3/S3BucketOptions.cs
@@ -6,11 +6,11 @@ namespace HealthChecks.Aws.S3
 {
     public class S3BucketOptions
     {
-        public AWSCredentials? Credentials { get; set; } = null;
+        public AWSCredentials? Credentials { get; set; }
 
-        [Obsolete("Specify access key and secret as a BasicCredential to AWSCredentials instead")]
+        [Obsolete("Specify access key and secret as a BasicCredential to Credentials property instead")]
         public string? AccessKey { get; set; }
-        [Obsolete("Specify access key and secret as a BasicCredential to AWSCredentials instead")]
+        [Obsolete("Specify access key and secret as a BasicCredential to Credentials property instead")]
         public string? SecretKey { get; set; }
 
         public AmazonS3Config S3Config { get; set; } = null!;

--- a/src/HealthChecks.Aws.S3/S3BucketOptions.cs
+++ b/src/HealthChecks.Aws.S3/S3BucketOptions.cs
@@ -1,12 +1,17 @@
 using Amazon.S3;
 using Amazon.S3.Model;
+using Amazon.Runtime;
+using System;
 
 namespace HealthChecks.Aws.S3
 {
     public class S3BucketOptions
     {
-        public string? AccessKey { get; set; }
+        public AWSCredentials Credentials { get; set; } = null!;
 
+        [Obsolete("Specify access key and secret as a BasicCredential to AWSCredentials instead")]
+        public string? AccessKey { get; set; }
+        [Obsolete("Specify access key and secret as a BasicCredential to AWSCredentials instead")]
         public string? SecretKey { get; set; }
 
         public AmazonS3Config S3Config { get; set; } = null!;

--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -1,3 +1,4 @@
+using Amazon.Runtime;
 using Amazon.S3;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -28,29 +29,45 @@ namespace HealthChecks.Aws.S3
                 AWSCredentials credentials = _bucketOptions.Credentials;
                 if (credentials == null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (!string.IsNullOrEmpty(_bucketOptions.AccessKey) && !string.IsNullOrEmpty(_bucketOptions.SecretKey))
                     {
                         // for backwards compatibility we create the basic credentials if the old fields are used
                         // but if they are not specified we fallback to using the default profile
                         credentials = new BasicAWSCredentials(_bucketOptions.AccessKey, _bucketOptions.SecretKey);
                     }
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
 
                 bool keysProvided = credentials != null;
-
+
+
+#pragma warning disable CS0618 // Type or member is obsolete
                 var client = keysProvided
                     ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
-                    : new AmazonS3Client(_bucketOptions.S3Config);
-
-                using (client)
-                {
-                    var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
-
-                    if (_bucketOptions.CustomResponseCheck != null)
-                    {
-                        return _bucketOptions.CustomResponseCheck.Invoke(response)
-                            ? HealthCheckResult.Healthy()
-                            : new HealthCheckResult(context.Registration.FailureStatus, description: "Custom response check is not satisfied.");
+                    : new AmazonS3Client(_bucketOptions.S3Config);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+
+
+                using (client)
+
+                {
+
+                    var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
+
+
+
+                    if (_bucketOptions.CustomResponseCheck != null)
+
+                    {
+
+                        return _bucketOptions.CustomResponseCheck.Invoke(response)
+
+                            ? HealthCheckResult.Healthy()
+
+                            : new HealthCheckResult(context.Registration.FailureStatus, description: "Custom response check is not satisfied.");
+
                     }
                 }
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -41,31 +41,19 @@ namespace HealthChecks.Aws.S3
 
                 bool keysProvided = credentials != null;
 
-
 #pragma warning disable CS0618 // Type or member is obsolete
                 var client = keysProvided
                     ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
                     : new AmazonS3Client(_bucketOptions.S3Config);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-
-
                 using (client)
-
                 {
-
                     var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
-
-
-
                     if (_bucketOptions.CustomResponseCheck != null)
-
                     {
-
                         return _bucketOptions.CustomResponseCheck.Invoke(response)
-
                             ? HealthCheckResult.Healthy()
-
                             : new HealthCheckResult(context.Registration.FailureStatus, description: "Custom response check is not satisfied.");
 
                     }

--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -44,7 +44,7 @@ namespace HealthChecks.Aws.S3
 #pragma warning disable CS0618 // Type or member is obsolete
                 var client = keysProvided
                     ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
-                    : new AmazonS3Client(_bucketOptions.S3Config);
+                    : new AmazonS3Client(credentials, _bucketOptions.S3Config);
 #pragma warning restore CS0618 // Type or member is obsolete
 
                 using (client)

--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -26,13 +26,13 @@ namespace HealthChecks.Aws.S3
         {
             try
             {
-                AWSCredentials credentials = _bucketOptions.Credentials;
+                AWSCredentials? credentials = _bucketOptions.Credentials;
                 if (credentials == null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
                     if (!string.IsNullOrEmpty(_bucketOptions.AccessKey) && !string.IsNullOrEmpty(_bucketOptions.SecretKey))
                     {
-                        // for backwards compatibility we create the basic credentials if the old fields are used
+                        // for backwards compatibility we create the basic credentials if the old properties were used
                         // but if they are not specified we fallback to using the default profile
                         credentials = new BasicAWSCredentials(_bucketOptions.AccessKey, _bucketOptions.SecretKey);
                     }
@@ -41,11 +41,9 @@ namespace HealthChecks.Aws.S3
 
                 bool keysProvided = credentials != null;
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 var client = keysProvided
-                    ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
-                    : new AmazonS3Client(credentials, _bucketOptions.S3Config);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    ? new AmazonS3Client(credentials, _bucketOptions.S3Config)
+                    : new AmazonS3Client(_bucketOptions.S3Config);
 
                 using (client)
                 {

--- a/src/HealthChecks.Aws.S3/S3HealthCheck.cs
+++ b/src/HealthChecks.Aws.S3/S3HealthCheck.cs
@@ -13,6 +13,7 @@ namespace HealthChecks.Aws.S3
             {
                 throw new ArgumentNullException(nameof(bucketOptions));
             }
+
             if (bucketOptions.S3Config == null)
             {
                 throw new ArgumentNullException(nameof(S3BucketOptions.S3Config));
@@ -24,22 +25,32 @@ namespace HealthChecks.Aws.S3
         {
             try
             {
-                bool keysProvided = !string.IsNullOrEmpty(_bucketOptions.AccessKey) &&
-                                    !string.IsNullOrEmpty(_bucketOptions.SecretKey);
+                AWSCredentials credentials = _bucketOptions.Credentials;
+                if (credentials == null)
+                {
+                    if (!string.IsNullOrEmpty(_bucketOptions.AccessKey) && !string.IsNullOrEmpty(_bucketOptions.SecretKey))
+                    {
+                        // for backwards compatibility we create the basic credentials if the old fields are used
+                        // but if they are not specified we fallback to using the default profile
+                        credentials = new BasicAWSCredentials(_bucketOptions.AccessKey, _bucketOptions.SecretKey);
+                    }
+                }
 
+                bool keysProvided = credentials != null;
+
                 var client = keysProvided
                     ? new AmazonS3Client(_bucketOptions.AccessKey, _bucketOptions.SecretKey, _bucketOptions.S3Config)
-                    : new AmazonS3Client(_bucketOptions.S3Config);
-
-                using (client)
-                {
-                    var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
-
-                    if (_bucketOptions.CustomResponseCheck != null)
-                    {
-                        return _bucketOptions.CustomResponseCheck.Invoke(response)
-                            ? HealthCheckResult.Healthy()
-                            : new HealthCheckResult(context.Registration.FailureStatus, description: "Custom response check is not satisfied.");
+                    : new AmazonS3Client(_bucketOptions.S3Config);
+
+                using (client)
+                {
+                    var response = await client.ListObjectsAsync(_bucketOptions.BucketName, cancellationToken);
+
+                    if (_bucketOptions.CustomResponseCheck != null)
+                    {
+                        return _bucketOptions.CustomResponseCheck.Invoke(response)
+                            ? HealthCheckResult.Healthy()
+                            : new HealthCheckResult(context.Registration.FailureStatus, description: "Custom response check is not satisfied.");
                     }
                 }
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
@@ -41,5 +41,39 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
+
+        /// <summary>
+        /// Add a health check for AWS DynamoDb database.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionOptionsFactory">A factory to build the DynamoDB connection data to use.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'dynamodb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddDynamoDb(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, DynamoDBOptions>? connectionOptionsFactory,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default)
+        {
+            if (connectionOptionsFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionOptionsFactory));
+            }
+
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new DynamoDbHealthCheck(connectionOptionsFactory(sp)),
+                failureStatus,
+                tags,
+                timeout));
+        }
     }
 }

--- a/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.DynamoDb/DependencyInjection/DynamoDbHealthCheckBuilderExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The specified <paramref name="builder"/>.</returns>
         public static IHealthChecksBuilder AddDynamoDb(
             this IHealthChecksBuilder builder,
-            Func<IServiceProvider, DynamoDBOptions>? connectionOptionsFactory,
+            Func<IServiceProvider, DynamoDBOptions> connectionOptionsFactory,
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,

--- a/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
@@ -19,7 +19,7 @@ namespace HealthChecks.DynamoDb
         {
             try
             {
-                AWSCredentials credentials = _options.Credentials;
+                AWSCredentials? credentials = _options.Credentials;
                 if (credentials == null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
@@ -25,7 +25,7 @@ namespace HealthChecks.DynamoDb
 #pragma warning disable CS0618 // Type or member is obsolete
                     if (!string.IsNullOrEmpty(_options.AccessKey) && !string.IsNullOrEmpty(_options.SecretKey))
                     {
-                        // for backwards compatibility we create the basic credentials if the old fields are used
+                        // for backwards compatibility we create the basic credentials if the old properties is used
                         // but if they are not specified we fallback to using the default profile
                         credentials = new BasicAWSCredentials(_options.AccessKey, _options.SecretKey);
                     }

--- a/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
@@ -22,12 +22,14 @@ namespace HealthChecks.DynamoDb
                 AWSCredentials credentials = _options.Credentials;
                 if (credentials == null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (!string.IsNullOrEmpty(_options.AccessKey) && !string.IsNullOrEmpty(_options.SecretKey))
                     {
                         // for backwards compatibility we create the basic credentials if the old fields are used
                         // but if they are not specified we fallback to using the default profile
                         credentials = new BasicAWSCredentials(_options.AccessKey, _options.SecretKey);
                     }
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
 
                 var client = new AmazonDynamoDBClient(credentials, _options.RegionEndpoint);

--- a/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbHealthCheck.cs
@@ -25,7 +25,8 @@ namespace HealthChecks.DynamoDb
 #pragma warning disable CS0618 // Type or member is obsolete
                     if (!string.IsNullOrEmpty(_options.AccessKey) && !string.IsNullOrEmpty(_options.SecretKey))
                     {
-                        // for backwards compatibility we create the basic credentials if the old properties is used
+                        // for backwards compatibility we create the basic credentials if the old properties are specified
+
                         // but if they are not specified we fallback to using the default profile
                         credentials = new BasicAWSCredentials(_options.AccessKey, _options.SecretKey);
                     }

--- a/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
@@ -1,4 +1,6 @@
+﻿using System;
 using Amazon;
+using Amazon.Runtime;
 
 namespace HealthChecks.DynamoDb
 {
@@ -7,10 +9,13 @@ namespace HealthChecks.DynamoDb
     /// </summary>
     public class DynamoDBOptions
     {
-        public string AccessKey { get; set; } = null!;
-
+        public AWSCredentials Credentials { get; set; } = null!;
+        
+        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials Field instead")]
+        public string AccessKey { get; set;} = null!;
+        
+        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials Field instead")]
         public string SecretKey { get; set; } = null!;
-
         public RegionEndpoint RegionEndpoint { get; set; } = null!;
     }
 }

--- a/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Amazon;
 using Amazon.Runtime;
 
@@ -10,11 +10,11 @@ namespace HealthChecks.DynamoDb
     public class DynamoDBOptions
     {
         public AWSCredentials Credentials { get; set; } = null!;
-        
-        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials Field instead")]
-        public string AccessKey { get; set;} = null!;
-        
-        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials Field instead")]
+
+        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials property instead")]
+        public string AccessKey { get; set; } = null!;
+
+        [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials property instead")]
         public string SecretKey { get; set; } = null!;
         public RegionEndpoint RegionEndpoint { get; set; } = null!;
     }

--- a/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
+++ b/src/HealthChecks.DynamoDb/DynamoDbOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using Amazon;
 using Amazon.Runtime;
 
@@ -9,7 +8,7 @@ namespace HealthChecks.DynamoDb
     /// </summary>
     public class DynamoDBOptions
     {
-        public AWSCredentials Credentials { get; set; } = null!;
+        public AWSCredentials? Credentials { get; set; }
 
         [Obsolete("Specify the access key and secret as a BasicCredential to the Credentials property instead")]
         public string AccessKey { get; set; } = null!;

--- a/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,3 +1,4 @@
+using Amazon.Runtime;
 using Amazon.S3;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,9 +17,8 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
             services.AddHealthChecks()
                 .AddS3(options =>
                 {
-                    options.AccessKey = "access-key";
+                    options.Credentials = new BasicAWSCredentials("access-key", "secret-key");
                     options.BucketName = "bucket-name";
-                    options.SecretKey = "secret-key";
                     options.S3Config = new AmazonS3Config();
                 });
 
@@ -39,9 +39,8 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
             services.AddHealthChecks()
                  .AddS3(options =>
                  {
-                     options.AccessKey = "access-key";
+                     options.Credentials = new BasicAWSCredentials("access-key", "secret-key");
                      options.BucketName = "bucket-name";
-                     options.SecretKey = "secret-key";
                      options.S3Config = new AmazonS3Config();
                  }, name: "aws s3 check");
 

--- a/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
@@ -33,6 +33,28 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
         }
 
         [Fact]
+        public void add_health_check_with_assumerole_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddS3(options =>
+                {
+                    options.Credentials = new AssumeRoleAWSCredentials(null, "role-arn", "session-name");
+                    options.BucketName = "bucket-name";
+                    options.S3Config = new AmazonS3Config();
+                });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("aws s3");
+            check.GetType().Should().Be(typeof(S3HealthCheck));
+        }
+
+        [Fact]
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();

--- a/test/HealthChecks.DynamoDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.DynamoDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -42,5 +42,22 @@ namespace HealthChecks.DynamoDb.Tests.DependencyInjection
             registration.Name.Should().Be("my-dynamodb-group");
             check.GetType().Should().Be(typeof(DynamoDbHealthCheck));
         }
+        [Fact]
+        public void add_health_check_with_assumecredentials_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddDynamoDb(_ => { _.Credentials = new AssumeRoleAWSCredentials(null, "role-arn", "role-session-name"); _.RegionEndpoint = RegionEndpoint.CNNorth1; });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("dynamodb");
+            check.GetType().Should().Be(typeof(DynamoDbHealthCheck));
+
+        }
     }
 }

--- a/test/HealthChecks.DynamoDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.DynamoDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,4 +1,5 @@
 using Amazon;
+using Amazon.Runtime;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -14,7 +15,7 @@ namespace HealthChecks.DynamoDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddDynamoDb(_ => { _.AccessKey = "key"; _.SecretKey = "key"; _.RegionEndpoint = RegionEndpoint.CNNorth1; });
+                .AddDynamoDb(_ => { _.Credentials = new BasicAWSCredentials("key", "key"); _.RegionEndpoint = RegionEndpoint.CNNorth1; });
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -30,7 +31,7 @@ namespace HealthChecks.DynamoDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddDynamoDb(_ => { _.AccessKey = "key"; _.SecretKey = "key"; _.RegionEndpoint = RegionEndpoint.CNNorth1; }, name: "my-dynamodb-group");
+                .AddDynamoDb(_ => { _.Credentials = new BasicAWSCredentials("key", "key"); _.RegionEndpoint = RegionEndpoint.CNNorth1; }, name: "my-dynamodb-group");
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();


### PR DESCRIPTION
Allows for expanded use cases of how to get the AWS credentials, for instance using Assume role (e.g. kubernetes service accounts bound to IAM roles)

**What this PR does / why we need it**:
Adds more control over which type of AWS credential is used. 

**Which issue(s) this PR fixes**:
Resolves #482 

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
Yes as it deprecated the previous passing of key / secret as string and instead asks you to specify the more specific type (BasicCredentials) used by AWS SDK. This is optional and we could change the PR so that the old fields are still valid and add a overload that accepts the credential types to use.

