### PR TITLE
[Feature] Adding Additional Azure Service Bus HealthCheck Checking for healthy Message- and Deadletter-Queue Count

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecks.AzureServiceBus
+{
+    public class AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
+    {
+        private readonly string _queueName;
+        private readonly int _degradedThreshold;
+        private readonly int _unhealthyThreshold;
+
+        public AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck(string connectionString, string queueName, int degradedThreshold = 5, int unhealthyThreshold = 10) 
+            : base(connectionString)
+        {
+            _queueName = queueName;
+            _degradedThreshold = degradedThreshold;
+            _unhealthyThreshold = unhealthyThreshold;
+        }
+
+        public AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck(string endpoint, string queueName, TokenCredential tokenCredential,  int degradedThreshold = 5, int unhealthyThreshold = 10) 
+            : base(endpoint, tokenCredential)
+        {
+            _queueName = queueName;
+            _degradedThreshold = degradedThreshold;
+            _unhealthyThreshold = unhealthyThreshold;
+        }
+
+        protected override string ConnectionKey => $"{Prefix}_{_queueName}";
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (!ManagementClientConnections.TryGetValue(ConnectionKey, out var managementClient))
+                {
+                    managementClient = CreateManagementClient();
+
+                    if (!ManagementClientConnections.TryAdd(ConnectionKey, managementClient))
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: "No service bus administration client connection can't be added into dictionary.");
+                    }
+                }
+
+                var properties = await managementClient.GetQueueRuntimePropertiesAsync(_queueName, cancellationToken);
+                if (properties.Value.DeadLetterMessageCount >= _unhealthyThreshold)
+                    return HealthCheckResult.Unhealthy($"Message in dead letter queue {_queueName} exceeded the amount of messages allowed for the unhealthy threshold {_unhealthyThreshold}/{properties.Value.DeadLetterMessageCount}");
+
+                if(properties.Value.DeadLetterMessageCount >= _degradedThreshold)
+                    return HealthCheckResult.Degraded($"Message in dead letter queue {_queueName} exceeded the amount of messages allowed for the degraded threshold {_degradedThreshold}/{properties.Value.DeadLetterMessageCount}");
+
+                return HealthCheckResult.Healthy();
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+    }
+}

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck.cs
@@ -49,7 +49,7 @@ namespace HealthChecks.AzureServiceBus
                 if (properties.Value.DeadLetterMessageCount >= _unhealthyThreshold)
                     return HealthCheckResult.Unhealthy($"Message in dead letter queue {_queueName} exceeded the amount of messages allowed for the unhealthy threshold {_unhealthyThreshold}/{properties.Value.DeadLetterMessageCount}");
 
-                if(properties.Value.DeadLetterMessageCount >= _degradedThreshold)
+                if (properties.Value.DeadLetterMessageCount >= _degradedThreshold)
                     return HealthCheckResult.Degraded($"Message in dead letter queue {_queueName} exceeded the amount of messages allowed for the degraded threshold {_degradedThreshold}/{properties.Value.DeadLetterMessageCount}");
 
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
@@ -49,7 +49,7 @@ namespace HealthChecks.AzureServiceBus
                 if (properties.Value.ActiveMessageCount >= _unhealthyThreshold)
                     return HealthCheckResult.Unhealthy($"Message in queue {_queueName} exceeded the amount of messages allowed for the unhealthy threshold {_unhealthyThreshold}/{properties.Value.ActiveMessageCount}");
 
