### PR TITLE
Fix similar race conditions in AzureServiceBusQueueHealthCheck and AzureServiceBusTopicHealthCheck.

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -35,18 +35,8 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                if (!ManagementClientConnections.TryGetValue(ConnectionKey, out var managementClient))
-                {
-                    managementClient = CreateManagementClient();
-
-                    if (!ManagementClientConnections.TryAdd(ConnectionKey, managementClient))
-                    {
-                        return new HealthCheckResult(context.Registration.FailureStatus, description: "No service bus administration client connection can't be added into dictionary.");
-                    }
-                }
-
+                var managementClient = ManagementClientConnections.GetOrAdd(ConnectionKey, _ => CreateManagementClient());
                 _ = await managementClient.GetQueueRuntimePropertiesAsync(_queueName, cancellationToken);
-
                 return HealthCheckResult.Healthy();
             }
             catch (Exception ex)

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -36,17 +36,7 @@ namespace HealthChecks.AzureServiceBus
         {
             try
             {
-                var connectionKey = $"{ConnectionKey}_{_topicName}";
-                if (!ManagementClientConnections.TryGetValue(connectionKey, out var managementClient))
-                {
-                    managementClient = CreateManagementClient();
-                    if (!ManagementClientConnections.TryAdd(connectionKey, managementClient))
-                    {
-                        return new HealthCheckResult(context.Registration.FailureStatus,
-                            "New service bus administration client can't be added into dictionary.");
-                    }
-                }
-
+                var managementClient = ManagementClientConnections.GetOrAdd(ConnectionKey, _ => CreateManagementClient());
                 _ = await managementClient.GetTopicRuntimePropertiesAsync(_topicName, cancellationToken);
                 return HealthCheckResult.Healthy();
             }


### PR DESCRIPTION
This fixes issue #903 by replacing separate calls to `TryGetValue` and `TryAdd` with a single `GetOrAdd` operation against the concurrent dictionary of client connections.