### PR TITLE
Allow the specification of tolerations on the health check custom resource definition.

### DIFF
--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -101,7 +101,21 @@ spec:
                   - uri
                   - payload
                   - restoredPayload
-
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  value:
+                    type: string
+                  effect:
+                    type: string
+                  seconds:
+                    type: number
           required:
             - name
             - scope

--- a/doc/k8s-operator.md
+++ b/doc/k8s-operator.md
@@ -54,23 +54,24 @@ Note: The UI resources created by the operator (deployment, service, configmap, 
 
 ### Optional fields
 
-| Field                 | Description                                                          | Default                                              |
-| --------------------- | :------------------------------------------------------------------- | ---------------------------------------------------- |
-| serviceType           | How the UI should be published (ClusterIP, LoadBalancer or NodePort) | ClusterIP                                            |
-| portNumber            | What port will be used to expose the UI service                      | 80                                                   |
-| uiPath                | Location where the UI frontend will be served                        | /healthchecks                                        |
-| uiApiPath             | Location where the UI backend API will be served                     | UI defaults                                          |
-| uiResourcesPath       | Location where the UI static files resources will be served          | UI defaults                                          |
-| uiWebhooksPath        | Location where the Webhooks api                                      | UI defaults                                          |
-| uiNoRelativePaths     | Disable UI front-end relative paths                                  | false                                                |
-| healthChecksPath      | Path where the UI will collect health from endpoints                 | /health (Can be overriden with a service annotation) |
-| healthChecksScheme    | Scheme to be used to collect health from endpoints                   | http (Can be overriden with a service annotation)    |
-| image                 | Image to be used by the UI                                           | xabarilcoding/healthchecksui:latest                  |
-| imagePullPolicy       | Deployment image pull policy                                         | Always                                               |
-| stylesheetContent     | css content used to brand the UI                                     | none                                                 |
-| serviceAnnotations    | name / value array to use custom annotations in UI service           | none                                                 |
-| deploymentAnnotations | name / value array to use custom annotations in UI Deployment        | none                                                 |
-| webhooks              | webhook array object (name, uri, payload and restoredPayload)        | none                                                 |
+| Field                 | Description                                                               | Default                                              |
+| --------------------- | :------------------------------------------------------------------------ | ---------------------------------------------------- |
+| serviceType           | How the UI should be published (ClusterIP, LoadBalancer or NodePort)      | ClusterIP                                            |
+| portNumber            | What port will be used to expose the UI service                           | 80                                                   |
+| uiPath                | Location where the UI frontend will be served                             | /healthchecks                                        |
+| uiApiPath             | Location where the UI backend API will be served                          | UI defaults                                          |
+| uiResourcesPath       | Location where the UI static files resources will be served               | UI defaults                                          |
+| uiWebhooksPath        | Location where the Webhooks api                                           | UI defaults                                          |
+| uiNoRelativePaths     | Disable UI front-end relative paths                                       | false                                                |
+| healthChecksPath      | Path where the UI will collect health from endpoints                      | /health (Can be overriden with a service annotation) |
+| healthChecksScheme    | Scheme to be used to collect health from endpoints                        | http (Can be overriden with a service annotation)    |
+| image                 | Image to be used by the UI                                                | xabarilcoding/healthchecksui:latest                  |
+| imagePullPolicy       | Deployment image pull policy                                              | Always                                               |
+| stylesheetContent     | css content used to brand the UI                                          | none                                                 |
+| serviceAnnotations    | name / value array to use custom annotations in UI service                | none                                                 |
+| deploymentAnnotations | name / value array to use custom annotations in UI Deployment             | none                                                 |
+| webhooks              | webhook array object (name, uri, payload and restoredPayload)             | none                                                 |
+| tolerations           | toleration array object (key, operator, value, effect and seconds)        | none                                                 |
 
 ## Sample HealthChecks Operator Tutorial
 

--- a/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/HealthCheckResourceSpec.cs
@@ -23,5 +23,6 @@ namespace HealthChecks.UI.K8s.Operator
         public List<NameValueObject> ServiceAnnotations { get; set; } = new List<NameValueObject>();
         public List<NameValueObject> DeploymentAnnotations { get; set; } = new List<NameValueObject>();
         public List<WebHookObject> Webhooks { get; set; } = new List<WebHookObject>();
+        public List<TolerationObject> Tolerations { get; set; } = new List<TolerationObject>();
     }
 }

--- a/src/HealthChecks.UI.K8s.Operator/Crd/ResourceDefinitionObjects.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Crd/ResourceDefinitionObjects.cs
@@ -6,6 +6,15 @@
         public string Value { get; set; }
     }
 
+    public class TolerationObject
+    {
+        public string Key { get; set; }
+        public string Operator { get; set; }
+        public string Value { get; set; }
+        public string Effect { get; set; }
+        public long? Seconds { get; set; }
+    }
+
     public class WebHookObject
     {
         public string Name { get; set; }

--- a/src/HealthChecks.UI.K8s.Operator/Handlers/DeploymentHandler.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Handlers/DeploymentHandler.cs
@@ -104,6 +104,9 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
 
             uiContainer.MapCustomUIPaths(resource, _operatorDiagnostics);
 
+            var tolerations = resource.Spec.Tolerations?.Select(toleration => new V1Toleration(toleration.Effect,
+                toleration.Key, toleration.Operator, toleration.Seconds, toleration.Value)).ToList() ?? new List<V1Toleration>();
+
             var spec = new V1DeploymentSpec
             {
                 Selector = new V1LabelSelector
@@ -128,7 +131,8 @@ namespace HealthChecks.UI.K8s.Operator.Handlers
                         Containers = new List<V1Container>
                         {
                            uiContainer
-                        }
+                        },
+                        Tolerations = tolerations
                     }
                 }
             };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: Allows the specification of tolerations on the HealthCheck custom resource in order to allow tolerations to be specified on the deployment.

**Which issue(s) this PR fixes**: Issue #798

Please reference the issue this PR will close: #798

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**: No, this feature is backwards compatible

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [X] End-to-end tests passing
- [X] Extended the documentation
- [ ] Provided sample for the feature
