### PR TITLE
Allow Uris healthcheck to configure HttpClient and custom HttpMessageHandler

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -87,6 +87,7 @@
     <SendGrid>9.21.1</SendGrid>
     <ArangoDBNetStandard>1.0.0-alpha03</ArangoDBNetStandard>
     <SystemServiceProcessServiceController>5.0.0</SystemServiceProcessServiceController>
+    <RichardSzalayMockHttp>6.0.0</RichardSzalayMockHttp>
   </PropertyGroup>
 
   <PropertyGroup Label="CLI Tools Versions">

--- a/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/ClusterServiceWatcher.cs
@@ -23,8 +23,8 @@ namespace HealthChecks.UI.K8s.Operator.Operator
           IKubernetes client,
           ILogger<K8sOperator> logger,
           OperatorDiagnostics diagnostics,
-          NotificationHandler notificationHandler,
-          IHttpClientFactory httpClientFactory)
+          NotificationHandler notificationHandler
+          )
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default,
             HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, 
@@ -57,8 +59,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
-        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default,
             HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
@@ -93,8 +95,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
-        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default,
             HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
@@ -123,8 +125,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
-        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default,
             HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
@@ -159,8 +161,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
-        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default,
             IEnumerable<string> tags = default, TimeSpan? timeout = default,
