### PR TITLE
IdSvr: Add prefix to request URI

### DIFF
--- a/.github/workflows/healthchecks_openidconnectserver_cd_preview.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_cd_preview.yml
@@ -29,7 +29,7 @@ jobs:
       run: dotnet build --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
     - name: Test
       run: dotnet test ./test/HealthChecks.OpenIdConnectServer.Tests/HealthChecks.OpenIdConnectServer.Tests.csproj --verbosity normal
-    - name: dotnet pack 
+    - name: dotnet pack
       run: dotnet pack ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.2

--- a/.github/workflows/healthchecks_openidconnectserver_ci.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_ci.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
     - name: Test
-      run: dotnet test ./test/HealthChecks.IdSvr.Tests/HealthChecks.IdSvr.Tests.csproj --verbosity normal
+      run: dotnet test ./test/HealthChecks.OpenIdConnectServer.Tests/HealthChecks.OpenIdConnectServer.Tests.csproj --verbosity normal

--- a/src/HealthChecks.OpenIdConnectServer/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.OpenIdConnectServer/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, string prefix = default)
         {
             var registrationName = name ?? NAME;
 
@@ -30,7 +30,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder.Add(new HealthCheckRegistration(
                 registrationName,
-                sp => new IdSvrHealthCheck(() => sp.GetRequiredService<IHttpClientFactory>().CreateClient(registrationName)),
+                sp => new IdSvrHealthCheck(
+                    () => sp.GetRequiredService<IHttpClientFactory>().CreateClient(registrationName),
+                    prefix
+                ),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.OpenIdConnectServer/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.OpenIdConnectServer/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, string prefix = default)
+        public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default, string requestUri = default)
         {
             var registrationName = name ?? NAME;
 
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 registrationName,
                 sp => new IdSvrHealthCheck(
                     () => sp.GetRequiredService<IHttpClientFactory>().CreateClient(registrationName),
-                    prefix
+                    requestUri
                 ),
                 failureStatus,
                 tags,

--- a/src/HealthChecks.OpenIdConnectServer/IdSvrHealthCheck.cs
+++ b/src/HealthChecks.OpenIdConnectServer/IdSvrHealthCheck.cs
@@ -12,16 +12,22 @@ namespace HealthChecks.IdSvr
         const string IDSVR_DISCOVER_CONFIGURATION_SEGMENT = ".well-known/openid-configuration";
 
         private readonly Func<HttpClient> _httpClientFactory;
-        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory)
+        private readonly string _prefix;
+        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory, string prefix)
         {
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _prefix = prefix;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
                 var httpClient = _httpClientFactory();
-                var response = await httpClient.GetAsync(IDSVR_DISCOVER_CONFIGURATION_SEGMENT, cancellationToken);
+                var requestUri = string.IsNullOrEmpty(_prefix)
+                    ? IDSVR_DISCOVER_CONFIGURATION_SEGMENT
+                    : $"{_prefix}/{IDSVR_DISCOVER_CONFIGURATION_SEGMENT}";
+
+                var response = await httpClient.GetAsync(requestUri, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/HealthChecks.OpenIdConnectServer/IdSvrHealthCheck.cs
+++ b/src/HealthChecks.OpenIdConnectServer/IdSvrHealthCheck.cs
@@ -9,25 +9,20 @@ namespace HealthChecks.IdSvr
     public class IdSvrHealthCheck
         : IHealthCheck
     {
-        const string IDSVR_DISCOVER_CONFIGURATION_SEGMENT = ".well-known/openid-configuration";
-
         private readonly Func<HttpClient> _httpClientFactory;
-        private readonly string _prefix;
-        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory, string prefix)
+        private readonly string _requestUri;
+        public IdSvrHealthCheck(Func<HttpClient> httpClientFactory, string requestUri = ".well-known/openid-configuration")
         {
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-            _prefix = prefix;
+            _requestUri = requestUri;
         }
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
                 var httpClient = _httpClientFactory();
-                var requestUri = string.IsNullOrEmpty(_prefix)
-                    ? IDSVR_DISCOVER_CONFIGURATION_SEGMENT
-                    : $"{_prefix}/{IDSVR_DISCOVER_CONFIGURATION_SEGMENT}";
 
-                var response = await httpClient.GetAsync(requestUri, cancellationToken);
+                var response = await httpClient.GetAsync(_requestUri, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
**What this PR does / why we need it**:
I have several .NET 5 APIs in which I want to check if Identity Server is already reachable. 
My Identity Server is behind an NGINX reverse proxy. The URI looks something like: https://dev.k8s-local.my-app.com/identityserver.
Both the APIs and Identity Server are part of the same Kubernetes deployment.

In described situation, the `GetAsync` call to .well-known/openid-configuration fails with the current version of the IdSvr health check.
With this fix, I can provide a prefix so that the request URI becomes identityserver/.well-known/openid-configuration.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The new prefix parameter of `AddIdentityServer` is optional.
If you don't use the prefix, code should still compile.

I tried to add unit tests, but my local build of HealthChecks.UI fails.
I just installed NPM version 8.1.4.
```
*** Bundling client files ***
1>
1>> healthchecks.ui@1.0.0 build
1>> npm run build:dll && npm run build:prod
1>
1>
1>> healthchecks.ui@1.0.0 build:dll
1>> webpack-cli --mode production --config ./build/webpack.dll.js
1>
1>node:internal/crypto/hash:67
1>  this[kHandle] = new _Hash(algorithm, xofLen);
1>                  ^
1>
1>Error : error : 0308010C:digital envelope routines::unsupported
1>    at new Hash (node:internal/crypto/hash:67:19)
1>    at Object.createHash (node:crypto:130:10)
1>    at module.exports (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\util\createHash.js:135:53)
1>    at NormalModule._initBuildHash (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:417:16)
1>    at handleParseError (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:471:10)
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:503:5
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\webpack\lib\NormalModule.js:358:12
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:373:3
1>    at iterateNormalLoaders (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:214:10)
1>    at Array.<anonymous> (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\loader-runner\lib\LoaderRunner.js:205:4)
1>    at Storage.finished (C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:55:16)
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:91:9
1>    at C:\Repos\ngruson\AspNetCore.Diagnostics.HealthChecks\src\HealthChecks.UI\node_modules\graceful-fs\graceful-fs.js:123:16
1>    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
1>  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
1>  library: 'digital envelope routines',
1>  reason: 'unsupported',
1>  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```