### PR TITLE
Aws s3 net6

### DIFF
--- a/src/HealthChecks.Aws.S3/DependencyInjection/S3HealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Aws.S3/DependencyInjection/S3HealthCheckBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using HealthChecks.Aws.S3;
+﻿using Amazon.S3;
+using HealthChecks.Aws.S3;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Collections.Generic;
@@ -27,9 +28,11 @@ namespace Microsoft.Extensions.DependencyInjection
             var options = new S3BucketOptions();
             setup?.Invoke(options);
 
+            builder.Services.AddSingleton<S3BucketOptions>(options);
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? Name,
-                sp => new S3HealthCheck(options),
+                sp => new S3HealthCheck(options, sp.GetRequiredService<IAmazonS3>()),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.Aws.S3/S3BucketOptions.cs
+++ b/src/HealthChecks.Aws.S3/S3BucketOptions.cs
@@ -6,9 +6,9 @@ namespace HealthChecks.Aws.S3
 {
     public class S3BucketOptions
     {
-        public string AccessKey { get; set; }
-        public string SecretKey { get; set; }
-        public AmazonS3Config S3Config { get; set; }
+        //public string AccessKey { get; set; }
+        //public string SecretKey { get; set; }
+        //public AmazonS3Config S3Config { get; set; }
         public string BucketName { get; set; }
         public Func<ListObjectsResponse, bool> CustomResponseCheck { get; set; }
     }

--- a/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
@@ -15,6 +15,15 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
         public void add_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
+
+
+            //var awsOptions = Configuration.GetAWSOptions();
+            //services.AddDefaultAWSOptions(awsOptions);
+
+            //services.AddAWSService<IAmazonS3>();
+
+
+            services.AddSingleton<IAmazonS3,AmazonS3Client>();
             services.AddHealthChecks()
                 .AddS3(options =>
                 {
@@ -35,6 +44,9 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
+
+            services.AddSingleton<IAmazonS3, AmazonS3Client>();
+
             services.AddHealthChecks()
                  .AddS3(options =>
                  {

--- a/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
@@ -18,10 +18,7 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
             services.AddHealthChecks()
                 .AddS3(options =>
                 {
-                    options.AccessKey = "access-key";
                     options.BucketName = "bucket-name";
-                    options.SecretKey = "secret-key";
-                    options.S3Config = new AmazonS3Config();
                 });
 
             var serviceProvider = services.BuildServiceProvider();
@@ -41,10 +38,7 @@ namespace HealthChecks.Aws.S3.Tests.DependencyInjection
             services.AddHealthChecks()
                  .AddS3(options =>
                  {
-                    options.AccessKey = "access-key";
                     options.BucketName = "bucket-name";
-                    options.SecretKey = "secret-key";
-                    options.S3Config = new AmazonS3Config();
                  }, name: "aws s3 check");
 
             var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
It's very standard to inject a an IAmazonS3 using config file settings or in startup like
1.
services.AddSingleton<IAmazonS3,AmazonS3Client>();
2.
var awsOptions = Configuration.GetAWSOptions();
services.AddDefaultAWSOptions(awsOptions);

services.AddAWSService<IAmazonS3>();

My changes allow you to use these settings and just have to pass the bucket name in for the health check and not have to setup yet another S3Config object.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
