### PR TITLE
Allow Service bus to generate tokens from AD rather than needing a key

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -1,35 +1,47 @@
-﻿using System;
-using System.Collections.Concurrent;
-using Azure.Core;
-using Azure.Messaging.ServiceBus.Administration;
-
-namespace HealthChecks.AzureServiceBus
+﻿namespace HealthChecks.AzureServiceBus
 {
+    using System;
+    using System.Collections.Concurrent;
+    using Azure.Core;
+    using Azure.Messaging.ServiceBus.Administration;
+
     public abstract class AzureServiceBusHealthCheck
     {
         protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient>
-            ManagementClientConnections = new ();
-        protected string ConnectionString { get; }
+            ManagementClientConnections = new();
 
-        protected string Prefix => ConnectionString ?? Endpoint;
-
-        private string Endpoint { get; }
-        private TokenCredential TokenCredential { get; }
-
-        protected AzureServiceBusHealthCheck (string connectionString)
+        protected AzureServiceBusHealthCheck(string connectionString)
         {
             if (string.IsNullOrEmpty(connectionString))
             {
                 throw new ArgumentNullException(nameof(connectionString));
             }
+
             ConnectionString = connectionString;
         }
 
-        protected AzureServiceBusHealthCheck (string endpoint, TokenCredential tokenCredential)
+        protected AzureServiceBusHealthCheck(string endpoint, TokenCredential tokenCredential)
         {
+            if (string.IsNullOrEmpty(endpoint))
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            if (tokenCredential == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredential));
+            }
+
             Endpoint = endpoint;
             TokenCredential = tokenCredential;
         }
