### PR TITLE
Add overload to configure json serilizer options in WriteHealthCheckUIResponse

### DIFF
--- a/src/HealthChecks.UI.Client/UIResponseWriter.cs
+++ b/src/HealthChecks.UI.Client/UIResponseWriter.cs
@@ -16,7 +16,9 @@ namespace HealthChecks.UI.Client
         private static byte[] emptyResponse = new byte[] { (byte)'{', (byte)'}' };
         private static Lazy<JsonSerializerOptions> options = new Lazy<JsonSerializerOptions>(() => CreateJsonOptions());
 
-        public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report)
+        public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report) => await WriteHealthCheckUIResponse(httpContext, report, null);
+
+        public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report, Action<JsonSerializerOptions> jsonConfigurator)
         {
             if (report != null)
             {
@@ -27,7 +29,10 @@ namespace HealthChecks.UI.Client
 
                 using var responseStream = new MemoryStream();
 
-                await JsonSerializer.SerializeAsync(responseStream, uiReport, options.Value);
+                var serializerOptions = options.Value;
+                if (jsonConfigurator != null)
+                    jsonConfigurator(serializerOptions);
+                await JsonSerializer.SerializeAsync(responseStream, uiReport, serializerOptions);
                 await httpContext.Response.BodyWriter.WriteAsync(responseStream.ToArray());
             }
             else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
In previous version I could configure settings for json serializer in `WriteHealthCheckUIResponse` method. (For example to add indented formatting)  
In current version there is no such overload for some reason, but it was very helpfull

**Which issue(s) this PR fixes**:
No issue, I can create one if needed

<!-- Please reference the issue this PR will close: #_[issue number]_ -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
