### PR TITLE
Optimized RavenDB HealthChecks

### DIFF
--- a/src/HealthChecks.RavenDB/RavenDBHealthCheck.cs
+++ b/src/HealthChecks.RavenDB/RavenDBHealthCheck.cs
@@ -1,8 +1,16 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Routing;
+using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
+using Sparrow.Json;
 using System;
-using System.Linq;
+using System.Collections.Concurrent;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,6 +19,15 @@ namespace HealthChecks.RavenDB
     public class RavenDBHealthCheck : IHealthCheck
     {
         private readonly RavenDBOptions _options;
+
+        private static readonly GetBuildNumberOperation ServerHealthCheck = new GetBuildNumberOperation();
+
+        private static readonly DatabaseHealthCheckOperation DatabaseHealthCheck = new DatabaseHealthCheckOperation();
+
+        private static readonly GetStatisticsOperation LegacyDatabaseHealthCheck = new GetStatisticsOperation();
+
+        private static readonly ConcurrentDictionary<RavenDBOptions, DocumentStoreHolder> Stores = new ConcurrentDictionary<RavenDBOptions, DocumentStoreHolder>();
+
         public RavenDBHealthCheck(RavenDBOptions options)
         {
             if (options == null)
@@ -25,42 +42,127 @@ namespace HealthChecks.RavenDB
 
             _options = options;
         }
+
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                using (var store = new DocumentStore
+                var value = Stores.GetOrAdd(_options, o =>
                 {
-                    Urls = _options.Urls,
-                })
-                {
-                    if (_options.Certificate != null)
+                    var s = new DocumentStore
                     {
-                        store.Certificate = _options.Certificate;
+                        Urls = o.Urls,
+                        Certificate = o.Certificate
+                    };
+
+                    try
+                    {
+                        s.Initialize();
+                        return new DocumentStoreHolder
+                        {
+                            Store = s,
+                            Legacy = false
+                        };
                     }
-
-                    store.Initialize();
-
-                    var databases = await store
-                        .Maintenance
-                        .Server
-                        .SendAsync(new GetDatabaseNamesOperation(start: 0, pageSize: 100), cancellationToken);
-
-                    if (!string.IsNullOrWhiteSpace(_options.Database)
-                        && !databases.Contains(_options.Database, StringComparer.OrdinalIgnoreCase))
+                    catch (Exception)
                     {
-                        return new HealthCheckResult(
-                            context.Registration.FailureStatus,
-                            $"RavenDB does not contain '{_options.Database}' database.");
+                        try
+                        {
+                            s.Dispose();
+                        }
+                        catch
+                        {
+                            // nothing that we can do
+                        }
+
+                        throw;
+                    }
+                });
+
+                var store = value.Store;
+
+                if (string.IsNullOrWhiteSpace(_options.Database))
+                {
+                    await CheckServerHealthAsync(store, cancellationToken);
+
+                    return HealthCheckResult.Healthy();
+                }
+
+                try
+                {
+                    try
+                    {
+                        await CheckDatabaseHealthAsync(store, _options.Database, value.Legacy, cancellationToken);
+                    }
+                    catch (ClientVersionMismatchException e) when (e.Message.Contains(nameof(RouteNotFoundException)))
+                    {
+                        value.Legacy = true;
+
+                        await CheckDatabaseHealthAsync(store, _options.Database, value.Legacy, cancellationToken);
                     }
 
                     return HealthCheckResult.Healthy();
+                }
+                catch (DatabaseDoesNotExistException)
+                {
+                    return new HealthCheckResult(context.Registration.FailureStatus, $"RavenDB does not contain '{_options.Database}' database.");
                 }
             }
             catch (Exception ex)
             {
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
+        }
+
+        private static Task CheckServerHealthAsync(IDocumentStore store, CancellationToken cancellationToken)
+        {
+            return store.Maintenance.Server.SendAsync(ServerHealthCheck, cancellationToken);
+        }
+
+        private static async Task CheckDatabaseHealthAsync(IDocumentStore store, string database, bool legacy, CancellationToken cancellationToken)
+        {
+            var executor = store.Maintenance.ForDatabase(database);
+
+            if (legacy)
+            {
+                await executor.SendAsync(LegacyDatabaseHealthCheck, cancellationToken);
+                return;
+            }
+
+            await executor.SendAsync(DatabaseHealthCheck, cancellationToken);
+        }
+
+        private class DatabaseHealthCheckOperation : IMaintenanceOperation
+        {
+            public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new DatabaseHealthCheckCommand();
+            }
+
+            private class DatabaseHealthCheckCommand : RavenCommand
+            {
+                public DatabaseHealthCheckCommand()
+                {
+                    Timeout = TimeSpan.FromSeconds(15); // maybe even less?
+                }
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/healthcheck";
+
+                    return new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Get
+                    };
+                }
+            }
+        }
+
+        private class DocumentStoreHolder
+        {
+            public IDocumentStore Store { get; set; }
+
+            public bool Legacy { get; set; }
         }
     }
 }

--- a/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithSingleConnectionStringHealthCheckTests.cs
+++ b/test/FunctionalTests/HealthChecks.RavenDB/RavenDBWithSingleConnectionStringHealthCheckTests.cs
@@ -12,6 +12,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
+
 #pragma warning disable 618
 
 namespace FunctionalTests.HealthChecks.RavenDB
@@ -35,18 +36,16 @@ namespace FunctionalTests.HealthChecks.RavenDB
                 {
                     store.Initialize();
 
-
                     store.Maintenance.Server.Send(
                         new CreateDatabaseOperation(new DatabaseRecord("Demo")));
                 }
-
             }
             catch { }
         }
+
         [SkipOnAppVeyor]
         public async Task be_healthy_if_ravendb_is_available()
         {
-
             var webHostBuilder = new WebHostBuilder()
                 .UseStartup<DefaultStartup>()
                 .ConfigureServices(services =>
@@ -139,7 +138,11 @@ namespace FunctionalTests.HealthChecks.RavenDB
                 {
                     services
                     .AddHealthChecks()
-                    .AddRavenDB(setup => setup.Urls = new[] { ConnectionString }, "ThisDatabaseReallyDoesnExist", tags: new string[] { "ravendb" });
+                    .AddRavenDB(setup =>
+                    {
+                        setup.Urls = new[] { ConnectionString };
+                        setup.Database = "ThisDatabaseReallyDoesnExist";
+                    }, "ThisDatabaseReallyDoesnExist", tags: new string[] { "ravendb" });
                 })
                 .Configure(app =>
                 {


### PR DESCRIPTION
- do not create DocumentStore on each healthcheck - initialization performs additional and unnecessary calls to the server causing a lot of traffic
- use more lightweight endpoints to perform the healthchecks
