### PR TITLE
Option to build connection string with a factory

### DIFF
--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -34,5 +34,35 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
+        
+        /// <summary>
+        /// Add a health check for Postgres databases.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionStringFactory">A factory to build the Postgres connection string to be used.</param>
+        /// /// <param name="healthQuery">The query to be used in check. Optional. If <c>null</c> SELECT 1 is used.</param>
+        /// <param name="connectionAction">An optional action to allow additional Npgsql-specific configuration.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, Func<IServiceProvider, string> connectionStringFactory, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default,TimeSpan? timeout = default)
+        {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+            
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new NpgSqlHealthCheck(connectionStringFactory(sp), healthQuery, connectionAction),
+                failureStatus,
+                tags,
+                timeout));
+        }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an additional health check builder extension in case there is need to use an instance of a class set up using dependency injection to retrieve the connection string.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Adding additional health check builder extension using a factory to get the connection string