-                if(properties.Value.ActiveMessageCount >= _degradedThreshold)
+                if (properties.Value.ActiveMessageCount >= _degradedThreshold)
                     return HealthCheckResult.Degraded($"Message in queue {_queueName} exceeded the amount of messages allowed for the degraded threshold {_degradedThreshold}/{properties.Value.ActiveMessageCount}");
 
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
@@ -6,13 +6,13 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.AzureServiceBus
 {
-    public class AzureServiceBusQueueMessageThresholdCountHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
+    public class AzureServiceBusQueueMessageCountThresholdHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
     {
         private readonly string _queueName;
         private readonly int _degradedThreshold;
         private readonly int _unhealthyThreshold;
 
-        public AzureServiceBusQueueMessageThresholdCountHealthCheck(string connectionString, string queueName, int degradedThreshold = 5, int unhealthyThreshold = 10) 
+        public AzureServiceBusQueueMessageCountThresholdHealthCheck(string connectionString, string queueName, int degradedThreshold = 5, int unhealthyThreshold = 10) 
             : base(connectionString)
         {
             _queueName = queueName;
@@ -20,7 +20,7 @@ namespace HealthChecks.AzureServiceBus
             _unhealthyThreshold = unhealthyThreshold;
         }
 
-        public AzureServiceBusQueueMessageThresholdCountHealthCheck(string endpoint, string queueName, TokenCredential tokenCredential,  int degradedThreshold = 5, int unhealthyThreshold = 10) 
+        public AzureServiceBusQueueMessageCountThresholdHealthCheck(string endpoint, string queueName, TokenCredential tokenCredential,  int degradedThreshold = 5, int unhealthyThreshold = 10) 
             : base(endpoint, tokenCredential)
         {
             _queueName = queueName;

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageCountThresholdHealthCheck.cs
@@ -47,10 +47,10 @@ namespace HealthChecks.AzureServiceBus
 
                 var properties = await managementClient.GetQueueRuntimePropertiesAsync(_queueName, cancellationToken);
                 if (properties.Value.ActiveMessageCount >= _unhealthyThreshold)
-                    return HealthCheckResult.Unhealthy();
+                    return HealthCheckResult.Unhealthy($"Message in queue {_queueName} exceeded the amount of messages allowed for the unhealthy threshold {_unhealthyThreshold}/{properties.Value.ActiveMessageCount}");
 
                 if(properties.Value.ActiveMessageCount >= _degradedThreshold)
-                    return HealthCheckResult.Degraded();
+                    return HealthCheckResult.Degraded($"Message in queue {_queueName} exceeded the amount of messages allowed for the degraded threshold {_degradedThreshold}/{properties.Value.ActiveMessageCount}");
 
                 return HealthCheckResult.Healthy();
             }

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageThresholdCountHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueMessageThresholdCountHealthCheck.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecks.AzureServiceBus
+{
+    public class AzureServiceBusQueueMessageThresholdCountHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
+    {
+        private readonly string _queueName;
+        private readonly int _degradedThreshold;
+        private readonly int _unhealthyThreshold;
+
+        public AzureServiceBusQueueMessageThresholdCountHealthCheck(string connectionString, string queueName, int degradedThreshold = 5, int unhealthyThreshold = 10) 
+            : base(connectionString)
+        {
+            _queueName = queueName;
+            _degradedThreshold = degradedThreshold;
+            _unhealthyThreshold = unhealthyThreshold;
+        }
+
+        public AzureServiceBusQueueMessageThresholdCountHealthCheck(string endpoint, string queueName, TokenCredential tokenCredential,  int degradedThreshold = 5, int unhealthyThreshold = 10) 
+            : base(endpoint, tokenCredential)
+        {
+            _queueName = queueName;
+            _degradedThreshold = degradedThreshold;
+            _unhealthyThreshold = unhealthyThreshold;
+        }
+
+        protected override string ConnectionKey => $"{Prefix}_{_queueName}";
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (!ManagementClientConnections.TryGetValue(ConnectionKey, out var managementClient))
+                {
+                    managementClient = CreateManagementClient();
+
+                    if (!ManagementClientConnections.TryAdd(ConnectionKey, managementClient))
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: "No service bus administration client connection can't be added into dictionary.");
+                    }
+                }
+
+                var properties = await managementClient.GetQueueRuntimePropertiesAsync(_queueName, cancellationToken);
+                if (properties.Value.ActiveMessageCount >= _unhealthyThreshold)
+                    return HealthCheckResult.Unhealthy();
+
+                if(properties.Value.ActiveMessageCount >= _degradedThreshold)
+                    return HealthCheckResult.Degraded();
+
+                return HealthCheckResult.Healthy();
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+    }
+}

--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREQUEUETHESHOLD_NAME,
-                sp => new AzureServiceBusQueueMessageThresholdCountHealthCheck(connectionString, queueName, degradedThresholdCount, unhealthyThresholdCount),
+                sp => new AzureServiceBusQueueMessageCountThresholdHealthCheck(connectionString, queueName, degradedThresholdCount, unhealthyThresholdCount),
                 failureStatus,
                 tags,
                 timeout));
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREQUEUETHESHOLD_NAME,
-                sp => new AzureServiceBusQueueMessageThresholdCountHealthCheck(endpoint, queueName, tokenCredential, degradedThresholdCount, unhealthyThresholdCount),
+                sp => new AzureServiceBusQueueMessageCountThresholdHealthCheck(endpoint, queueName, tokenCredential, degradedThresholdCount, unhealthyThresholdCount),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         const string AZUREQUEUE_NAME = "azurequeue";
         const string AZURETOPIC_NAME = "azuretopic";
         const string AZUREQUEUETHESHOLD_NAME = "azurequeuethreshold";
+        const string AZUREDEADLETTERQUEUETHESHOLD_NAME = "azuredeadletterqueuethreshold";
         const string AZURESUBSCRIPTION_NAME = "azuresubscription";
 
         /// <summary>
@@ -170,6 +171,63 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                 name ?? AZUREQUEUETHESHOLD_NAME,
                 sp => new AzureServiceBusQueueMessageCountThresholdHealthCheck(endpoint, queueName, tokenCredential, degradedThresholdCount, unhealthyThresholdCount),
