### PR TITLE
Add to AspNetCore.HealthChecks.Network new SSL certificate HealthCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ HealthChecks packages include health checks for:
 - Amazon DynamoDb
 - Amazon S3
 - Google Cloud Firestore
-- Network: Ftp, SFtp, Dns, Tcp port, Smtp, Imap
+- Network: Ftp, SFtp, Dns, Tcp port, Smtp, Imap, Ssl
 - MongoDB
 - Kafka
 - Identity Server

--- a/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         const string IMAP_NAME = "imap";
         const string SMTP_NAME = "smtp";
         const string TCP_NAME = "tcp";
+        const string SSL_NAME = "ssl";
 
         /// <summary>
         /// Add a health check for network ping.
@@ -240,6 +241,34 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                 name ?? TCP_NAME,
                 sp => new TcpHealthCheck(options),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for SSL connection and validate the certificate.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="setup">The action to configure Ssl connection parameters.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'tcp' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddSslHealthCheck(this IHealthChecksBuilder builder,
+            Action<SslHealthCheckOptions> setup, string name = default, HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            var options = new SslHealthCheckOptions();
+            setup?.Invoke(options);
+
+            return builder.Add(new HealthCheckRegistration(
+                name ?? SSL_NAME,
+                sp => new SslHealthCheck(options),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.Network/SslHealthCheck.cs
+++ b/src/HealthChecks.Network/SslHealthCheck.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using HealthChecks.Network.Extensions;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+
+namespace HealthChecks.Network
+{
+    public class SslHealthCheck
+        : IHealthCheck
+    {
+        private readonly SslHealthCheckOptions _options;
+        public SslHealthCheck(SslHealthCheckOptions options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                foreach (var (host, port, checkLeftDays) in _options.ConfiguredHosts)
+                {
+                    using (var tcpClient = new TcpClient())
+                    {
+                        await tcpClient.ConnectAsync(host, port).WithCancellationTokenAsync(cancellationToken);
+
+                        if (!tcpClient.Connected)
+                        {
+                            return new HealthCheckResult(context.Registration.FailureStatus, description: $"Connection to host {host}:{port} failed");
+                        }
+
+                        var crt = await GetSslCertificate(tcpClient, host);
+
+                        if (crt is null || !crt.Verify())
+                        {
+                            return new HealthCheckResult(context.Registration.FailureStatus, description: $"Ssl certificate not present or not valid for {host}:{port}");
+                        }
+
+                        if (crt.NotAfter.Subtract(DateTime.Now).TotalDays <= checkLeftDays)
+                        {
+                            return HealthCheckResult.Degraded(description: $"Ssl certificate for {host}:{port} is about to expire in {checkLeftDays} days");
+                        }
+
+                        return HealthCheckResult.Healthy();
+                    }
+                }
+
+                return HealthCheckResult.Healthy();
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+
+        private async Task<X509Certificate2> GetSslCertificate(TcpClient client, string host)
+        {
+                SslStream ssl = new SslStream(client.GetStream(), false, new RemoteCertificateValidationCallback((sender, cert, ca, sslPolicyErrors) => sslPolicyErrors == SslPolicyErrors.None), null);
+
+                try
+                {
+                    await ssl.AuthenticateAsClientAsync(host);
+                    var cert = new X509Certificate2(ssl.RemoteCertificate);
+                    ssl.Close();
+                    return cert;
+                }
+                catch (Exception)
+                {
+                    ssl.Close();
+                    return null;
+                }
+        }
+
+    }
+}

--- a/src/HealthChecks.Network/SslHealthCheckOptions.cs
+++ b/src/HealthChecks.Network/SslHealthCheckOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace HealthChecks.Network
+{
+    public class SslHealthCheckOptions
+    {
+        internal List<(string host, int port, int checkLeftDays)> ConfiguredHosts = new List<(string host, int port, int checkLeftDays)>();
+        public SslHealthCheckOptions AddHost(string host, int port = 443, int checkLeftDays = 60)
+        {
+            ConfiguredHosts.Add((host, port, checkLeftDays));
+            return this;
+        }
+    }
+}

--- a/test/FunctionalTests/HealthCheck.Network/SslHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthCheck.Network/SslHealthCheckTests.cs
@@ -1,0 +1,188 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using HealthChecks.Network;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FunctionalTests.HealthChecks.Network
+{
+    [Collection("execution")]
+    public class ssl_healthcheck_should
+    {
+        private readonly ExecutionFixture _fixture;
+
+        public ssl_healthcheck_should(ExecutionFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        //Use https://badssl.com web site, witch provide samples certificates with varius states and types 
+        private const string _validHost256 = "sha256.badssl.com";
+        private const string _validHost384 = "sha384.badssl.com";
+        private const string _validHost512 = "sha512.badssl.com";
+        private const string _httpHost = "http.badssl.com";
+        private const string _revokedHost = "revoked.badssl.com";
+        private const string _expiredHost = "expired.badssl.com";
+        
+        [Fact]
+        public async Task be_healthy_if_ssl_is_valid()
+        {
+            
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddSslHealthCheck(options => { 
+                        options.AddHost(_validHost256);
+                        options.AddHost(_validHost384);
+                        options.AddHost(_validHost512);
+                    } , tags: new string[] { "ssl" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("ssl")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_ssl_is_not_present()
+        {
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddSslHealthCheck(options => options.AddHost(_httpHost, 80), tags: new string[] { "ssl" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("ssl")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_ssl_is_not_valid()
+        {
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddSslHealthCheck(options => options.AddHost(_revokedHost), tags: new string[] { "ssl" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("ssl")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [Fact]
+        public async Task be_unhealthy_if_ssl_is_expired()
+        {
+
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddSslHealthCheck(options => options.AddHost(_expiredHost), tags: new string[] { "ssl" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("ssl")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+
+        [Fact]
+        public async Task be_degraded_if_ssl_daysbefore()
+        {
+            var webHostBuilder = new WebHostBuilder()
+               .UseStartup<DefaultStartup>()
+               .ConfigureServices(services =>
+               {
+                   services.AddHealthChecks()
+                    .AddSslHealthCheck(options => options.AddHost(_validHost256, checkLeftDays: 1095), tags: new string[] { "ssl" });
+               })
+               .Configure(app =>
+               {
+                   app.UseHealthChecks("/health", new HealthCheckOptions()
+                   {
+                       Predicate = r => r.Tags.Contains("ssl")
+                   });
+               });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var resultAsString = await response.Content.ReadAsStringAsync();
+            resultAsString.Should().Contain(HealthStatus.Degraded.ToString());
+        }
+
+        [Fact]
+        public async Task respect_configured_timeout_and_throw_operation_cancelled_exception()
+        {
+            var options = new SslHealthCheckOptions();
+            options.AddHost("invalid", 5555);
+
+            var sslHealthCheck = new SslHealthCheck(options);
+
+            var result = await sslHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = new HealthCheckRegistration("ssl", instance: sslHealthCheck, failureStatus: HealthStatus.Degraded,
+                    null, timeout: null)
+            }, new CancellationTokenSource(TimeSpan.FromSeconds(2)).Token);
+
+            result.Exception.Should().BeOfType<OperationCanceledException>();
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/Network/NetworkUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/Network/NetworkUnitTests.cs
@@ -219,5 +219,39 @@ namespace UnitTests.HealthChecks.DependencyInjection.Network
             registration.Name.Should().Be("tcp-1");
             check.GetType().Should().Be(typeof(TcpHealthCheck));
         }
+
+        [Fact]
+        public void add_ssl_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddSslHealthCheck(options => { options.AddHost("the-host"); });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("ssl");
+            check.GetType().Should().Be(typeof(SslHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_ssl_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddSslHealthCheck(options => { options.AddHost("the-host", port: 111, checkLeftDays: 120); }, name: "ssl-1");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("ssl-1");
+            check.GetType().Should().Be(typeof(SslHealthCheck));
+        }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new HealthCheck SSL in AspNetCore.HealthChecks.Network for check validity of certificate or the expire date.

**Special notes for your reviewer**:
Verify SSL connection and validate certificate:
* If is not valid return unhealthy state.
* If is about to expire return degraded state.
* You can use checkLeftDays option for many days left to expire check

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ x] Code compiles correctly
- [ x] Created/updated tests
- [ x] Unit tests passing
- [ x] End-to-end tests passing
- [ x] Extended the documentation
- [ ] Provided sample for the feature
