### PR TITLE
Fix oracle tests

### DIFF
--- a/.github/workflows/healthchecks_oracle_cd.yml
+++ b/.github/workflows/healthchecks_oracle_cd.yml
@@ -12,12 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: oracleinanutshell/oracle-xe-11g
+        image: gvenzl/oracle-xe:18-slim
         ports:
           - 1521:1521
-          - 5500:5500
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
         env:
-          ORACLE_ALLOW_REMOTE: true
+          ORACLE_PASSWORD: oracle
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -41,4 +45,3 @@ jobs:
         nuget-version: latest
     - name: Publish Oracle Health Check nuget
       run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.Oracle.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-

--- a/.github/workflows/healthchecks_oracle_cd_preview.yml
+++ b/.github/workflows/healthchecks_oracle_cd_preview.yml
@@ -13,12 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: oracleinanutshell/oracle-xe-11g
+        image: gvenzl/oracle-xe:18-slim
         ports:
           - 1521:1521
-          - 5500:5500
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
         env:
-          ORACLE_ALLOW_REMOTE: true
+          ORACLE_PASSWORD: oracle
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -30,8 +34,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
-    # - name: Test
-    #   run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
+    - name: Test
+      run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
     - name: dotnet pack
       run: dotnet pack ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
@@ -42,4 +46,3 @@ jobs:
         nuget-version: latest
     - name: Publish Oracle Health Check nuget
       run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.Oracle.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: gvenzl/oracle-xe:latest
+        image: gvenzl/oracle-xe:latest-slim
         ports:
           - 1521:1521
         options: >-

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: gvenzl/oracle-xe:11-slim
+        image: gvenzl/oracle-xe:18-slim
         ports:
           - 1521:1521
         options: >-

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -30,8 +30,14 @@ jobs:
         ports:
           - 1521:1521
           #- 5500:5500
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
         env:
           #ORACLE_ALLOW_REMOTE: true
+          ORACLE_PASSWORD: oracle_password
           APP_USER: oracle_user
           APP_USER_PASSWORD: oracle_password
     steps:
@@ -53,4 +59,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
     - name: Test
-      run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
+      run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: gvenzl/oracle-xe:latest-slim
+        image: gvenzl/oracle-xe:11-slim
         ports:
           - 1521:1521
         options: >-

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -25,21 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        #image: oracleinanutshell/oracle-xe-11g
         image: gvenzl/oracle-xe:latest
         ports:
           - 1521:1521
-          #- 5500:5500
         options: >-
           --health-cmd healthcheck.sh
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
         env:
-          #ORACLE_ALLOW_REMOTE: true
-          ORACLE_PASSWORD: oracle_password
-          APP_USER: oracle_user
-          APP_USER_PASSWORD: oracle_password
+          ORACLE_PASSWORD: oracle
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -28,11 +28,6 @@ jobs:
         image: gvenzl/oracle-xe:18-slim
         ports:
           - 1521:1521
-        options: >-
-          --health-cmd healthcheck.sh
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
         env:
           ORACLE_PASSWORD: oracle
     steps:

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -52,5 +52,5 @@ jobs:
         dotnet format --no-restore --verify-no-changes --severity warn style || (echo "Run 'dotnet format' to fix style issues" && exit 1)
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
+    - name: Test
+      run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -25,12 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: oracleinanutshell/oracle-xe-11g
+        #image: oracleinanutshell/oracle-xe-11g
+        image: gvenzl/oracle-xe:latest
         ports:
           - 1521:1521
-          - 5500:5500
+          #- 5500:5500
         env:
