### PR TITLE
Added configurable storage via resource definition

### DIFF
--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -62,6 +62,16 @@ spec:
               type: string
             stylesheetContent:
               type: string
+            storageProvider:
+              type: string
+              enum:
+                - InMemory
+                - SqlServer
+                - Sqlite
+                - PostgreSql
+                - MySql
+            storageConnection:
+              type: string
             serviceAnnotations:
               type: array
               items:

--- a/doc/k8s-operator.md
+++ b/doc/k8s-operator.md
@@ -54,23 +54,25 @@ Note: The UI resources created by the operator (deployment, service, configmap, 
 
 ### Optional fields
 
-| Field                 | Description                                                          | Default                                              |
-| --------------------- | :------------------------------------------------------------------- | ---------------------------------------------------- |
-| serviceType           | How the UI should be published (ClusterIP, LoadBalancer or NodePort) | ClusterIP                                            |
-| portNumber            | What port will be used to expose the UI service                      | 80                                                   |
-| uiPath                | Location where the UI frontend will be served                        | /healthchecks                                        |
-| uiApiPath             | Location where the UI backend API will be served                     | UI defaults                                          |
-| uiResourcesPath       | Location where the UI static files resources will be served          | UI defaults                                          |
-| uiWebhooksPath        | Location where the Webhooks api                                      | UI defaults                                          |
-| uiNoRelativePaths     | Disable UI front-end relative paths                                  | false                                                |
-| healthChecksPath      | Path where the UI will collect health from endpoints                 | /health (Can be overriden with a service annotation) |
-| healthChecksScheme    | Scheme to be used to collect health from endpoints                   | http (Can be overriden with a service annotation)    |
-| image                 | Image to be used by the UI                                           | xabarilcoding/healthchecksui:latest                  |
-| imagePullPolicy       | Deployment image pull policy                                         | Always                                               |
-| stylesheetContent     | css content used to brand the UI                                     | none                                                 |
-| serviceAnnotations    | name / value array to use custom annotations in UI service           | none                                                 |
-| deploymentAnnotations | name / value array to use custom annotations in UI Deployment        | none                                                 |
-| webhooks              | webhook array object (name, uri, payload and restoredPayload)        | none                                                 |
+| Field                 | Description                                                                     | Default                                              |
+| --------------------- | :------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| serviceType           | How the UI should be published (ClusterIP, LoadBalancer or NodePort)            | ClusterIP                                            |
+| portNumber            | What port will be used to expose the UI service                                 | 80                                                   |
+| uiPath                | Location where the UI frontend will be served                                   | /healthchecks                                        |
+| uiApiPath             | Location where the UI backend API will be served                                | UI defaults                                          |
+| uiResourcesPath       | Location where the UI static files resources will be served                     | UI defaults                                          |
+| uiWebhooksPath        | Location where the Webhooks api                                                 | UI defaults                                          |
+| uiNoRelativePaths     | Disable UI front-end relative paths                                             | false                                                |
+| healthChecksPath      | Path where the UI will collect health from endpoints                            | /health (Can be overriden with a service annotation) |
+| healthChecksScheme    | Scheme to be used to collect health from endpoints                              | http (Can be overriden with a service annotation)    |
+| image                 | Image to be used by the UI                                                      | xabarilcoding/healthchecksui:latest                  |
+| imagePullPolicy       | Deployment image pull policy                                                    | Always                                               |
+| stylesheetContent     | css content used to brand the UI                                                | none                                                 |
+| storageProvider       | Storage provider used by UI (SqlServer, Sqlite, PostgreSql, MySql and InMemory) | InMemory                                             |
+| storageConnection     | Connection string for the selected provider                                     | none                                                 |
+| serviceAnnotations    | name / value array to use custom annotations in UI service                      | none                                                 |
+| deploymentAnnotations | name / value array to use custom annotations in UI Deployment                   | none                                                 |
+| webhooks              | webhook array object (name, uri, payload and restoredPayload)                   | none                                                 |
 
 ## Sample HealthChecks Operator Tutorial
 

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -20,6 +20,8 @@ namespace HealthChecks.UI.K8s.Operator
         public string Image { get; set; }
         public string ImagePullPolicy { get; set; }
         public string StylesheetContent { get; set; }
+        public string StorageProvider { get; set; }
+        public string StorageConnection { get; set; }
         public List<NameValueObject> ServiceAnnotations { get; set; } = new List<NameValueObject>();
         public List<NameValueObject> DeploymentAnnotations { get; set; } = new List<NameValueObject>();
         public List<WebHookObject> Webhooks { get; set; } = new List<WebHookObject>();

--- a/src/HealthChecks.UI.K8s.Operator/Extensions/HealthCheckResourceExtensions.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Extensions/HealthCheckResourceExtensions.cs
@@ -20,5 +20,7 @@ namespace HealthChecks.UI.K8s.Operator.Extensions
         public static bool HasBrandingConfigured(this HealthCheckResource resource) =>
                 resource.Spec.StylesheetContent.NotEmpty();
 
+        public static bool HasStorageConfigured(this HealthCheckResource resource) =>
+            resource.Spec.StorageProvider.NotEmpty() && resource.Spec.StorageConnection.NotEmpty();
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/DeploymentHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/DeploymentHandler.cs
@@ -167,6 +167,12 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
                 container.VolumeMounts.Add(new V1VolumeMount($"/app/{Constants.StylesPath}", volumeName));
             }
 
+            if (resource.HasStorageConfigured())
+            {
+                container.Env.Add(new V1EnvVar("storage_provider", resource.Spec.StorageProvider));
+                container.Env.Add(new V1EnvVar("storage_connection", resource.Spec.StorageConnection));
+            }
+
             return new V1Deployment(metadata: metadata, spec: spec);
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Currently, there is no way to configure a storage provider using the k8s Operator other than the InMemory provider. This PR makes it possible to use any storage the Healthcheck UI provides.

**Which issue(s) this PR fixes**:
None, it is a new feature.

**Special notes for your reviewer**:
There are no tests, as there are no tests for the operator. I've successfully tested with my dev AKS instance.

**Does this PR introduce a user-facing change?**:
Yes, there are new optional parameters, omitting them will result in no changes to the current behavior.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
