### PR TITLE
Update SendGrid nuget to 9.21.0 to resolve #586

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -84,7 +84,7 @@
     <SolrNetCore>1.0.19</SolrNetCore>
     <IBMMQDotnetClient>9.1.4</IBMMQDotnetClient>
     <PomeloEntityFrameworkCoreMySql>3.1.2</PomeloEntityFrameworkCoreMySql>
-    <SendGrid>9.14.0</SendGrid>
+    <SendGrid>9.21.0</SendGrid>
     <ArangoDBNetStandard>1.0.0-alpha02</ArangoDBNetStandard>
   </PropertyGroup>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates SendGrid nuget package to version 9.21.0 which added previously removed [constructor ](https://github.com/sendgrid/sendgrid-csharp/issues/1027)which in turn broke SendGrid HealthCheck

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #586 

**Special notes for your reviewer**:
-none
**Does this PR introduce a user-facing change?**:
-no
