### PR TITLE
backport HealthChecks.Publisher.Prometheus to .net-core-2.2

### DIFF
--- a/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.Prometheus.Metrics/Extensions/ApplicationBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using HealthChecks.Prometheus.Metrics;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class PrometheusHealthCheckMiddleware
+    {
+        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint)
+        {
+            return applicationBuilder.UseHealthChecksPrometheusExporter(endpoint, configure: null);
+        }
+
+        public static IApplicationBuilder UseHealthChecksPrometheusExporter(this IApplicationBuilder applicationBuilder, PathString endpoint, Action<HealthCheckOptions> configure)
+        {
+            var options = new HealthCheckOptions
+            {
+                ResponseWriter = PrometheusResponseWriter.WritePrometheusResultText
+            };
+            configure?.Invoke(options);
+
+            applicationBuilder.UseHealthChecks(endpoint, options);
+            return applicationBuilder;
+        }
+    }
+}

--- a/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
+++ b/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
+    <PackageLicenseUrl>$(PackageLicenseUrl)</PackageLicenseUrl>
+    <PackageProjectUrl>$(PackageProjectUrl)</PackageProjectUrl>
+    <PackageTags>HealthCheck;Prometheus;Prometheus Exporter;Metrics</PackageTags>
+    <Description>HealthChecks.Publisher.Prometheus is a health check prometheus metrics exporter.</Description>
+    <Version>$(HealthCheckPrometheusMetrics)</Version>
+    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
+    <Company>$(Company)</Company>
+    <Authors>$(Authors)</Authors>
+    <PackageId>AspNetCore.HealthChecks.Prometheus.Metrics</PackageId>
+    <PublishRepositoryUrl>$(PublishRepositoryUrl)</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="prometheus-net" Version="$(PrometheusNet)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecks)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGithub)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/HealthChecks.Prometheus.Metrics/LivenessPrometheusMetrics.cs
+++ b/src/HealthChecks.Prometheus.Metrics/LivenessPrometheusMetrics.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Prometheus;
+
+namespace HealthChecks.Prometheus.Metrics
+{
+    public abstract class LivenessPrometheusMetrics
+    {
+        protected const string ContentType = "text/plain; version=0.0.4";
+        private const string HealthCheckLabelName = "healthcheck";
+        private readonly Gauge _healthChecksDuration;
+        private readonly Gauge _healthChecksResult;
+        protected readonly CollectorRegistry Registry;
+
+        internal LivenessPrometheusMetrics()
+        {
+            Registry = global::Prometheus.Metrics.DefaultRegistry;
+            var factory = global::Prometheus.Metrics.WithCustomRegistry(Registry);
+
+            _healthChecksResult = factory.CreateGauge("healthcheck",
+                "Shows raw health check status (0 = Unhealthy, 1 = Degraded, 2 = Healthy)", new GaugeConfiguration
+                {
+                    LabelNames = new[] { HealthCheckLabelName },
+                    SuppressInitialValue = false
+                });
+
+            _healthChecksDuration = factory.CreateGauge("healthcheck_duration_seconds",
+                "Shows duration of the health check execution in seconds",
+                new GaugeConfiguration
+                {
+                    LabelNames = new[] { HealthCheckLabelName },
+                    SuppressInitialValue = false
+                });
+        }
+        protected void WriteMetricsFromHealthReport(HealthReport report)
+        {
+            foreach (var reportEntry in report.Entries)
+            {
+                _healthChecksResult.Labels(reportEntry.Key).
+                    Set((double)reportEntry.Value.Status);
+
+                _healthChecksDuration.Labels(reportEntry.Key)
+                    .Set(reportEntry.Value.Duration.TotalSeconds);
+            }
+        }
+    }
+}

--- a/src/HealthChecks.Prometheus.Metrics/PrometheusResponseWriter.cs
+++ b/src/HealthChecks.Prometheus.Metrics/PrometheusResponseWriter.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecks.Prometheus.Metrics
+{
+    public sealed class PrometheusResponseWriter : LivenessPrometheusMetrics
+    {
+        public static async Task WritePrometheusResultText(HttpContext context, HealthReport report)
+        {
+            var instance = new PrometheusResponseWriter();
+            instance.WriteMetricsFromHealthReport(report);
+
+            context.Response.ContentType = ContentType;
+            await instance.Registry.CollectAndExportAsTextAsync(context.Response.Body, context.RequestAborted);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Users on .net core 2.2 would like HealthChecks.Publisher.Prometheus functionality

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X ] Code compiles correctly
- [X ] Created/updated tests
- [X ] Unit tests passing
- [X ] End-to-end tests passing
- [X ] Extended the documentation
- [X ] Provided sample for the feature
