### PR TITLE
Normalize IHealthChecksBuilder extensions

### DIFF
--- a/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
@@ -208,7 +208,10 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<SmtpHealthCheckOptions> setup, string name = default, HealthStatus? failureStatus = default,
             IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
-            builder.Services.Configure(setup);
+            if (setup != null)
+            {
+                builder.Services.Configure(setup);
+            }
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? SMTP_NAME,

--- a/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
@@ -205,13 +205,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddSmtpHealthCheck(this IHealthChecksBuilder builder,
-            Action<SmtpHealthCheckOptions> setup, string name = default, HealthStatus? failureStatus = default,
+            Action<SmtpHealthCheckOptions> setup = null, string name = default, HealthStatus? failureStatus = default,
             IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
-            if (setup != null)
-            {
-                builder.Services.Configure(setup);
-            }
+            builder.Services.Configure(setup ?? (_ => { }));
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? SMTP_NAME,

--- a/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Network/DependencyInjection/NetworkHealthCheckBuilderExtensions.cs
@@ -218,6 +218,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 timeout));
         }
 
+        public static IHealthChecksBuilder AddSmtpHealthCheck(this IHealthChecksBuilder builder,
+            Action<IServiceProvider, SmtpHealthCheckOptions> setup, string name = default, HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default, TimeSpan? timeout = default) =>
+            builder.Add(new HealthCheckRegistration(
+                name ?? SMTP_NAME,
+                sp =>
+                {
+                    var options = new SmtpHealthCheckOptions();
+                    setup?.Invoke(sp, options);
+                    return new SmtpHealthCheck(options);
+                },
+                failureStatus,
+                tags,
+                timeout));
+        
         /// <summary>
         /// Add a health check for network TCP connection.
         /// </summary>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

Please consider this as a quick example/POC.  I wanted to get some feedback from the primary maintainers of this project before I spent time adding similar overloads across the many health check extensions.  I don't want to sink a lot of time into this if there's no desire or intention to extend the framework in this way.

**What this PR does / why we need it**:
There are two candidate approaches I'm proposing.

## Option 1: configure via `IOptions`
Where some health check `IHealthCheckBuilder` extensions may provide an `Action<XXXHealthCheckOptions> setup`, this first approach makes use of the `IOptions` framework by invoking `builder.Services.Configure(setup);`
### advantages:
 - `Microsoft.Extensions.Options` is already a dependency of `Microsoft.Extensions.Diagnostics.HealthChecks`
 - API doesn't change for health check extensions that have a similar `Action<XXXHealthCheckOptions>` parameter
 - developers can take advantage of `IConfigureOptions<T>` to load config however they want, with full DI support
 - by resolving `IOptionsMonitor<T>`, health check options will resolve to their current runtime values when the health check is invoked.  with the current implementation, health check options are set once at application start.
   - an example use case: I have requirements to use [Azure App Configuration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview).  Our applications/services must react to runtime configuration changes and so must our health checks.
### disadvantages:
 - let me know if you see any, because I don't

Note: I did notice some health checks take different approaches to this already.  I saw some accepting a `Func<IServiceProvider, XXXOptions>`

## Option 2: configure directly from `IServiceProvider`
The second approach does not make use of the `IOptions<T>` framework.  Instead, the developer can provide a `Action<IServiceProvider, XXXHealthCheckOptions> setup` which is invoked when the health check is resolved from DI
### advantages:
 - does not depend on `Microsoft.Extensions.Options`
 - the intention of this api is more clear
### disadvantages:
 - not as flexible as option 1

**Special notes for your reviewer**:
The general goal here is to normalize how health checks are configured.  There seem to be a variety of approaches in use and deferring configuration management to the `IOptions` framework would open up a lot of flexibility for developers in a standard, familiar way.

**Does this PR introduce a user-facing change?**:
If the developer adding health checks is the "user", then yes, this introduces non-breaking changes.  If the "user" refers to someone accessing health checks UI, then no.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
