### PR TITLE
update Microsoft.Azure.Devices dependency

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -77,7 +77,7 @@
     <AWSSKDS3>3.7.0.10</AWSSKDS3>
     <MicrosoftAzureKeyVault>4.2.0</MicrosoftAzureKeyVault>
     <DogStatsDCSharpClient>5.1.0</DogStatsDCSharpClient>
-    <MicrosoftAzureDevices>1.27.3</MicrosoftAzureDevices>
+    <MicrosoftAzureDevices>1.36.0</MicrosoftAzureDevices>
     <KubernetesClient>3.0.12</KubernetesClient>
     <SolrNetCore>1.0.19</SolrNetCore>
     <IBMMQDotnetClient>9.2.0.1</IBMMQDotnetClient>


### PR DESCRIPTION
The ServiceClient.CreateFromConnectionString method used by the health checks had a method signature change in later versions of Microsoft.Azure.Devices, which leads to a "Method not found" error when used in a project that references said later version of Microsoft.Azure.Devices.

The method header change (backward compatible): https://github.com/Azure/azure-iot-sdk-csharp/commit/c7f9469653f80092ace6c91de208df272e4d085a#diff-463d4ae31ba19a6fda6ce70b4c3a164bc8d711dd11ce6e51739dd7c5dd62dfb2

The resulting error:
```Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
      Health check iothub completed after 0.4714ms with status Unhealthy and description '(null)'
      System.MissingMethodException: Method not found: 'Microsoft.Azure.Devices.ServiceClient Microsoft.Azure.Devices.ServiceClient.CreateFromConnectionString(System.String, Microsoft.Azure.Devices.TransportType)'.
         at HealthChecks.Azure.IoTHub.IoTHubHealthCheck.ExecuteServiceConnectionCheckAsync(CancellationToken cancellationToken)
         at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
         at HealthChecks.Azure.IoTHub.IoTHubHealthCheck.ExecuteServiceConnectionCheckAsync(CancellationToken cancellationToken)
         at HealthChecks.Azure.IoTHub.IoTHubHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)```
