### PR TITLE
In HealthChecks.UI.Image/Dockerfile, update base images and NodeJs

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Dockerfile
+++ b/build/docker-images/HealthChecks.UI.Image/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.7-buster-slim AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.100-buster-slim AS sdk-with-node
+FROM mcr.microsoft.com/dotnet/sdk:5.0.301-buster-slim AS sdk-with-node
 
-ENV NODE_VERSION 8.11.1
-ENV NODE_DOWNLOAD_SHA 0e20787e2eda4cc31336d8327556ebc7417e8ee0a6ba0de96a09b0ec2b841f60
+ENV NODE_VERSION 14.17.0
+ENV NODE_DOWNLOAD_SHA 3d06eabc73ec8626337bff370474306eac1c3c21122f677720d154c556ceafaf
 RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" --output nodejs.tar.gz \
     && echo "$NODE_DOWNLOAD_SHA nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \


### PR DESCRIPTION
In HealthChecks.UI.Image/Dockerfile, update the used SDK to 5.0.301 and the used asp runtime to 5.0.7. For earlier versions, there were Nuget restore certificate errors. Also, dotnet build reports that npm 8 is no longer supported, so I updated that as well. Works for me.

**What this PR does / why we need it**:
It uses more a more current dotnet sdk/asp runtime/nodejs in the UI.Image dockerfile.

**Which issue(s) this PR fixes**:
Nuget restore issues: "The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain..."

MsBuild issue:
*** Installing npm packages ***
npm WARN npm npm does not support Node.js v8.11.1

Please reference the issue this PR will close: There was none.

**Special notes for your reviewer**:
The dockerfile builds for me now and runs fine. The newer SDK is pretty certainly safe, I am not sure about the implications of a version jump of nodejs from 8.x to 14.x.

**Does this PR introduce a user-facing change?**: Did not observe any. None intended.

Please make sure you've completed the relevant tasks for this PR, out of the following list: (No real code changes/new features)