+
+        private string ConnectionString { get; }
+
+        protected string Prefix => ConnectionString ?? Endpoint;
+
+        private string Endpoint { get; }
+        private TokenCredential TokenCredential { get; }
 
         protected ServiceBusAdministrationClient CreateManagementClient()
         {

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -1,10 +1,10 @@
-﻿namespace HealthChecks.AzureServiceBus
-{
-    using System;
-    using System.Collections.Concurrent;
-    using Azure.Core;
-    using Azure.Messaging.ServiceBus.Administration;
+﻿using System;
+using System.Collections.Concurrent;
+using Azure.Core;
+using Azure.Messaging.ServiceBus.Administration;
 
+namespace HealthChecks.AzureServiceBus
+{
     public abstract class AzureServiceBusHealthCheck
     {
         protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient>

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -1,17 +1,20 @@
-﻿namespace HealthChecks.AzureServiceBus
-{
-    using System;
-    using System.Collections.Concurrent;
-    using Azure.Core;
-    using Azure.Messaging.ServiceBus.Administration;
+﻿using System;
+using System.Collections.Concurrent;
+using Azure.Core;
+using Azure.Messaging.ServiceBus.Administration;
 
+namespace HealthChecks.AzureServiceBus
+{
     public abstract class AzureServiceBusHealthCheck
     {
-        protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient> ManagementClientConnections = new ConcurrentDictionary<string, ServiceBusAdministrationClient>()
-
+        protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient>
+            ManagementClientConnections = new ();
         protected string ConnectionString { get; }
-        protected string Endpoint { get; }
-        protected TokenCredential TokenCredential { get; }
+
+        protected string Prefix => ConnectionString ?? Endpoint;
+
+        private string Endpoint { get; }
+        private TokenCredential TokenCredential { get; }
 
         protected AzureServiceBusHealthCheck (string connectionString)
         {
@@ -28,7 +31,6 @@
             TokenCredential = tokenCredential;
         }
 
-
         protected ServiceBusAdministrationClient CreateManagementClient()
         {
             ServiceBusAdministrationClient managementClient;
@@ -44,9 +46,6 @@
             return managementClient;
         }
 
-        protected string GetFirstPartOfKey()
-        {
-            return ConnectionString ?? Endpoint;
-        }
+        protected abstract string GetConnectionKey();
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -60,6 +60,6 @@ namespace HealthChecks.AzureServiceBus
             return managementClient;
         }
 
-        protected abstract string GetConnectionKey();
+        protected abstract string ConnectionKey { get; }
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -1,0 +1,52 @@
+﻿namespace HealthChecks.AzureServiceBus
+{
+    using System;
+    using System.Collections.Concurrent;
+    using Azure.Core;
+    using Azure.Messaging.ServiceBus.Administration;
+
+    public abstract class AzureServiceBusHealthCheck
+    {
+        protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient> ManagementClientConnections = new ConcurrentDictionary<string, ServiceBusAdministrationClient>()
+
+        protected string ConnectionString { get; }
+        protected string Endpoint { get; }
+        protected TokenCredential TokenCredential { get; }
+
+        protected AzureServiceBusHealthCheck (string connectionString)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+            ConnectionString = connectionString;
+        }
+
+        protected AzureServiceBusHealthCheck (string endpoint, TokenCredential tokenCredential)
+        {
+            Endpoint = endpoint;
+            TokenCredential = tokenCredential;
+        }
+
+
+        protected ServiceBusAdministrationClient CreateManagementClient()
+        {
+            ServiceBusAdministrationClient managementClient;
+            if (TokenCredential != null)
+            {
+                managementClient = new ServiceBusAdministrationClient(Endpoint, TokenCredential);
+            }
+            else
+            {
+                managementClient = new ServiceBusAdministrationClient(ConnectionString);
+            }
+
+            return managementClient;
+        }
+
+        protected string GetFirstPartOfKey()
+        {
+            return ConnectionString ?? Endpoint;
+        }
+    }
+}

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -10,6 +10,14 @@
         protected static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient>
             ManagementClientConnections = new();
 
+        private string ConnectionString { get; }
+
+        protected string Prefix => ConnectionString ?? Endpoint;
+
+        private string Endpoint { get; }
+        private TokenCredential TokenCredential { get; }
+
+
         protected AzureServiceBusHealthCheck(string connectionString)
         {
             if (string.IsNullOrEmpty(connectionString))
@@ -36,12 +44,6 @@
             TokenCredential = tokenCredential;
         }
 
-        private string ConnectionString { get; }
-
-        protected string Prefix => ConnectionString ?? Endpoint;
-
-        private string Endpoint { get; }
-        private TokenCredential TokenCredential { get; }
 
         protected ServiceBusAdministrationClient CreateManagementClient()
         {

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusHealthCheck.cs
@@ -15,8 +15,8 @@ namespace HealthChecks.AzureServiceBus
         protected string Prefix => ConnectionString ?? Endpoint;
 
         private string Endpoint { get; }
-        private TokenCredential TokenCredential { get; }
 
+        private TokenCredential TokenCredential { get; }
 
         protected AzureServiceBusHealthCheck(string connectionString)
         {

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -9,8 +9,6 @@ namespace HealthChecks.AzureServiceBus
     public class AzureServiceBusQueueHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
     {
         private readonly string _queueName;
-        private readonly TokenCredential _tokenCredential;
-
 
         public AzureServiceBusQueueHealthCheck(string connectionString, string queueName) : base(connectionString)
         {
@@ -18,8 +16,6 @@ namespace HealthChecks.AzureServiceBus
             {
                 throw new ArgumentNullException(nameof(queueName));
             }
-
-            _queueName = queueName;
         }
 
         public AzureServiceBusQueueHealthCheck(string endPoint, string queueName, TokenCredential tokenCredential) :
@@ -30,7 +26,6 @@ namespace HealthChecks.AzureServiceBus
                 throw new ArgumentNullException(nameof(queueName));
             }
 
-            _tokenCredential = tokenCredential ;
             _queueName = queueName;
         }
 
@@ -38,7 +33,6 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-
                 if (!ManagementClientConnections.TryGetValue(GetConnectionKey(), out var managementClient))
                 {
                     managementClient = CreateManagementClient();

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -6,10 +6,8 @@ using Azure.Core;
 
 namespace HealthChecks.AzureServiceBus
 {
-    public class AzureServiceBusQueueHealthCheck
-        : AzureServiceBusHealthCheck, IHealthCheck
+    public class AzureServiceBusQueueHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
     {
-        private readonly string _endPoint;
         private readonly string _queueName;
         private readonly TokenCredential _tokenCredential;
 
@@ -32,7 +30,6 @@ namespace HealthChecks.AzureServiceBus
                 throw new ArgumentNullException(nameof(queueName));
             }
 
-            _endPoint = endPoint;
             _tokenCredential = tokenCredential ;
             _queueName = queueName;
         }
@@ -41,12 +38,12 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = $"{GetFirstPartOfKey()}_{_queueName}";
-                if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
+
+                if (!ManagementClientConnections.TryGetValue(GetConnectionKey(), out var managementClient))
                 {
                     managementClient = CreateManagementClient();
 
-                    if (!ManagementClientConnections.TryAdd(connectionKey, managementClient))
+                    if (!ManagementClientConnections.TryAdd(GetConnectionKey(), managementClient))
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: "No service bus administration client connection can't be added into dictionary.");
                     }
@@ -63,5 +60,9 @@ namespace HealthChecks.AzureServiceBus
         }
 
 
+        protected override string GetConnectionKey()
+        {
+           return $"{Prefix}_{_queueName}";
+        }
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -33,11 +33,11 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                if (!ManagementClientConnections.TryGetValue(GetConnectionKey(), out var managementClient))
+                if (!ManagementClientConnections.TryGetValue(ConnectionKey, out var managementClient))
                 {
                     managementClient = CreateManagementClient();
 
-                    if (!ManagementClientConnections.TryAdd(GetConnectionKey(), managementClient))
+                    if (!ManagementClientConnections.TryAdd(ConnectionKey, managementClient))
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: "No service bus administration client connection can't be added into dictionary.");
                     }
@@ -54,9 +54,6 @@ namespace HealthChecks.AzureServiceBus
         }
 
 
-        protected override string GetConnectionKey()
-        {
-           return $"{Prefix}_{_queueName}";
-        }
+        protected override string ConnectionKey => $"{Prefix}_{_queueName}";
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
@@ -48,7 +48,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = GetConnectionKey();
+                var connectionKey = ConnectionKey;
                 if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
                 {
                     managementClient = CreateManagementClient();
@@ -68,9 +68,6 @@ namespace HealthChecks.AzureServiceBus
             }
         }
 
-        protected override string GetConnectionKey()
-        {
-            return $"{Prefix}_{_topicName}_{_subscriptionName}";
-        }
+        protected override string ConnectionKey => $"{Prefix}_{_topicName}_{_subscriptionName}";
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
@@ -48,7 +48,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = $"{GetFirstPartOfKey()}_{_topicName}_{_subscriptionName}";
+                var connectionKey = GetConnectionKey();
                 if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
                 {
                     managementClient = CreateManagementClient();
@@ -66,6 +66,11 @@ namespace HealthChecks.AzureServiceBus
             {
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
+        }
+
+        protected override string GetConnectionKey()
+        {
+            return $"{Prefix}_{_topicName}_{_subscriptionName}";
         }
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -1,50 +1,49 @@
-﻿using Azure.Messaging.ServiceBus.Administration;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using System;
-using System.Collections.Concurrent;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.AzureServiceBus
 {
     public class AzureServiceBusTopicHealthCheck
-        : IHealthCheck
+        : AzureServiceBusHealthCheck, IHealthCheck
     {
-        private static readonly ConcurrentDictionary<string, ServiceBusAdministrationClient> _managementClientConnections
-            = new ConcurrentDictionary<string, ServiceBusAdministrationClient>();
-
-
-        private readonly string _connectionString;
         private readonly string _topicName;
 
-        public AzureServiceBusTopicHealthCheck(string connectionString, string topicName)
+        public AzureServiceBusTopicHealthCheck(string connectionString, string topicName) : base(connectionString)
         {
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-
             if (string.IsNullOrEmpty(topicName))
             {
                 throw new ArgumentNullException(nameof(topicName));
             }
 
-
-            _connectionString = connectionString;
             _topicName = topicName;
         }
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+
+        public AzureServiceBusTopicHealthCheck(string endpoint, string topicName, TokenCredential tokenCredential) : base(endpoint, tokenCredential)
+        {
+            if (string.IsNullOrEmpty(topicName))
+            {
+                throw new ArgumentNullException(nameof(topicName));
+            }
+
+            _topicName = topicName;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var connectionKey = $"{_connectionString}_{_topicName}";
-                if (!_managementClientConnections.TryGetValue(connectionKey, out var managementClient))
+                var connectionKey = $"{GetFirstPartOfKey()}_{_topicName}";
+                if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
                 {
-                    managementClient = new ServiceBusAdministrationClient(_connectionString);
-
-                    if (!_managementClientConnections.TryAdd(connectionKey, managementClient))
+                    managementClient = CreateManagementClient();
+                    if (!ManagementClientConnections.TryAdd(connectionKey, managementClient))
                     {
-                        return new HealthCheckResult(context.Registration.FailureStatus, description: "New service bus administration client can't be added into dictionary.");
+                        return new HealthCheckResult(context.Registration.FailureStatus,
+                            "New service bus administration client can't be added into dictionary.");
                     }
                 }
 

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -36,7 +36,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = $"{GetFirstPartOfKey()}_{_topicName}";
+                var connectionKey = $"{GetConnectionKey()}_{_topicName}";
                 if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
                 {
                     managementClient = CreateManagementClient();
@@ -54,6 +54,11 @@ namespace HealthChecks.AzureServiceBus
             {
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
+        }
+
+        protected override string GetConnectionKey()
+        {
+            return $"{Prefix}_{_topicName}";
         }
     }
 }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -36,7 +36,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = $"{GetConnectionKey()}_{_topicName}";
+                var connectionKey = $"{ConnectionKey}_{_topicName}";
                 if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
                 {
                     managementClient = CreateManagementClient();
@@ -56,9 +56,6 @@ namespace HealthChecks.AzureServiceBus
             }
         }
 
-        protected override string GetConnectionKey()
-        {
-            return $"{Prefix}_{_topicName}";
-        }
+        protected override string ConnectionKey => $"{Prefix}_{_topicName}";
     }
 }

--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    using global::Azure.Core;
+
     public static class AzureServiceBusHealthCheckBuilderExtensions
     {
         const string AZUREEVENTHUB_NAME = "azureeventhub";
@@ -87,6 +89,35 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
+
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Queue.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="queueName">The name of the queue to check.</param>
+        /// <param name="tokenCredential">The token credential for auth
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when queue is partitioned or with duplication detection feature enabled Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="requiresSession">An optional boolean flag that indicates whether session is enabled on the queue or not. Defaults to false.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusQueue(this IHealthChecksBuilder builder, string endpoint, string queueName,TokenCredential tokenCredential ,string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZUREQUEUE_NAME,
+                sp => new AzureServiceBusQueueHealthCheck(endpoint, queueName,tokenCredential),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+
         /// <summary>
         /// Add a health check for Azure Service Bus Topic.
         /// </summary>
@@ -111,6 +142,33 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Topic.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="topicName">The topic name of the topic to check.</param>
+        /// <param name="tokenCredential">The token credential for auth
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when topic is partitioned or with duplication detection feature enabled. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusTopic(this IHealthChecksBuilder builder, string endpoint, string topicName,TokenCredential tokenCredential, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZURETOPIC_NAME,
+                sp => new AzureServiceBusTopicHealthCheck(endpoint, topicName, tokenCredential),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
         /// <summary>
         /// Add a health check for Azure Service Bus Subscription.
         /// </summary>
@@ -132,6 +190,34 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZURESUBSCRIPTION_NAME,
                 sp => new AzureServiceBusSubscriptionHealthCheck(connectionString, topicName, subscriptionName),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for Azure Service Bus Subscription.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="topicName">The topic name of the topic to check.</param>
+        /// <param name="topicName">The topic name of the topic to check.</param>
+        /// <param name="subscriptionName">The subscription name of the topic to check.</param>
+        /// <param name="tokenCredential">The token credential for auth
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azuretopic' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when topic is partitioned or with duplication detection feature enabled. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusSubscription(this IHealthChecksBuilder builder, string endpoint, string topicName, string subscriptionName, TokenCredential tokenCredential, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZURESUBSCRIPTION_NAME,
+                sp => new AzureServiceBusSubscriptionHealthCheck(endpoint, topicName, subscriptionName,tokenCredential),
                 failureStatus,
                 tags,
                 timeout));

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueUnitWithTokenUnitTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+    using global::Azure.Identity;
+
+    public class azure_service_bus_queue_registration_with_token_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue("cnn", "queueName",new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeue");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue("cnn", "queueName",new AzureCliCredential(),
+                name: "azureservicebusqueuecheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusqueuecheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue(string.Empty, string.Empty,new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusSubscriptionWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusSubscriptionWithTokenUnitTests.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+    using global::Azure.Identity;
+
+    public class azure_service_bus_subscription_registration_with_token_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription("cnn", "topicName", "subscriptionName", new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscription");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription("cnn", "topic", "subscriptionName", new AzureCliCredential(),
+                name: "azuresubscriptioncheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuresubscriptioncheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusSubscriptionHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusSubscription(string.Empty, string.Empty, string.Empty, new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicWithTokenUnitTests.cs
@@ -1,15 +1,15 @@
+using FluentAssertions;
+using global::Azure.Identity;
+using global::HealthChecks.AzureServiceBus;
+using global::System;
+using global::System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
 namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
 {
-    using FluentAssertions;
-    using global::Azure.Identity;
-    using global::HealthChecks.AzureServiceBus;
-    using global::System;
-    using global::System.Linq;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Diagnostics.HealthChecks;
-    using Microsoft.Extensions.Options;
-    using Xunit;
-
     public class azure_service_bus_topic_registration_with_token_should
     {
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusTopicWithTokenUnitTests.cs
@@ -1,0 +1,65 @@
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+    using FluentAssertions;
+    using global::Azure.Identity;
+    using global::HealthChecks.AzureServiceBus;
+    using global::System;
+    using global::System.Linq;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+    using Microsoft.Extensions.Options;
+    using Xunit;
+
+    public class azure_service_bus_topic_registration_with_token_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusTopic("cnn", "topicName", new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretopic");
+            check.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusTopic("cnn", "topic", new AzureCliCredential(),
+                    "azuretopiccheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretopiccheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusTopicHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusTopic(string.Empty, string.Empty, new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows service bus to be setup using service authentication rather than requiring  a key

**Which issue(s) this PR fixes**:
https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/753

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No, only additional functionality 
Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
