### PR TITLE
Features/add metric health status to promethues exporter

### DIFF
--- a/src/HealthChecks.Prometheus.Metrics/LivenessPrometheusMetrics.cs
+++ b/src/HealthChecks.Prometheus.Metrics/LivenessPrometheusMetrics.cs
@@ -9,6 +9,7 @@ namespace HealthChecks.Prometheus.Metrics
         private const string HealthCheckLabelName = "healthcheck";
         private readonly Gauge _healthChecksDuration;
         private readonly Gauge _healthChecksResult;
+        private readonly Gauge _healthStatus;
         protected readonly CollectorRegistry Registry;
 
         internal LivenessPrometheusMetrics()
@@ -19,7 +20,7 @@ namespace HealthChecks.Prometheus.Metrics
             _healthChecksResult = factory.CreateGauge("healthcheck",
                 "Shows raw health check status (0 = Unhealthy, 1 = Degraded, 2 = Healthy)", new GaugeConfiguration
                 {
-                    LabelNames = new[] {HealthCheckLabelName},
+                    LabelNames = new[] { HealthCheckLabelName },
                     SuppressInitialValue = false
                 });
 
@@ -27,7 +28,15 @@ namespace HealthChecks.Prometheus.Metrics
                 "Shows duration of the health check execution in seconds",
                 new GaugeConfiguration
                 {
-                    LabelNames = new[] {HealthCheckLabelName},
+                    LabelNames = new[] { HealthCheckLabelName },
+                    SuppressInitialValue = false
+                });
+
+            _healthStatus = factory.CreateGauge("health_status",
+                "Shows global health status (0 = Unhealthy, 2 = Healthy)",
+                new GaugeConfiguration
+                {
+                    LabelNames = new[] { "health_status" },
                     SuppressInitialValue = false
                 });
         }
@@ -41,6 +50,8 @@ namespace HealthChecks.Prometheus.Metrics
                 _healthChecksDuration.Labels(reportEntry.Key)
                     .Set(reportEntry.Value.Duration.TotalSeconds);
             }
+
+            _healthStatus.Set((int)report.Status);
         }
     }
 }

--- a/test/FunctionalTests/HealthChecks.Prometheus.Metrics/PrometheusResponseWriterTests.cs
+++ b/test/FunctionalTests/HealthChecks.Prometheus.Metrics/PrometheusResponseWriterTests.cs
@@ -43,6 +43,7 @@ namespace FunctionalTests.HealthChecks.Prometheus.Metrics
             response.EnsureSuccessStatusCode();
             var resultAsString = await response.Content.ReadAsStringAsync();
             resultAsString.Should().ContainCheckAndResult("fake", HealthStatus.Healthy);
+            resultAsString.Should().Contain("health_status 2");
         }
 
         [SkipOnAppVeyor]
@@ -66,6 +67,7 @@ namespace FunctionalTests.HealthChecks.Prometheus.Metrics
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
             var resultAsString = await response.Content.ReadAsStringAsync();
             resultAsString.Should().ContainCheckAndResult("fake", HealthStatus.Unhealthy);
+            resultAsString.Should().Contain("health_status 0");
         }
 
         [SkipOnAppVeyor]
@@ -80,7 +82,7 @@ namespace FunctionalTests.HealthChecks.Prometheus.Metrics
                 })
                 .Configure(app =>
                 {
-                    app.UseHealthChecksPrometheusExporter("/health",options => options.ResultStatusCodes[HealthStatus.Unhealthy] = (int)HttpStatusCode.OK);
+                    app.UseHealthChecksPrometheusExporter("/health", options => options.ResultStatusCodes[HealthStatus.Unhealthy] = (int)HttpStatusCode.OK);
                 }));
 
             var response = await sut.CreateRequest("/health")
@@ -89,6 +91,7 @@ namespace FunctionalTests.HealthChecks.Prometheus.Metrics
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             var resultAsString = await response.Content.ReadAsStringAsync();
             resultAsString.Should().ContainCheckAndResult("fake", HealthStatus.Unhealthy);
+            resultAsString.Should().Contain("health_status 0");
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Add a new metric to the `PrometheusExporter` called health_status, that show you if all your healthchecks are healthy or one your healthchecks are unhealthy. 

With this metric we only have to consult it, instead of making a query with PromQL that checks every healthchecks metric.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #729 

**Special notes for your reviewer**:
As follow, I will show you two examples:

**One** of your **dependencies are unhealthy**
> #HELP healthcheck Shows raw health check status (0 = Unhealthy, 1 = Degraded, 2 = Healthy)
> #TYPE healthcheck gauge
> healthcheck{healthcheck="dependecy1"} 2
> healthcheck{healthcheck="dependecy2"} 0
> #HELP health_status Global health status. Unhealthy = 0, Degraded = 1, Healthy = 2
> **health_status 0**

**All** of your **dependencies are healthy**
> #HELP healthcheck Shows raw health check status (0 = Unhealthy, 1 = Degraded, 2 = Healthy)
> #TYPE healthcheck gauge
> healthcheck{healthcheck="dependecy1"} 2
> healthcheck{healthcheck="dependecy2"} 2
> #HELP health_status Global health status. Unhealthy = 0, Degraded = 1, Healthy = 2
> **health_status 2**


**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
