### PR TITLE
Kafka. Configuring default LogHandler for kafka producer

### DIFF
--- a/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
@@ -92,8 +92,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddKafka(this IHealthChecksBuilder builder, ProducerConfig config,
-            Action<LogMessage> kafkaLogHandler, string topic = default, string name = default,
-            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+            Action<LogMessage> kafkaLogHandler, string? topic = default, string? name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, TimeSpan? timeout = default)
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
@@ -119,8 +119,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddKafka(this IHealthChecksBuilder builder, Action<ProducerConfig> setup,
-            Action<LogMessage> kafkaLogHandler, string topic = default, string name = default,
-            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+            Action<LogMessage> kafkaLogHandler, string? topic = default, string? name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, TimeSpan? timeout = default)
         {
             var config = new ProducerConfig();
             setup?.Invoke(config);

--- a/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                new KafkaHealthCheck(config, topic),
+                new KafkaHealthCheck(config, topic, null),
                 failureStatus,
                 tags,
                 timeout));
@@ -70,7 +70,64 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                new KafkaHealthCheck(config, topic),
+                new KafkaHealthCheck(config, topic, null),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for Kafka cluster.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="config">The kafka connection configuration parameters to be used.</param>
+        /// <param name="kafkaLogHandler">The action to handle LogMessage entry spawned by kafka producer.</param>
+        /// <param name="topic">The topic name to produce kafka messages on. Optional. If <c>null</c> the topic default 'healthcheck-topic' will be used for the name.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'kafka' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddKafka(this IHealthChecksBuilder builder, ProducerConfig config,
+            Action<LogMessage> kafkaLogHandler, string topic = default, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                new KafkaHealthCheck(config, topic, kafkaLogHandler),
+                failureStatus,
+                tags,
+                timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for Kafka cluster.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="setup">The action to configure the kafka connection configuration parameters to be used.</param>
+        /// <param name="kafkaLogHandler">The action to handle LogMessage entry spawned by kafka producer.</param>
+        /// <param name="topic">The topic name to produce kafka messages on. Optional. If <c>null</c> the topic default 'healthcheck-topic' will be used for the name.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'kafka' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddKafka(this IHealthChecksBuilder builder, Action<ProducerConfig> setup,
+            Action<LogMessage> kafkaLogHandler, string topic = default, string name = default,
+            HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
+            var config = new ProducerConfig();
+            setup?.Invoke(config);
+
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                new KafkaHealthCheck(config, topic, kafkaLogHandler),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -7,11 +7,10 @@ namespace HealthChecks.Kafka
     {
         private readonly ProducerConfig _configuration;
         private readonly string _topic;
-        private readonly Action<LogMessage> _kafkaLogHandler;
+        private readonly Action<LogMessage>? _kafkaLogHandler;
+        private IProducer<string, string>? _producer;
 
-        private IProducer<string, string> _producer;
-
-        public KafkaHealthCheck(ProducerConfig configuration, string topic, Action<LogMessage> kafkaLogHandler)
+        public KafkaHealthCheck(ProducerConfig configuration, string? topic, Action<LogMessage>? kafkaLogHandler)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _kafkaLogHandler = kafkaLogHandler;
@@ -29,7 +28,7 @@ namespace HealthChecks.Kafka
                     {
                         producerBuilder.SetLogHandler((_, logMessage) => _kafkaLogHandler(logMessage));
                     }
-                   
+
                     _producer = producerBuilder.Build();
                 }
 

--- a/test/HealthChecks.Kafka.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Kafka.Tests/DependencyInjection/RegistrationTests.cs
@@ -47,10 +47,10 @@ namespace HealthChecks.Kafka.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddKafka(new ProducerConfig(), message => {});
+                .AddKafka(new ProducerConfig(), message => { });
 
             var serviceProvider = services.BuildServiceProvider();
-            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();
             var check = registration.Factory(serviceProvider);

--- a/test/HealthChecks.Kafka.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Kafka.Tests/DependencyInjection/RegistrationTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace HealthChecks.Kafka.Tests.DependencyInjection
 {
+
     public class kafka_registration_should
     {
         [Fact]
@@ -39,6 +40,22 @@ namespace HealthChecks.Kafka.Tests.DependencyInjection
             var check = registration.Factory(serviceProvider);
 
             registration.Name.Should().Be("my-kafka-group");
+            check.GetType().Should().Be(typeof(KafkaHealthCheck));
+        }
+        [Fact]
+        public void add_health_check_with_log_handling_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddKafka(new ProducerConfig(), message => {});
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("kafka");
             check.GetType().Should().Be(typeof(KafkaHealthCheck));
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends Kafka health checks by adding possibility of overwriting default Confluent's kafka producer logging behavior (log co console directly) by passing Action for LogMessage handling .

Right now confluent kafka client writes logs to stdout by default. By having this addition application consuming this healthcheck would be able to keep their log processing in unified way.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
No

