### PR TITLE
Added support for using IServiceProvider when configuring Redis check

### DIFF
--- a/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
@@ -24,9 +24,38 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddRedis(this IHealthChecksBuilder builder, string redisConnectionString, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
+            return builder.AddRedis(_ => redisConnectionString, name, failureStatus, tags, timeout);
+        }
+
+        /// <summary>
+        /// Add a health check for Redis services.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// /// <param name="connectionStringFactory">A factory to build the Redis connection string to use.</param>
+        /// <param name="redisConnectionString">The Redis connection string to be used.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'redis' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddRedis(this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> connectionStringFactory,
+            string name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string> tags = default,
+            TimeSpan? timeout = default)
+        {
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+
             return builder.Add(new HealthCheckRegistration(
                name ?? NAME,
-               sp => new RedisHealthCheck(redisConnectionString),
+               sp => new RedisHealthCheck(connectionStringFactory(sp)),
                failureStatus,
                tags,
                timeout));

--- a/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using HealthChecks.Redis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -42,6 +41,29 @@ namespace HealthChecks.Redis.Tests.DependencyInjection
 
             registration.Name.Should().Be("my-redis");
             check.GetType().Should().Be(typeof(RedisHealthCheck));
+        }
+
+        [Fact]
+        public void add_health_check_with_connection_string_factory_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            var factoryCalled = false;
+            services.AddHealthChecks()
+                .AddRedis(_ =>
+                {
+                    factoryCalled = true;
+                    return "connectionstring";
+                });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("redis");
+            check.GetType().Should().Be(typeof(RedisHealthCheck));
+            factoryCalled.Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it: 
This pull request adds support for configuring the key vault URI and option using an IServiceProvider similar to how the SqlServerHealthCheck supports this for a connection string. This way the ASP.net core options pattern can be used to retrieve the key vault URI and/or keys and secrets. 

So instead of this: 
var provider = services.BuildServiceProvider(); 
var settings = services.GetRequiredService<IOptions<MyOptions>>();

services.AddHealthChecks().AddRedis( settings.Value.RedisConnectionString);

You can now do something like this:

services.AddHealthChecks().AddRedis( sp => services.GetRequiredService<IOptions<MyOptions>>().Value.RedisConnectionString); 

**Which issue(s) this PR fixes: 
none 

**Special notes for your reviewer**: 
This is based on the connectionStringFactory implementation in the SqlServerHealthCheck. 

**Does this PR introduce a user-facing change?**: 
It extends but does not break the existing options for configuring a RedisHealthCheck 

Please make sure you've completed the relevant tasks for this PR, out of the following list: 

- [x] Code compiles correctly 
- [x] Created/updated tests 
- [x] Unit tests passing 
- [ ] End-to-end tests passing
- [ ] Extended the documentation 
- [ ] Provided sample for the feature