### PR TITLE
Added ExpectedContent to URI Groups

### DIFF
--- a/src/HealthChecks.Uris/UriHealthCheck.cs
+++ b/src/HealthChecks.Uris/UriHealthCheck.cs
@@ -55,6 +55,15 @@ namespace HealthChecks.Uris
                             return new HealthCheckResult(context.Registration.FailureStatus, description: $"Discover endpoint #{idx} is not responding with code in {expectedStatusCodes.Min}...{expectedStatusCodes.Max} range, the current status is {response.StatusCode}.");
                         }
 
+                        if (!string.IsNullOrWhiteSpace(item.ExpectedContent))
+                        {
+                            var responseBody = await response.Content.ReadAsStringAsync();
+                            if (responseBody != item.ExpectedContent)
+                            {
+                                return new HealthCheckResult(context.Registration.FailureStatus, description: $"The expected value '{item.ExpectedContent}' was not found in the reponsebody!");
+                            }
+                        }
+
                         ++idx;
                     }
                 }

--- a/src/HealthChecks.Uris/UriHealthCheckOptions.cs
+++ b/src/HealthChecks.Uris/UriHealthCheckOptions.cs
@@ -13,6 +13,7 @@ namespace HealthChecks.Uris
         IUriOptions ExpectHttpCode(int codeToExpect);
         IUriOptions ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect);
         IUriOptions AddCustomHeader(string name, string value);
+        IUriOptions ExpectContent(string expectedContent);
     }
     public class UriOptions : IUriOptions
     {
@@ -21,6 +22,8 @@ namespace HealthChecks.Uris
         public TimeSpan Timeout { get; private set; }
 
         public (int Min, int Max)? ExpectedHttpCodes { get; private set; }
+        
+        public string ExpectedContent { get; private set; }
 
         public Uri Uri { get; }
 
@@ -67,6 +70,12 @@ namespace HealthChecks.Uris
             Timeout = timeout;
             return this;
         }
+
+        IUriOptions IUriOptions.ExpectContent(string expectedContent)
+        {
+            ExpectedContent = expectedContent;
+            return this;
+        }
     }
 
     public class UriHealthCheckOptions
@@ -76,6 +85,7 @@ namespace HealthChecks.Uris
         internal HttpMethod HttpMethod { get; private set; }
         internal TimeSpan Timeout { get; private set; }
         internal (int Min, int Max) ExpectedHttpCodes { get; private set; }
+        internal string ExpectedContent { get; private set; }
 
         public UriHealthCheckOptions()
         {
@@ -121,6 +131,11 @@ namespace HealthChecks.Uris
         public UriHealthCheckOptions ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect)
         {
             ExpectedHttpCodes = (minCodeToExpect, maxCodeToExpect);
+            return this;
+        }
+        public UriHealthCheckOptions ExpectContent(string expectedContent)
+        {
+            ExpectedContent = expectedContent;
             return this;
         }
         internal static UriHealthCheckOptions CreateFromUris(IEnumerable<Uri> uris)

--- a/test/FunctionalTests/HealthChecks.Uris/UriHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.Uris/UriHealthCheckTests.cs
@@ -299,5 +299,37 @@ namespace FunctionalTests.HealthChecks.Uris
             response.StatusCode
                 .Should().Be(HttpStatusCode.OK);
         }
+        [Fact]
+        public async Task be_unhealthy_if_request_succeeds_and_expected_response_fails()
+        {
+            var uri = new Uri($"https://httpbin.org/robots.txt");
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                        .AddUrlGroup(opt =>
+                        {
+                            opt.AddUri(uri);
+                            opt.ExpectContent("non-existent");
+                        }, tags: new string[] { "uris" });
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions()
+                    {
+                        Predicate = r => r.Tags.Contains("uris")
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Adds the ExpectedContent method to the IURIOptions to be able to expect a specific phrase in the response of the URL.

**Which issue(s) this PR fixes**:
None, it's a new feature

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [] Provided sample for the feature
