### PR TITLE
Added support for using IServiceProvider when configuring Postgresql …

### DIFF
--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, string npgsqlConnectionString, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
-            return builder.AddNpgSql(_ => npgsqlConnectionString, healthQuery, connectionAction, name, failureStatus,tags,timeout);
+            return builder.AddNpgSql(_ => npgsqlConnectionString, healthQuery, connectionAction, name, failureStatus, tags, timeout);
         }
         
         /// <summary>

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, string npgsqlConnectionString, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
-            return builder.AddNpgSql(_ => npgsqlConnectionString, name, failureStatus, tags, timeout,tags,timeout);
+            return builder.AddNpgSql(_ => npgsqlConnectionString, healthQuery, connectionAction, name, failureStatus,tags,timeout);
         }
         
         /// <summary>

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, Func<IServiceProvider,string> connectionStringFactory, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default){
+        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, Func<IServiceProvider, string> connectionStringFactory, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
+        {
 
             if (connectionStringFactory == null)
             {

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -61,6 +61,5 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
-
     }
 }

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -27,12 +27,39 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, string npgsqlConnectionString, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
+            return builder.AddNpgSql(_ => npgsqlConnectionString, name, failureStatus, tags, timeout,tags,timeout);
+        }
+        
+        /// <summary>
+        /// Add a health check for Postgres databases.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// /// /// <param name="connectionStringFactory">A factory to build the Redis connection string to use.</param>
+        /// <param name="connectionStringFactory">The Postgres connection string to be used.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, Func<IServiceProvider,string> connectionStringFactory, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default){
+
+            if (connectionStringFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionStringFactory));
+            }
+
+            builder.Services.AddSingleton(sp => new NpgSqlHealthCheck(connectionStringFactory(sp),healthQuery,connectionAction));
+
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new NpgSqlHealthCheck(npgsqlConnectionString, healthQuery, connectionAction),
+                sp => sp.GetRequiredService<NpgSqlHealthCheck>(),
                 failureStatus,
                 tags,
                 timeout));
         }
+
     }
 }

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddNpgSql(this IHealthChecksBuilder builder, Func<IServiceProvider, string> connectionStringFactory, string healthQuery = "SELECT 1;", Action<NpgsqlConnection> connectionAction = null, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default, TimeSpan? timeout = default)
         {
-
             if (connectionStringFactory == null)
             {
                 throw new ArgumentNullException(nameof(connectionStringFactory));

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Add a health check for Postgres databases.
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-        /// /// /// <param name="connectionStringFactory">A factory to build the Redis connection string to use.</param>
+        /// <param name="connectionStringFactory">A factory to build the Postgres connection string to use.</param>
         /// <param name="connectionStringFactory">The Postgres connection string to be used.</param>
         /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
         /// <param name="failureStatus">

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(connectionStringFactory));
             }
 
-            builder.Services.AddSingleton(sp => new NpgSqlHealthCheck(connectionStringFactory(sp),healthQuery,connectionAction));
+            builder.Services.AddSingleton(sp => new NpgSqlHealthCheck(connectionStringFactory(sp), healthQuery, connectionAction));
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -57,7 +57,8 @@ namespace HealthChecks.Npgsql.Tests.DependencyInjection
                     return "connectionstring";
                 },name:"my-npg-1");
 
-            var serviceProvider = services.BuildServiceProvider();
+            using var serviceProvider = services.BuildServiceProvider();
+
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
 
             var registration = options.Value.Registrations.First();

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -44,5 +44,28 @@ namespace HealthChecks.Npgsql.Tests.DependencyInjection
             registration.Name.Should().Be("my-npg-1");
             check.GetType().Should().Be(typeof(NpgSqlHealthCheck));
         }
+
+        [Fact]
+        public void add_health_check_with_connection_string_factory_when_properly_configured()
+        {
+            var services = new ServiceCollection();
+            var factoryCalled = false;
+            services.AddHealthChecks()
+                .AddNpgSql(_ =>
+                {
+                    factoryCalled = true;
+                    return "connectionstring";
+                },"my-npg-1");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("my-npg-1");
+            check.GetType().Should().Be(typeof(NpgSqlHealthCheck));
+            factoryCalled.Should().BeTrue();
+        }
     }
 }

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -55,7 +55,7 @@ namespace HealthChecks.Npgsql.Tests.DependencyInjection
                 {
                     factoryCalled = true;
                     return "connectionstring";
-                },"my-npg-1");
+                },name:"my-npg-1");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();

--- a/test/HealthChecks.Npgsql.Tests/Functional/NpgsqlHealthCheckTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/Functional/NpgsqlHealthCheckTests.cs
@@ -105,7 +105,6 @@ namespace HealthChecks.Npgsql.Tests.Functional
                 .Should().Be(HttpStatusCode.ServiceUnavailable);
         }
         
-        
         [Fact]
         public async Task be_healthy_if_npgsql_is_available_by_iServiceProvider_registered()
         {

--- a/test/HealthChecks.Npgsql.Tests/Functional/NpgsqlHealthCheckTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/Functional/NpgsqlHealthCheckTests.cs
@@ -109,7 +109,6 @@ namespace HealthChecks.Npgsql.Tests.Functional
         [Fact]
         public async Task be_healthy_if_npgsql_is_available_by_iServiceProvider_registered()
         {
-
             var webHostBuilder = new WebHostBuilder()
                                  .UseStartup<DefaultStartup>()
                                  .ConfigureServices(services =>


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request is supported for configuring the connection and option using an `IServiceProvider` similar to how the `SqlServerHealthCheck` supports this for a connection string. 

So instead of this:

```
var provider = services.BuildServiceProvider();
var settings = services.GetRequiredService<IOptions>();
```

We need to set string type for Postgresql DB connection from heartbeat before.

```
services.AddHealthChecks().AddNpgSql("DBconnectionstring");
```

You can now do something like the code below.

```
services.AddHealthChecks().AddNpgSql(sp => services.GetRequiredService<IOptions>().Value.PostgresqlConnectionString);
```

**Special notes for your reviewer**:

This is based on the connectionStringFactory implementation in the SqlServerHealthCheck.

I had added some unit tests & functional tests for this feature, I passed by this picture below

![image](https://user-images.githubusercontent.com/9159452/154625407-bd218d7f-6fdd-4afd-9ebf-cd0440c68611.png)

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

It extends but does not break the existing options for configuring a Postgresql DB HealthCheck

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
