### PR TITLE
Add Support For Azure Storage Options (Client Version)

### DIFF
--- a/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
@@ -16,21 +16,24 @@ namespace HealthChecks.AzureStorage
 
         private readonly string _connectionString;
         private readonly string _containerName;
+        private readonly BlobClientOptions _clientOptions;
 
         private static readonly ConcurrentDictionary<string, BlobServiceClient> _blobClientsHolder
             = new ConcurrentDictionary<string, BlobServiceClient>();
 
-        public AzureBlobStorageHealthCheck(string connectionString, string containerName = default)
+        public AzureBlobStorageHealthCheck(string connectionString, string containerName = default, BlobClientOptions clientOptions = null)
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
             _containerName = containerName;
+            _clientOptions = clientOptions;
         }
 
-        public AzureBlobStorageHealthCheck(Uri blobServiceUri, TokenCredential credential, string containerName = default)
+        public AzureBlobStorageHealthCheck(Uri blobServiceUri, TokenCredential credential, string containerName = default,BlobClientOptions clientOptions=null)
         {
             _blobServiceUri = blobServiceUri ?? throw new ArgumentNullException(nameof(blobServiceUri));
             _azureCredential = credential ?? throw new ArgumentNullException(nameof(credential));
             _containerName = containerName;
+            _clientOptions = clientOptions;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -68,11 +71,11 @@ namespace HealthChecks.AzureStorage
             {
                 if (_connectionString != null)
                 {
-                    client = new BlobServiceClient(_connectionString);
+                    client = new BlobServiceClient(_connectionString,_clientOptions);
                 }
                 else
                 {
-                    client = new BlobServiceClient(_blobServiceUri, _azureCredential);
+                    client = new BlobServiceClient(_blobServiceUri, _azureCredential, _clientOptions);
                 }
 
                 _blobClientsHolder.TryAdd(serviceUri, client);

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -3,6 +3,7 @@ using HealthChecks.AzureStorage;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Collections.Generic;
+using Azure.Storage.Blobs;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -25,11 +26,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddAzureBlobStorage(this IHealthChecksBuilder builder, string connectionString, string containerName = default, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddAzureBlobStorage(this IHealthChecksBuilder builder, string connectionString, string containerName = default, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,BlobClientOptions clientOptions = null)
         {
             return builder.Add(new HealthCheckRegistration(
                name ?? AZURESTORAGE_NAME,
-               sp => new AzureBlobStorageHealthCheck(connectionString, containerName),
+               sp => new AzureBlobStorageHealthCheck(connectionString, containerName, clientOptions),
                failureStatus,
                tags,
                timeout));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Azure Blob Health Checks Need Support For Custom Client Version

**Which issue(s) this PR fixes**:

No existing PR.
The original is that I use AzureStorage Health Check and I got an unhealty result with "Unhealty with 'null'" message.
I clone the source code and find the blob client return Header error that I solve in my application with set the client version to earlier version.
So I need to set the version of blob client to use the health check extension.
I fix it with adding an optional parameters in AddAzureBlobStorage Function and the related configurations.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
