### PR TITLE
Issue 651 - Fixed an issue in UI when deserializing invalid UIHealthReport

### DIFF
--- a/src/HealthChecks.UI/Core/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/HealthChecks.UI/Core/Extensions/HttpResponseMessageExtensions.cs
@@ -5,7 +5,7 @@ namespace System.Net.Http
 {
     public static class HttpResponseMessageExtensions
     {
-        public static async Task<TContent> As<TContent>(this HttpResponseMessage response)
+        public static async Task<TContent> As<TContent>(this HttpResponseMessage response, params JsonConverter[] converters)
         {
             if (response != null)
             {
@@ -14,7 +14,7 @@ namespace System.Net.Http
 
                 if (body != null)
                 {
-                    var content = JsonConvert.DeserializeObject<TContent>(body);
+                    var content = JsonConvert.DeserializeObject<TContent>(body, converters);
 
                     if (content != null)
                     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
#651 occurs when a health endpoint returns JSON that deserializes to a UIHealthReport but not necessarily a vaild one.
For example in my case, the health endpoint was returning a 404 problem details which deserialized to a UIHealthReport with 404 status (instead of healthy/unhealthy) and a null Entries dictionary (which ended triggering the exception).
This PR addresses the validations in a JsonConverter added and passed to the deserialization.

**Which issue(s) this PR fixes**:
Please reference the issue this PR will close: #651

**Special notes for your reviewer**:
Something even simpler would have been to just add the validations inline after the As<UIHealthReport>() call but I felt tying them to the deserialization itself would be better, with some more work maybe it could be made the default converter for the class.

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
