### PR TITLE
IdSvr: Add prefix to request URI

### DIFF
--- a/.github/workflows/healthchecks_openidconnectserver_cd.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_cd.yml
@@ -1,0 +1,40 @@
+name: HealthChecks OpenIdConnectServer CD
+
+on:
+  push:
+    tags:       
+      - release-openidconnectserver-*
+
+jobs:
+  build:
+    env:
+      BUILD_CONFIG: Release
+    runs-on: ubuntu-latest
+    services:
+      idsvr:
+        image: nakah/identityserver4
+        ports:
+          - 8888:80
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+        include-prerelease: false
+    - name: Restore dependencies
+      run: dotnet restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
+    - name: Build
+      run: dotnet build --no-restore ./src/HealthChecks.IdSvr/HealthChecks.OpenIdConnectServer.csproj
+    - name: Test
+      run: dotnet test ./test/HealthChecks.OpenIdConnectServer.Tests/HealthChecks.OpenIdConnectServer.Tests.csproj --verbosity normal
+    - name: dotnet pack 
+      run: dotnet pack ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: setup nuget
+      uses: NuGet/setup-nuget@v1.0.2
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+      with:
+        nuget-version: latest
+    - name: Publish IdSvr Health Check nuget
+      run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.OpenIdConnectServer.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/healthchecks_openidconnectserver_cd.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_cd.yml
@@ -2,6 +2,7 @@ name: HealthChecks OpenIdConnectServer CD
 
 on:
   push:
+    branches: [ master ]
     tags:       
       - release-openidconnectserver-*
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -118,7 +118,7 @@
     <HealthCheckDocumentDb>5.0.1</HealthCheckDocumentDb>
     <HealthCheckAzureStorage>5.0.1</HealthCheckAzureStorage>
     <HealthCheckHangfire>5.0.1</HealthCheckHangfire>
-    <HealthCheckAzureServiceBus>5.1.1</HealthCheckAzureServiceBus>
+    <HealthCheckAzureServiceBus>5.1.2</HealthCheckAzureServiceBus>
     <HealthCheckConsul>5.0.1</HealthCheckConsul>
     <HealthCheckUI>5.0.1</HealthCheckUI>
     <HealthCheckUICore>5.0.1</HealthCheckUICore>

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
@@ -7,10 +7,11 @@ namespace HealthChecks.AzureServiceBus
 {
     using Azure.Core;
 
-    public class AzureServiceBusSubscriptionHealthCheck   : AzureServiceBusHealthCheck, IHealthCheck
+    public class AzureServiceBusSubscriptionHealthCheck : AzureServiceBusHealthCheck, IHealthCheck
     {
         private readonly string _topicName;
         private readonly string _subscriptionName;
+        private string _connectionKey;
 
         public AzureServiceBusSubscriptionHealthCheck(string connectionString, string topicName, string subscriptionName) : base(connectionString)
         {
@@ -48,17 +49,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = ConnectionKey;
-                if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
-                {
-                    managementClient = CreateManagementClient();
-                    if (!ManagementClientConnections.TryAdd(connectionKey, managementClient))
-                    {
-                        return new HealthCheckResult(context.Registration.FailureStatus, description:
-                            "New service bus administration client connection can't be added into dictionary.");
-                    }
-                }
-
+                var managementClient = ManagementClientConnections.GetOrAdd(ConnectionKey, key => CreateManagementClient());
                 _ = await managementClient.GetSubscriptionRuntimePropertiesAsync(_topicName, _subscriptionName, cancellationToken);
                 return HealthCheckResult.Healthy();
             }
@@ -68,6 +59,6 @@ namespace HealthChecks.AzureServiceBus
             }
         }
 
-        protected override string ConnectionKey => $"{Prefix}_{_topicName}_{_subscriptionName}";
+        protected override string ConnectionKey => _connectionKey ??= $"{Prefix}_{_topicName}_{_subscriptionName}";
     }
 }

--- a/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string prefix = default, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
             var registrationName = name ?? NAME;
 
@@ -30,7 +30,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
-                sp => new IdSvrHealthCheck(() => sp.GetRequiredService<IHttpClientFactory>().CreateClient(registrationName)),
+                sp => new IdSvrHealthCheck(
+                    () => sp.GetRequiredService<IHttpClientFactory>().CreateClient(registrationName),
+                    prefix
+                ),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string prefix = default, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, string prefix = default)
         {
             var registrationName = name ?? NAME;
 

--- a/src/HealthChecks.IdSvr/IdSvrHealthCheck.cs
+++ b/src/HealthChecks.IdSvr/IdSvrHealthCheck.cs
@@ -12,16 +12,22 @@ namespace HealthChecks.IdSvr
         const string IDSVR_DISCOVER_CONFIGURATION_SEGMENT = ".well-known/openid-configuration";
 
         private readonly Func<HttpClient> _httpClientFactory;
-        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory)
+        private readonly string _prefix;
+        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory, string prefix = default)
         {
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _prefix = prefix;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
                 var httpClient = _httpClientFactory();
-                var response = await httpClient.GetAsync(IDSVR_DISCOVER_CONFIGURATION_SEGMENT, cancellationToken);
+                var requestUri = !string.IsNullOrEmpty(_prefix)
+                    ? $"{_prefix}/{IDSVR_DISCOVER_CONFIGURATION_SEGMENT}"
+                    : IDSVR_DISCOVER_CONFIGURATION_SEGMENT;
+
+                var response = await httpClient.GetAsync(requestUri, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
**What this PR does / why we need it**:
I have several .NET 5 APIs in which I want to check if Identity Server is already reachable. 
My Identity Server is behind an NGINX reverse proxy. The URI looks something like: https://dev.k8s-local.my-app.com/identityserver.
Both the APIs and Identity Server are part of the same Kubernetes deployment.

In described situation, the `GetAsync` call to .well-known/openid-configuration fails with the current version of the IdSvr health check.
With this fix, I can provide a prefix so that the request URI becomes identityserver/.well-known/openid-configuration.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The new prefix parameter of `AddIdentityServer` is optional.
If you don't use the prefix, code should still compile.

I tried to add unit tests, but my local build of HealthChecks.UI fails.
I just installed NPM version 8.1.4.
```
*** Bundling client files ***
1>
1>> healthchecks.ui@1.0.0 build
1>> npm run build:dll && npm run build:prod
1>
1>
1>> healthchecks.ui@1.0.0 build:dll
1>> webpack-cli --mode production --config ./build/webpack.dll.js
1>
1>node:internal/crypto/hash:67
1>  this[kHandle] = new _Hash(algorithm, xofLen);
1>                  ^
1>
1>Error : error : 0308010C:digital envelope routines::unsupported
1>    at new Hash (node:internal/crypto/hash:67:19)
1>    at Object.createHash (node:crypto:130:10)
1>    at module.exports (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\util\createHash.js:135:53)
1>    at NormalModule._initBuildHash (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:417:16)
1>    at handleParseError (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:471:10)
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:503:5
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:358:12
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:373:3
1>    at iterateNormalLoaders (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:214:10)
1>    at Array.<anonymous> (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:205:4)
1>    at Storage.finished (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:55:16)
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:91:9
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\graceful-fs\graceful-fs.js:123:16
1>    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
1>  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
1>  library: 'digital envelope routines',
1>  reason: 'unsupported',
1>  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```