+                failureStatus,
+                tags,
+                timeout));
+        }
+        
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Dead letter Queue message threshold
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionString">The azure service bus connection string to be used.</param>
+        /// <param name="queueName">The name of the queue to check.</param>
+        /// <param name="degradedThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Degraded"/></param>
+        /// <param name="unhealthyThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Unhealthy"/></param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when queue is partitioned or with duplication detection feature enabled Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="requiresSession">An optional boolean flag that indicates whether session is enabled on the queue or not. Defaults to false.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusDeadLetterQueueMessageCountThreshold(this IHealthChecksBuilder builder, string connectionString, string queueName, int degradedThresholdCount = 5, int unhealthyThresholdCount = 10, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZUREDEADLETTERQUEUETHESHOLD_NAME,
+                sp => new AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck(connectionString, queueName, degradedThresholdCount, unhealthyThresholdCount),
+                failureStatus,
+                tags,
+                timeout));
+        }
+        
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Dead letter Queue message threshold
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="queueName">The name of the queue to check.</param>
+        /// <param name="tokenCredential">The token credential for auth>
+        /// <param name="degradedThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Degraded"/></param>
+        /// <param name="unhealthyThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Unhealthy"/></param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when queue is partitioned or with duplication detection feature enabled Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="requiresSession">An optional boolean flag that indicates whether session is enabled on the queue or not. Defaults to false.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusDeadLetterQueueMessageCountThreshold(this IHealthChecksBuilder builder, string endpoint, string queueName,TokenCredential tokenCredential, int degradedThresholdCount = 5, int unhealthyThresholdCount = 10, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZUREDEADLETTERQUEUETHESHOLD_NAME,
+                sp => new AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck(endpoint, queueName, tokenCredential, degradedThresholdCount, unhealthyThresholdCount),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureServiceBus/DependencyInjection/AzureServiceBusHealthCheckBuilderExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
         const string AZUREEVENTHUB_NAME = "azureeventhub";
         const string AZUREQUEUE_NAME = "azurequeue";
         const string AZURETOPIC_NAME = "azuretopic";
+        const string AZUREQUEUETHESHOLD_NAME = "azurequeuethreshold";
         const string AZURESUBSCRIPTION_NAME = "azuresubscription";
 
         /// <summary>
@@ -117,7 +118,63 @@ namespace Microsoft.Extensions.DependencyInjection
                 timeout));
         }
 
-
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Queue message threshold
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="connectionString">The azure service bus connection string to be used.</param>
+        /// <param name="queueName">The name of the queue to check.</param>
+        /// <param name="degradedThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Degraded"/></param>
+        /// <param name="unhealthyThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Unhealthy"/></param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when queue is partitioned or with duplication detection feature enabled Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="requiresSession">An optional boolean flag that indicates whether session is enabled on the queue or not. Defaults to false.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusQueueMessageCountThreshold(this IHealthChecksBuilder builder, string connectionString, string queueName, int degradedThresholdCount = 5, int unhealthyThresholdCount = 10, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZUREQUEUETHESHOLD_NAME,
+                sp => new AzureServiceBusQueueMessageThresholdCountHealthCheck(connectionString, queueName, degradedThresholdCount, unhealthyThresholdCount),
+                failureStatus,
+                tags,
+                timeout));
+        }
+        
+        /// <summary>
+        /// Add a health check for specified Azure Service Bus Queue message threshold
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The azure service bus endpoint to be used, format sb://myservicebus.servicebus.windows.net/.</param>
+        /// <param name="queueName">The name of the queue to check.</param>
+        /// <param name="tokenCredential">The token credential for auth>
+        /// <param name="degradedThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Degraded"/></param>
+        /// <param name="unhealthyThresholdCount">Number of <see cref="Azure.Messaging.ServiceBus.Administration.ActiveMessageCount"/> in the queue before message health check returned <see cref="HealthStatus.Unhealthy"/></param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'azurequeue' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="configuringMessage">Message configuration Action, usually used when queue is partitioned or with duplication detection feature enabled Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <param name="requiresSession">An optional boolean flag that indicates whether session is enabled on the queue or not. Defaults to false.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureServiceBusQueueMessageCountThreshold(this IHealthChecksBuilder builder, string endpoint, string queueName,TokenCredential tokenCredential, int degradedThresholdCount = 5, int unhealthyThresholdCount = 10, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? AZUREQUEUETHESHOLD_NAME,
+                sp => new AzureServiceBusQueueMessageThresholdCountHealthCheck(endpoint, queueName, tokenCredential, degradedThresholdCount, unhealthyThresholdCount),
+                failureStatus,
+                tags,
+                timeout));
+        }
+        
         /// <summary>
         /// Add a health check for Azure Service Bus Topic.
         /// </summary>

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+    public class azure_service_bus_deadletter_queue_message_threshold_registration_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusDeadLetterQueueMessageCountThreshold("cnn", "queueName");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuredeadletterqueuethreshold");
+            check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
+
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusDeadLetterQueueMessageCountThreshold("cnn", "queueName",
+                name: "azureservicebusdeadletterqueuemessagethresholdcheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusdeadletterqueuemessagethresholdcheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusDeadLetterQueueMessageCountThreshold(string.Empty, string.Empty);
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitTests.cs
@@ -26,7 +26,6 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
 
             registration.Name.Should().Be("azuredeadletterqueuethreshold");
             check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
-
         }
 
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitWithTokenUnitTests.cs
@@ -28,7 +28,6 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
 
             registration.Name.Should().Be("azuredeadletterqueuethreshold");
             check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