-          ORACLE_ALLOW_REMOTE: true
+          #ORACLE_ALLOW_REMOTE: true
+          APP_USER: oracle_user
+          APP_USER_PASSWORD: oracle_password
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -16,7 +16,7 @@ namespace HealthChecks.Oracle.Tests.Functional
         [Fact]
         public async Task be_healthy_when_oracle_is_available()
         {
-            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=oracle_user;Password=oracle_password";
+            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle_password";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -15,7 +16,7 @@ namespace HealthChecks.Oracle.Tests.Functional
         [Fact]
         public async Task be_healthy_when_oracle_is_available()
         {
-            var connectionString = "Data Source=localhost:1521/oracle;User Id=oracle_user;Password=oracle_password";
+            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=oracle_user;Password=oracle_password";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -27,7 +28,8 @@ namespace HealthChecks.Oracle.Tests.Functional
                 {
                     app.UseHealthChecks("/health", new HealthCheckOptions()
                     {
-                        Predicate = r => r.Tags.Contains("oracle")
+                        Predicate = r => r.Tags.Contains("oracle"),
+                        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
                     });
                 });
 
@@ -36,7 +38,7 @@ namespace HealthChecks.Oracle.Tests.Functional
             var response = await server.CreateRequest("/health")
                 .GetAsync();
 
-            response.EnsureSuccessStatusCode();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
         }
 
         [Fact(Skip = "aaa")]

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using FluentAssertions;
-using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -28,8 +27,7 @@ namespace HealthChecks.Oracle.Tests.Functional
                 {
                     app.UseHealthChecks("/health", new HealthCheckOptions()
                     {
-                        Predicate = r => r.Tags.Contains("oracle"),
-                        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                        Predicate = r => r.Tags.Contains("oracle")
                     });
                 });
 

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -16,7 +16,7 @@ namespace HealthChecks.Oracle.Tests.Functional
         [Fact]
         public async Task be_healthy_when_oracle_is_available()
         {
-            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle_password";
+            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -41,10 +41,10 @@ namespace HealthChecks.Oracle.Tests.Functional
             response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
         }
 
-        [Fact(Skip = "aaa")]
+        [Fact]
         public async Task be_unhealthy_when_oracle_is_not_available()
         {
-            var connectionString = "Data Source=255.255.255.255:1521/oracle;User Id=oracle_user;Password=oracle_password";
+            var connectionString = "Data Source=255.255.255.255:1521/XEPDB1;User Id=system;Password=oracle";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -69,10 +69,10 @@ namespace HealthChecks.Oracle.Tests.Functional
                 .Be(HttpStatusCode.ServiceUnavailable);
         }
 
-        [Fact(Skip = "aaa")]
+        [Fact]
         public async Task be_unhealthy_when_sql_query_is_not_valid()
         {
-            var connectionString = "Data Source=localhost:1521/xe;User Id=system;Password=oracle";
+            var connectionString = "Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle";
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
@@ -96,11 +96,11 @@ namespace HealthChecks.Oracle.Tests.Functional
                 .Be(HttpStatusCode.ServiceUnavailable);
         }
 
-        [Fact(Skip = "aaa")]
+        [Fact]
         public async Task be_healthy_with_connection_string_factory_when_oracle_is_available()
         {
             bool factoryCalled = false;
-            string connectionString = "Data Source=localhost:1521/xe;User Id=system;Password=oracle";
+            string connectionString = "Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -15,7 +15,7 @@ namespace HealthChecks.Oracle.Tests.Functional
         [Fact]
         public async Task be_healthy_when_oracle_is_available()
         {
-            var connectionString = "Data Source=localhost:1521/xe;User Id=system;Password=oracle";
+            var connectionString = "Data Source=localhost:1521/oracle;User Id=oracle_user;Password=oracle_password";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -39,10 +39,10 @@ namespace HealthChecks.Oracle.Tests.Functional
             response.EnsureSuccessStatusCode();
         }
 
-        [Fact]
+        [Fact(Skip = "aaa")]
         public async Task be_unhealthy_when_oracle_is_not_available()
         {
-            var connectionString = "Data Source=255.255.255.255:1521/xe;User Id=system;Password=oracle";
+            var connectionString = "Data Source=255.255.255.255:1521/oracle;User Id=oracle_user;Password=oracle_password";
 
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -67,7 +67,7 @@ namespace HealthChecks.Oracle.Tests.Functional
                 .Be(HttpStatusCode.ServiceUnavailable);
         }
 
-        [Fact]
+        [Fact(Skip = "aaa")]
         public async Task be_unhealthy_when_sql_query_is_not_valid()
         {
             var connectionString = "Data Source=localhost:1521/xe;User Id=system;Password=oracle";
@@ -94,7 +94,7 @@ namespace HealthChecks.Oracle.Tests.Functional
                 .Be(HttpStatusCode.ServiceUnavailable);
         }
 
-        [Fact]
+        [Fact(Skip = "aaa")]
         public async Task be_healthy_with_connection_string_factory_when_oracle_is_available()
         {
             bool factoryCalled = false;

--- a/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj
+++ b/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.Oracle\HealthChecks.Oracle.csproj" />
-    <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj
+++ b/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.Oracle\HealthChecks.Oracle.csproj" />
+    <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
fixes #1019 

Changes:
- oracleinanutshell/oracle-xe-11g   ->   gvenzl/oracle-xe:18-slim for CI/CD
- xe   ->   XEPDB1
- `health-*` options for `docker create` were added for CD (skipped for CI since CI has long-running `dotnet format` before tests)