### PR TITLE
Adding an optional Func to SqlServerHealthCheck to allow adding an Ac…

### DIFF
--- a/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.SqlServer/DependencyInjection/SqlServerHealthCheckBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
         /// <param name="beforeOpenConnectionConfigurer">An optional action executed before the connection is Open on the healthcheck.</param>
+        /// <param name="accessTokenProvider">An optional function to retrieve and Access Token before the connection is instantiated on the healthcheck.</param>
         /// <returns>The specified <paramref name="builder"/>.</returns>
         public static IHealthChecksBuilder AddSqlServer(
             this IHealthChecksBuilder builder,
@@ -35,9 +36,10 @@ namespace Microsoft.Extensions.DependencyInjection
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
             TimeSpan? timeout = default,
-            Action<SqlConnection>? beforeOpenConnectionConfigurer = default)
+            Action<SqlConnection>? beforeOpenConnectionConfigurer = default,
+            Func<string>? accessTokenProvider = default)
         {
-            return builder.AddSqlServer(_ => connectionString, healthQuery, name, failureStatus, tags, timeout, beforeOpenConnectionConfigurer);
+            return builder.AddSqlServer(_ => connectionString, healthQuery, name, failureStatus, tags, timeout, beforeOpenConnectionConfigurer, accessTokenProvider);
         }
 
         /// <summary>
@@ -54,6 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
         /// <param name="beforeOpenConnectionConfigurer">An optional action executed before the connection is Open on the healthcheck.</param>
+        /// <param name="accessTokenProvider">An optional function to retrieve and Access Token before the connection is instantiated on the healthcheck.</param>
         /// <returns>The specified <paramref name="builder"/>.</returns>
         public static IHealthChecksBuilder AddSqlServer(
             this IHealthChecksBuilder builder,
@@ -63,7 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
             TimeSpan? timeout = default,
-            Action<SqlConnection>? beforeOpenConnectionConfigurer = default)
+            Action<SqlConnection>? beforeOpenConnectionConfigurer = default,
+            Func<string>? accessTokenProvider = default)
         {
             if (connectionStringFactory == null)
             {
@@ -72,7 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                sp => new SqlServerHealthCheck(connectionStringFactory(sp), healthQuery ?? HEALTH_QUERY, beforeOpenConnectionConfigurer),
+                sp => new SqlServerHealthCheck(connectionStringFactory(sp), healthQuery ?? HEALTH_QUERY, beforeOpenConnectionConfigurer, accessTokenProvider),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
+++ b/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
@@ -8,19 +8,21 @@ namespace HealthChecks.SqlServer
         private readonly string _connectionString;
         private readonly string _sql;
         private readonly Action<SqlConnection>? _beforeOpenConnectionConfigurer;
+        private readonly Func<string>? _accessTokenProvider;
 
-        public SqlServerHealthCheck(string sqlserverconnectionstring, string sql, Action<SqlConnection>? beforeOpenConnectionConfigurer = null)
+        public SqlServerHealthCheck(string sqlserverconnectionstring, string sql, Action<SqlConnection>? beforeOpenConnectionConfigurer = null, Func<string>? accessTokenProvider = null)
         {
             _connectionString = sqlserverconnectionstring ?? throw new ArgumentNullException(nameof(sqlserverconnectionstring));
             _sql = sql ?? throw new ArgumentNullException(nameof(sql));
             _beforeOpenConnectionConfigurer = beforeOpenConnectionConfigurer;
+            _accessTokenProvider = accessTokenProvider;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                using (var connection = new SqlConnection(_connectionString))
+                using (var connection = new SqlConnection() { ConnectionString = _connectionString, AccessToken = _accessTokenProvider?.Invoke() })
                 {
                     _beforeOpenConnectionConfigurer?.Invoke(connection);
 

--- a/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
+++ b/src/HealthChecks.SqlServer/SqlServerHealthCheck.cs
@@ -22,7 +22,7 @@ namespace HealthChecks.SqlServer
         {
             try
             {
-                using (var connection = new SqlConnection() { ConnectionString = _connectionString, AccessToken = _accessTokenProvider?.Invoke() })
+                using (var connection = new SqlConnection(_connectionString) { AccessToken = _accessTokenProvider?.Invoke() })
                 {
                     _beforeOpenConnectionConfigurer?.Invoke(connection);
 


### PR DESCRIPTION
…cessToken Provider for the SqlConnection object

**What this PR does / why we need it**:
Currently the SqlServerHealthCheck only allows authentication to SQL server via User/Password, which limits the ways of using the Health Check to SQL DBs that might user other types of authentication, such as an Access Token (Azure AD). I created an optional parameter so that an access token provider can be added, hence being able to connect to a SQL database with a connection string that does not have a User/Password in it but does make use of Access Tokens to Authenticate.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes, There is a new optional parameter. If this parameter is not supplied by the user the functionality is backwards compatible.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
