### PR TITLE
Add an optional func parameter to SqlServer healthcheck for validatio…

### DIFF
--- a/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <param name="beforeOpenConnectionConfigurer">An optional action executed before the connection is Open on the healthcheck.</param>
+        /// <param name="queryValidator">An optional func to validate the object returned by the sql query.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddSqlServer(this IHealthChecksBuilder builder,
             string connectionString,
@@ -33,9 +34,10 @@ namespace Microsoft.Extensions.DependencyInjection
             HealthStatus? failureStatus = default,
             IEnumerable<string> tags = default,
             TimeSpan? timeout = default,
-            Action<SqlConnection> beforeOpenConnectionConfigurer = default)
+            Action<SqlConnection> beforeOpenConnectionConfigurer = default,
+            Func<object, HealthCheckResult> queryValidator = default)
         {
-            return builder.AddSqlServer(_ => connectionString, healthQuery, name, failureStatus, tags, timeout, beforeOpenConnectionConfigurer);
+            return builder.AddSqlServer(_ => connectionString, healthQuery, name, failureStatus, tags, timeout, beforeOpenConnectionConfigurer, queryValidator);
         }
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <param name="beforeOpenConnectionConfigurer">An optional action executed before the connection is Open on the healthcheck.</param>
+        /// <param name="queryValidator">An optional func to validate the object returned by the healthQuery.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddSqlServer(this IHealthChecksBuilder builder,
             Func<IServiceProvider, string> connectionStringFactory,
@@ -60,7 +63,8 @@ namespace Microsoft.Extensions.DependencyInjection
             HealthStatus? failureStatus = default,
             IEnumerable<string> tags = default,
             TimeSpan? timeout = default,
-            Action<SqlConnection> beforeOpenConnectionConfigurer = default)
+            Action<SqlConnection> beforeOpenConnectionConfigurer = default,
+            Func<object, HealthCheckResult> queryValidator = default)
         {
             if (connectionStringFactory == null)
             {
@@ -69,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new SqlServerHealthCheck(connectionStringFactory(sp), healthQuery ?? HEALTH_QUERY, beforeOpenConnectionConfigurer),
+                sp => new SqlServerHealthCheck(connectionStringFactory(sp), healthQuery ?? HEALTH_QUERY, beforeOpenConnectionConfigurer, queryValidator),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
+++ b/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
@@ -34,7 +34,7 @@ namespace HealthChecks.SqlServer
                     {
                         command.CommandText = _sql;
                         var queryResult = await command.ExecuteScalarAsync(cancellationToken);
-                        if (null != _queryValidator)
+                        if (_queryValidator != null)
                         {
                             return _queryValidator(queryResult);
                         }

--- a/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
+++ b/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
@@ -12,12 +12,14 @@ namespace HealthChecks.SqlServer
         private readonly string _connectionString;
         private readonly string _sql;
         private readonly Action<SqlConnection> _beforeOpenConnectionConfigurer;
+        private readonly Func<object, HealthCheckResult> _queryValidator;
 
-        public SqlServerHealthCheck(string sqlserverconnectionstring, string sql, Action<SqlConnection> beforeOpenConnectionConfigurer = null)
+        public SqlServerHealthCheck(string sqlserverconnectionstring, string sql, Action<SqlConnection> beforeOpenConnectionConfigurer = null, Func<object, HealthCheckResult> queryValidator = null)
         {
             _connectionString = sqlserverconnectionstring ?? throw new ArgumentNullException(nameof(sqlserverconnectionstring));
             _sql = sql ?? throw new ArgumentNullException(nameof(sql));
             _beforeOpenConnectionConfigurer = beforeOpenConnectionConfigurer;
+            _queryValidator = queryValidator;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
@@ -31,7 +33,11 @@ namespace HealthChecks.SqlServer
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = _sql;
-                        await command.ExecuteScalarAsync(cancellationToken);
+                        var queryResult = await command.ExecuteScalarAsync(cancellationToken);
+                        if (null != _queryValidator)
+                        {
+                            return _queryValidator(queryResult);
+                        }
                     }
                     return HealthCheckResult.Healthy();
                 }


### PR DESCRIPTION
…n of the returned object from the SQL query.

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Currently SqlSever healthcheck executes a query which for Healthy status just needs to execute. This change adds an optional parameter to allow the result object to be validated by the user providing a func which is passed the result object.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes, There is a new optional parameter. If this parameter is not supplied by the user the functionality is backwards compatible.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
