### PR TITLE
Bump SSH.NET version to 2020.0.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -58,7 +58,7 @@
     <MongoDBDriver>2.11.3</MongoDBDriver>
     <MySqlConnector>1.1.0</MySqlConnector>
     <ConfluentKafka>1.5.2</ConfluentKafka>
-    <SSHNet>2016.1.0</SSHNet>
+    <SSHNet>2020.0.1</SSHNet>
     <NEST>7.9.0</NEST>
     <SystemBuffers>4.5.1</SystemBuffers>
     <MicrosoftAzureDocumentDbCore>2.6.0</MicrosoftAzureDocumentDbCore>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

Bumps SSH.NET to [2020.0.1](https://github.com/sshnet/SSH.NET/releases/tag/2020.0.1) to fix a build failure when publishing a self-contained app.

**Which issue(s) this PR fixes**:

Error when publishing a self-contained app.

Please reference the issue this PR will close: #735 

**Special notes for your reviewer**:

This is the dependency graph for the version of SSH.NET that AspNetCore.HealthChecks.Network is currently using (2016.1.0):

```
AspNetCore.HealthChecks.Network 5.0.1
  -> SSH.NET 2016.1.0
    -> System.Net.Sockets 4.1.0
      -> runtime.unix.System.Net.Sockets 4.3.0
        -> System.Threading.ThreadPool (>= 4.3.0)
    -> System.Threading.ThreadPool (>= 4.0.10)
```

As you can see, there's a conflict in `System.Threading.ThreadPool (>= 4.3.0)` and `System.Threading.ThreadPool (>= 4.0.10)`. Which is now fixed in SSH.NET 2020.0.1:

https://github.com/sshnet/SSH.NET/blob/acda1431d23a9196377464e6f48056dfd42cc867/src/Renci.SshNet/Renci.SshNet.csproj#L24-L25

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
