### PR TITLE
Update UIHealthReport.cs

### DIFF
--- a/src/HealthChecks.UI.Core/UIHealthReport.cs
+++ b/src/HealthChecks.UI.Core/UIHealthReport.cs
@@ -18,7 +18,7 @@ namespace HealthChecks.UI.Core
 
         public UIHealthReport(Dictionary<string, UIHealthReportEntry> entries, TimeSpan totalDuration)
         {
-            Entries = entries;
+            Entries = entries ?? new Dictionary<string, UIHealthReportEntry>();
             TotalDuration = totalDuration;
         }
         public static UIHealthReport CreateFrom(HealthReport report)


### PR DESCRIPTION
Fix null Entries in _UIHealthReport_

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Fixes the NullReferenceException when accessing null Entries in _UIHealthReport_. For example in _HealthReportExtensions_.

**Which issue(s) this PR fixes**:

~~Please reference the issue this PR will close: #_[issue number]_~~

**Special notes for your reviewer**:
Occurs when _HealthCheckReportCollector.GetHealthReport_ successfully deserializes the response, but in the requested URI is another API, which provide only "status" property and "entries" are omitted:
```json
{"title":"NotFound","status":404,"detail":"NotFound"}
```
 
**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [#] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
