### PR TITLE
Added support for non-default http version and version policy

### DIFF
--- a/src/HealthChecks.Uris/UriHealthCheck.cs
+++ b/src/HealthChecks.Uris/UriHealthCheck.cs
@@ -40,6 +40,11 @@ namespace HealthChecks.Uris
 
                     var requestMessage = new HttpRequestMessage(method, item.Uri);
 
+#if NET5_0_OR_GREATER
+                    requestMessage.Version = httpClient.DefaultRequestVersion;
+                    requestMessage.VersionPolicy = httpClient.DefaultVersionPolicy;
+#endif
+
                     foreach (var (Name, Value) in item.Headers)
                     {
                         requestMessage.Headers.Add(Name, Value);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Change enables requests to endpoints requiring http/2.

**Which issue(s) this PR fixes**:
Current behaviour is that even when using `configureClient: (provider, client) => client.DefaultRequestVersion = HttpVersion.Version20` in the `AddUrlGroup` extension, the HttpRequestMessage will be created with a default Version of HttpVersion.Version11 thereby making it functionally impossible to test an endpoint that requires http/2.

**Special notes for your reviewer**:
This change is functionally equivalent to how the HttpRequestMessage is handled inside the HttpClient. See: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs#L821

**Does this PR introduce a user-facing change?**:
No