@@ -194,8 +196,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
-        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <param name="configureClient">An optional setup action to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional setup action to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(
             this IHealthChecksBuilder builder,

--- a/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, 
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
             var registrationName = name ?? NAME;
             ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
@@ -55,8 +57,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
             var registrationName = name ?? NAME;
             ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
@@ -87,8 +93,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
             var registrationName = name ?? NAME;
             ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
@@ -113,8 +123,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default,
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
             var registrationName = name ?? NAME;
             ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
@@ -145,8 +159,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default, TimeSpan? timeout = default,
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
 
             var registrationName = name ?? NAME;
@@ -176,7 +194,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <returns></returns>
+        /// <param name="configureClient">An optional to configure the Uris HealthCheck http client</param>
+        /// <param name="configureHttpMessageHandler">An optional to configure the Uris HealthCheck http client message handler</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddUrlGroup(
             this IHealthChecksBuilder builder,
             Func<IServiceProvider, Uri> uriProvider,
@@ -184,7 +204,7 @@ namespace Microsoft.Extensions.DependencyInjection
             HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null,
             TimeSpan? timeout = null,
-            Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
+            Action<IServiceProvider, HttpClient> configureClient = null, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler = null)
         {
             var registrationName = name ?? NAME;
             ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
@@ -214,10 +234,10 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
 
-        static Action<HttpClient> EmptyHttpClientCallback = (client) => { };
-        static Func<HttpMessageHandler> DefaultHttpMessageHandlerCallback = () => new HttpClientHandler();
+        static Action<IServiceProvider, HttpClient> EmptyHttpClientCallback = (_, _) => { };
+        static Func<IServiceProvider, HttpMessageHandler> DefaultHttpMessageHandlerCallback = _ => new HttpClientHandler();
 
-        private static void ConfigureUrisClient(IHealthChecksBuilder builder, Action<HttpClient> configureHttpclient, Func<HttpMessageHandler> configureHttpMessageHandler, string registrationName)
+        private static void ConfigureUrisClient(IHealthChecksBuilder builder, Action<IServiceProvider, HttpClient> configureHttpclient, Func<IServiceProvider, HttpMessageHandler> configureHttpMessageHandler, string registrationName)
         {
             builder.Services.AddHttpClient(registrationName)
                 .ConfigureHttpClient(configureHttpclient ?? EmptyHttpClientCallback)

--- a/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
@@ -214,14 +214,14 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
 
-        static Action<HttpClient> NullHttpClientCallback = (client) => { };
-        static Func<HttpMessageHandler> NullHttpMessageHandlerCallback = () => new HttpClientHandler();
+        static Action<HttpClient> EmptyHttpClientCallback = (client) => { };
+        static Func<HttpMessageHandler> DefaultHttpMessageHandlerCallback = () => new HttpClientHandler();
 
         private static void ConfigureUrisClient(IHealthChecksBuilder builder, Action<HttpClient> configureHttpclient, Func<HttpMessageHandler> configureHttpMessageHandler, string registrationName)
         {
             builder.Services.AddHttpClient(registrationName)
-                .ConfigureHttpClient(configureHttpclient ?? NullHttpClientCallback)
-                .ConfigurePrimaryHttpMessageHandler(configureHttpMessageHandler ?? NullHttpMessageHandlerCallback);
+                .ConfigureHttpClient(configureHttpclient ?? EmptyHttpClientCallback)
+                .ConfigurePrimaryHttpMessageHandler(configureHttpMessageHandler ?? DefaultHttpMessageHandlerCallback);
         }
 
     }

--- a/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Uris/DependencyInjection/UrisHealthCheckBuilderExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         const string NAME = "uri-group";
 
+
         /// <summary>
         /// Add a health check for single uri.
         /// </summary>
@@ -23,11 +24,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
-
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
+
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
                 sp =>
@@ -55,11 +56,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Uri uri, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
-
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
+
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
                 sp =>
@@ -87,11 +88,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
-
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
+
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
                 sp => CreateHealthCheck(sp, registrationName, UriHealthCheckOptions.CreateFromUris(uris)),
@@ -113,11 +114,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, IEnumerable<Uri> uris, HttpMethod httpMethod, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
-
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
+
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
                 sp =>
@@ -145,11 +146,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddUrlGroup(this IHealthChecksBuilder builder, Action<UriHealthCheckOptions> uriOptions, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
 
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
+
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
                 sp =>
@@ -181,10 +183,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string name = null,
             HealthStatus? failureStatus = null,
             IEnumerable<string> tags = null,
-            TimeSpan? timeout = null)
+            TimeSpan? timeout = null,
+            Action<HttpClient> configureClient = null, Func<HttpMessageHandler> configureHttpMessageHandler = null)
         {
-            builder.Services.AddHttpClient();
             var registrationName = name ?? NAME;
+            ConfigureUrisClient(builder, configureClient, configureHttpMessageHandler, registrationName);
 
             return builder.Add(
                 new HealthCheckRegistration(
@@ -209,5 +212,17 @@ namespace Microsoft.Extensions.DependencyInjection
             var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
             return new UriHealthCheck(options, () => httpClientFactory.CreateClient(name));
         }
+
+
+        static Action<HttpClient> NullHttpClientCallback = (client) => { };
+        static Func<HttpMessageHandler> NullHttpMessageHandlerCallback = () => new HttpClientHandler();
+
+        private static void ConfigureUrisClient(IHealthChecksBuilder builder, Action<HttpClient> configureHttpclient, Func<HttpMessageHandler> configureHttpMessageHandler, string registrationName)
+        {
+            builder.Services.AddHttpClient(registrationName)
+                .ConfigureHttpClient(configureHttpclient ?? NullHttpClientCallback)
+                .ConfigurePrimaryHttpMessageHandler(configureHttpMessageHandler ?? NullHttpMessageHandlerCallback);
+        }
+
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="$(RichardSzalayMockHttp)" />
     <PackageReference Include="xunit" Version="$(xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudio)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdk)" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="$(xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudio)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />

--- a/test/UnitTests/Uris/UrisHealthcheckTests.cs
+++ b/test/UnitTests/Uris/UrisHealthcheckTests.cs
@@ -18,12 +18,11 @@ namespace UnitTests.Uris
     public class uris_healthcheck_should
     {
         private const string RequestUri = "http://localhost/mock";
+        private const string hcname = "uri-healthcheck";
         [Fact]
         public async Task use_configured_http_client_and_handler_with_default_overload()
         {
             var services = new ServiceCollection();
-            var hcname = "uri-healthcheck";
-
 
             Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
 
@@ -50,8 +49,7 @@ namespace UnitTests.Uris
         public async Task use_configured_http_client_and_handler_when_configuring_method()
         {
             var services = new ServiceCollection();
-            var hcname = "uri-healthcheck";
-            
+
             Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
 
             Func<HttpMessageHandler> configureHttpClientHandler = () => GetMockedStatusCodeHandler(StatusCodes.Status500InternalServerError);
@@ -76,8 +74,6 @@ namespace UnitTests.Uris
         public async Task use_configured_http_client_and_handler_when_using_setup_method()
         {
             var services = new ServiceCollection();
-            var hcname = "uri-healthcheck";
-
 
             Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
 
@@ -105,7 +101,6 @@ namespace UnitTests.Uris
         public void create_healthcheck_with_no_configured_httpclient_or_handler()
         {
             var services = new ServiceCollection();
-            var hcname = "uri-healthcheck";
 
             services
                 .AddHealthChecks()

--- a/test/UnitTests/Uris/UrisHealthcheckTests.cs
+++ b/test/UnitTests/Uris/UrisHealthcheckTests.cs
@@ -1,0 +1,134 @@
+﻿using FluentAssertions;
+using HealthChecks.Uris;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using RichardSzalay.MockHttp;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.Uris
+{
+    public class uris_healthcheck_should
+    {
+        private const string RequestUri = "http://localhost/mock";
+        [Fact]
+        public async Task use_configured_http_client_and_handler_with_default_overload()
+        {
+            var services = new ServiceCollection();
+            var hcname = "uri-healthcheck";
+
+
+            Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
+
+            Func<HttpMessageHandler> configureHttpClientHandler = () => GetMockedStatusCodeHandler(StatusCodes.Status200OK);
+
+            services
+                .AddHealthChecks()
+                .AddUrlGroup(new Uri(RequestUri), hcname, configureClient: clientConfigurationCallback, configureHttpMessageHandler: configureHttpClientHandler);
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(sp);
+
+            var result = await check.CheckHealthAsync(new HealthCheckContext { Registration = registration });
+            result.Status.Should().Be(HealthStatus.Healthy);
+            var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(hcname);
+            client.DefaultRequestHeaders.Any(s => s.Key == "MockHeader").Should().BeTrue();
+            
+        }
+
+        [Fact]
+        public async Task use_configured_http_client_and_handler_when_configuring_method()
+        {
+            var services = new ServiceCollection();
+            var hcname = "uri-healthcheck";
+            
+            Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
+
+            Func<HttpMessageHandler> configureHttpClientHandler = () => GetMockedStatusCodeHandler(StatusCodes.Status500InternalServerError);
+
+            services
+                .AddHealthChecks()
+                .AddUrlGroup(new Uri(RequestUri), HttpMethod.Post, hcname, configureClient: clientConfigurationCallback, configureHttpMessageHandler: configureHttpClientHandler);
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(sp);
+            var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(hcname);
+            var result = await check.CheckHealthAsync(new HealthCheckContext { Registration = registration });
+
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+            client.DefaultRequestHeaders.Any(s => s.Key == "MockHeader").Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task use_configured_http_client_and_handler_when_using_setup_method()
+        {
+            var services = new ServiceCollection();
+            var hcname = "uri-healthcheck";
+
+
+            Action<HttpClient> clientConfigurationCallback = (HttpClient client) => client.DefaultRequestHeaders.Add("MockHeader", "value");
+
+            Func<HttpMessageHandler> configureHttpClientHandler = () => GetMockedStatusCodeHandler(400);
+
+            services
+                .AddHealthChecks()
+                .AddUrlGroup(uriOptions: uriOptions => uriOptions.AddUri(new Uri(RequestUri)) , name: hcname, configureClient: clientConfigurationCallback, configureHttpMessageHandler: configureHttpClientHandler);
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(sp);
+            var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(hcname);
+
+            var result = await check.CheckHealthAsync(new HealthCheckContext { Registration = registration });
+
+            client.DefaultRequestHeaders.Any(s => s.Key == "MockHeader").Should().BeTrue();
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+        }
+
+
+        [Fact]
+        public void create_healthcheck_with_no_configured_httpclient_or_handler()
+        {
+            var services = new ServiceCollection();
+            var hcname = "uri-healthcheck";
+
+            services
+                .AddHealthChecks()
+                .AddUrlGroup(new Uri(RequestUri));
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var hc = registration.Factory(sp);
+            var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(hcname);
+
+            client.DefaultRequestHeaders.Should().BeEmpty();
+            hc.Should().BeOfType<UriHealthCheck>();
+
+        }
+
+        private HttpMessageHandler GetMockedStatusCodeHandler(int statusCode)
+        {
+            var handler = new MockHttpMessageHandler();
+            handler.Expect(RequestUri).Respond((HttpStatusCode) statusCode, "text/plain", "ok");
+
+            return handler;
+        }
+    }
+}


### PR DESCRIPTION
Allow Uris HealthCheck method overloads to setup delegates to configure HttpClient and the primary Http Message handler.

Sample usage:

```csharp

services.AddSingleton(new ApiKeyConfiguration { HeaderName = "X-API-KEY", HeaderValue = "my-api-key"});

Action<IServiceProvider, HttpClient> clientConfigurationCallback = (sp, client) => {
       var keyConfiguration = sp.GetRequiredService<ApiKeyConfiguration>();
       client.DefaultRequestHeaders.Add(keyConfiguration.HeaderName, keyConfiguration.HeaderValue);
};

 Func<IServiceProvider, HttpMessageHandler> configureHttpClientHandler = _ => new MyCustomMessageHandler();

services
   .AddHealthChecks()
   .AddUrlGroup(new Uri(RequestUri), HttpMethod.Post, hcname, 
    configureClient: clientConfigurationCallback, configureHttpMessageHandler: configureHttpClientHandler);

```

**What this PR does / why we need it**: 

Allow to configure HttpClient and HttpMessageHandler for Uri healthcheck

**Which issue(s) this PR fixes**: #675


Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
