### PR TITLE
Most recent history should be on TOP.

### DIFF
--- a/src/HealthChecks.UI/client/components/LivenessDetail.tsx
+++ b/src/HealthChecks.UI/client/components/LivenessDetail.tsx
@@ -26,7 +26,7 @@ const LivenessDetail: FunctionComponent<LivenessDetailsProps> = props => {
         {props.executionHistory.length > 0 && (
           <VerticalTimeline className="hc-timeline">
             {' '}
-            {props.executionHistory.reverse().map(e => {
+            {props.executionHistory.map(e => {
               return (
                 <VerticalTimelineElement
                   className="hc-timeline__event"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently API is returning history in Desc Order (which is correct), but on UI we are showing older on TOP which is not really obvious.

**Does this PR introduce a user-facing change?**: YES

It will show histories, as it is shown on documentation: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks#health-status-history-timeline
