### PR TITLE
Allow AzureBlobHealthCheck to work with "Storage Blob Data Contributor"

### DIFF
--- a/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
@@ -41,9 +41,9 @@ namespace HealthChecks.AzureStorage
             try
             {
                 var blobServiceClient = GetBlobServiceClient();
-                await foreach (var container in blobServiceClient.GetBlobContainersAsync(cancellationToken: cancellationToken))
+                await foreach (var page in blobServiceClient.GetBlobContainersAsync(cancellationToken: cancellationToken).AsPages(pageSizeHint: 1))
                 {
-                    // We are just validating that we have access to list the containers.
+                    break;
                 }
 
                 if (!string.IsNullOrEmpty(_containerName))

--- a/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
@@ -41,7 +41,10 @@ namespace HealthChecks.AzureStorage
             try
             {
                 var blobServiceClient = GetBlobServiceClient();
-                var serviceProperties = await blobServiceClient.GetPropertiesAsync(cancellationToken);
+                await foreach (var container in blobServiceClient.GetBlobContainersAsync(cancellationToken: cancellationToken))
+                {
+                    // We are just validating that we have access to list the containers.
+                }
 
                 if (!string.IsNullOrEmpty(_containerName))
                 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request allows for the AzureBlobHealthCheck to use Azure AD roles for authentication.
Specially it allows an user with the role `Storage Blob Data Contributor` to run the health check.

**Which issue(s) this PR fixes**:

This will fix the issue #783

**Special notes for your reviewer**:

`Storage Blob Data Contributor` is an Azure AD RBAC role that can read and write data to storage containers. Its typically used together with Managed Identities. The `Storage Blob Data Contributor` only have a very limited set of permissions (See image)

![image](https://user-images.githubusercontent.com/1127727/126117045-7e89d9d8-cf86-4d55-85f2-fddb19df6c2d.png)

The GetServiceProperties requires account ownership, that you generally don't wanna delegate to your account.
As a note, an Storage Account Key equals full account ownership.

**Does this PR introduce a user-facing change?**:
There should be no noticeable changes.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