-
         }
 
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusDeadLetterQueueMessageThresholdCountUnitWithTokenUnitTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+   using global::Azure.Identity;
+
+    public class azure_service_bus_deadletter_queue_message_threshold_registration_with_token_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusDeadLetterQueueMessageCountThreshold("cnn", "queueName",new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuredeadletterqueuethreshold");
+            check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
+
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusDeadLetterQueueMessageCountThreshold("cnn", "queueName",new AzureCliCredential(),
+                name: "azureservicebusdeadletterqueuemessagethresholdcheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusdeadletterqueuemessagethresholdcheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusDeadLetterQueueMessageCountThresholdHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold(string.Empty, string.Empty,new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+    public class azure_service_bus_queue_message_threshold_registration_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold("cnn", "queueName");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeuethreshold");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold("cnn", "queueName",
+                name: "azureservicebusqueuemessagethresholdcheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusqueuemessagethresholdcheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueue(string.Empty, string.Empty);
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
@@ -26,7 +26,6 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
 
             registration.Name.Should().Be("azurequeuethreshold");
             check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
-
         }
 
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitTests.cs
@@ -25,7 +25,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("azurequeuethreshold");
-            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
 
         }
 
@@ -44,7 +44,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("azureservicebusqueuemessagethresholdcheck");
-            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
         }
 
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("azurequeuethreshold");
-            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
 
         }
 
@@ -46,7 +46,7 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("azureservicebusqueuemessagethresholdcheck");
-            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
         }
 
         [Fact]

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using HealthChecks.AzureServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
+{
+   using global::Azure.Identity;
+
+    public class azure_service_bus_queue_message_threshold_registration_with_token_should
+    {
+        [Fact]
+        public void add_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold("cnn", "queueName",new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azurequeuethreshold");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+
+        }
+
+        [Fact]
+        public void add_named_health_check_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold("cnn", "queueName",new AzureCliCredential(),
+                name: "azureservicebusqueuemessagethresholdcheck");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azureservicebusqueuemessagethresholdcheck");
+            check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageThresholdCountHealthCheck));
+        }
+
+        [Fact]
+        public void fail_when_no_health_check_configuration_provided()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureServiceBusQueueMessageCountThreshold(string.Empty, string.Empty,new AzureCliCredential());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+
+            Assert.Throws<ArgumentNullException>(() => registration.Factory(serviceProvider));
+        }
+    }
+}

--- a/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/AzureServiceBus/AzureServiceBusQueueMessageThresholdCountUnitWithTokenUnitTests.cs
@@ -28,7 +28,6 @@ namespace UnitTests.HealthChecks.DependencyInjection.AzureServiceBus
 
             registration.Name.Should().Be("azurequeuethreshold");
             check.GetType().Should().Be(typeof(AzureServiceBusQueueMessageCountThresholdHealthCheck));
-
         }
 
         [Fact]


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in #821 this feature creates two new Health Checks for setting a threshold on how many messages that can be in an Azure Service Bus Queue or Dead-letter queue. Internally we use this feature to determine whether our services are running correctly of we see an increased amount of messages in our error that we need to be aware of. We thought others might benefit for this as well 🙌 

Adding ServiceBus Queue Message Count Threshold
```csharp
services
   . AddHealthChecks()
   . AddAzureServiceBusQueueMessageCountThreshold(connectionString: "", queueName: "", degradedThresholdCount: 5, unhealthyThresholdCount: 10);
```

Adding ServiceBus Deadletter Queue Message Count Threshold
```csharp
services
   . AddHealthChecks()
   . AddAzureServiceBusDeadLetterQueueMessageCountThreshold(connectionString: "", queueName: "", degradedThresholdCount: 5, unhealthyThresholdCount: 10);
```

**Which issue(s) this PR fixes**:
#821 

Please reference the issue this PR will close: #821 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No it doesn't not change any user-facing changes, it adds an additional user facing feature for people whom uses `HealthChecks.AzureServiceBus` package

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
