### PR TITLE
[UI] Add support for custom webhooks HttpClient delegating handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ You can visit the section [custom styles and branding](./doc/styles-branding.md)
 
 ## UI Configure HttpClient and HttpMessageHandler for Api and Webhooks endpoints
 
-If you need to configure a proxy, or set an authentication header, the UI allows you to configure the `HttpMessageHandler` and the `HttpClient` for the webhooks and healtheck api endpoints.
+If you need to configure a proxy, or set an authentication header, the UI allows you to configure the `HttpMessageHandler` and the `HttpClient` for the webhooks and healtheck api endpoints. You can also register custom delegating handlers for the API and WebHooks HTTP clients.
 
 ```csharp
 services.AddHealthChecksUI(setupSettings: setup =>
@@ -590,6 +590,7 @@ services.AddHealthChecksUI(setupSettings: setup =>
             Proxy = new WebProxy("http://proxy:8080")
         };
     })
+    .UseApiEndpointDelegatingHandler<CustomDelegatingHandler>()
     .ConfigureWebhooksEndpointHttpclient((sp, client) =>
     {
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "sampletoken");
@@ -603,7 +604,8 @@ services.AddHealthChecksUI(setupSettings: setup =>
                 ["prop"] = "value"
             }
         };
-    });
+    })
+    .UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler2>();
 })
 .AddInMemoryStorage();
 ```

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -13,9 +13,10 @@ namespace HealthChecks.UI.Configuration
         internal int MinimumSecondsBetweenFailureNotifications { get; set; } = 60 * 10;
         internal Func<IServiceProvider, HttpMessageHandler> ApiEndpointHttpHandler { get; private set; }
         internal Action<IServiceProvider, HttpClient> ApiEndpointHttpClientConfig { get; private set; }
+        internal Dictionary<string, Type> ApiEndpointDelegatingHandlerTypes { get; set; } = new Dictionary<string, Type>();
         internal Func<IServiceProvider, HttpMessageHandler> WebHooksEndpointHttpHandler { get; private set; }
-        internal Dictionary<string, Type> DelegatingHandlerTypes { get; set; } = new Dictionary<string, Type>();
         internal Action<IServiceProvider, HttpClient> WebHooksEndpointHttpClientConfig { get; private set; }
+        internal Dictionary<string, Type> WebHooksEndpointDelegatingHandlerTypes { get; set; } = new Dictionary<string, Type>();
         internal string HeaderText { get; private set; } = "Health Checks Status";
 
         public Settings AddHealthCheckEndpoint(string name, string uri)
@@ -83,9 +84,9 @@ namespace HealthChecks.UI.Configuration
         {
             var delegatingHandlerType = typeof(T);
 
-            if (!DelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
+            if (!ApiEndpointDelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
             {
-                DelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType);
+                ApiEndpointDelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType);
             }
 
             return this;
@@ -94,6 +95,18 @@ namespace HealthChecks.UI.Configuration
         public Settings UseWebhookEndpointHttpMessageHandler(Func<IServiceProvider, HttpClientHandler> webhookEndpointHttpHandler)
         {
             WebHooksEndpointHttpHandler = webhookEndpointHttpHandler;
+            return this;
+        }
+
+        public Settings UseWebHooksEndpointDelegatingHandler<T>() where T : DelegatingHandler
+        {
+            var delegatingHandlerType = typeof(T);
+
+            if (!WebHooksEndpointDelegatingHandlerTypes.ContainsKey(delegatingHandlerType.FullName))
+            {
+                WebHooksEndpointDelegatingHandlerTypes.Add(delegatingHandlerType.FullName, delegatingHandlerType);
+            }
+
             return this;
         }
 

--- a/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     var settings = builder.Services.GetService<IOptions<Settings>>();
 
-                    foreach (var handlerType in settings.Value.DelegatingHandlerTypes.Values)
+                    foreach (var handlerType in settings.Value.ApiEndpointDelegatingHandlerTypes.Values)
                     {
                         builder.AdditionalHandlers.Add((DelegatingHandler)builder.Services.GetRequiredService(handlerType));
                     }
@@ -76,6 +76,15 @@ namespace Microsoft.Extensions.DependencyInjection
                  var settings = sp.GetService<IOptions<Settings>>();
                  return settings.Value.WebHooksEndpointHttpHandler?.Invoke(sp) ?? new HttpClientHandler();
              })
+            .ConfigureHttpMessageHandlerBuilder(builder =>
+            {
+                var settings = builder.Services.GetService<IOptions<Settings>>();
+
+                foreach (var handlerType in settings.Value.WebHooksEndpointDelegatingHandlerTypes.Values)
+                {
+                    builder.AdditionalHandlers.Add((DelegatingHandler)builder.Services.GetRequiredService(handlerType));
+                }
+            })
             .Services;
         }
 

--- a/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
@@ -48,7 +48,7 @@ namespace HealthChecks.UI.Tests
         }
 
         [Fact]
-        public Task configure_custom_delegating_handlers()
+        public Task configure_api_endpoint_custom_delegating_handlers()
         {
             var hostReset = new ManualResetEventSlim(false);
             var tracer = Substitute.For<MessageHandlerTracer>();
@@ -66,6 +66,45 @@ namespace HealthChecks.UI.Tests
                         setup.AddHealthCheckEndpoint("endpoint1", "https://httpstat.us/200");
                         setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler>();
                         setup.UseApiEndpointDelegatingHandler<CustomDelegatingHandler2>();
+
+                    }).AddInMemoryStorage();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(setup => setup.MapHealthChecksUI());
+                });
+
+            var server = new TestServer(builder);
+
+            hostReset.Wait(3000);
+
+            tracer.Received().Log(nameof(CustomDelegatingHandler), "SendAsync");
+            tracer.Received().Log(nameof(CustomDelegatingHandler2), "SendAsync");
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public Task configure_webhooks_endpoint_custom_delegating_handlers()
+        {
+            var hostReset = new ManualResetEventSlim(false);
+            var tracer = Substitute.For<MessageHandlerTracer>();
+
+            var builder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services
+                    .AddRouting()
+                    .AddSingleton<IHealthCheckCollectorInterceptor>(sp => new TestCollectorInterceptor(hostReset))
+                    .AddTransient(sp => new CustomDelegatingHandler(tracer))
+                    .AddTransient(sp => new CustomDelegatingHandler2(tracer))
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup.AddHealthCheckEndpoint("endpoint1", "https://httpstat.us/200");
+                        setup.AddWebhookNotification("webhook1", "https://httpstat.us/200", "test payload");
+                        setup.UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler>();
+                        setup.UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler2>();
 
                     }).AddInMemoryStorage();
                 })


### PR DESCRIPTION
**What this PR does / why we need it**: 
Add support to register custom delegating handlers for webhooks HttpClient to mutate requests.

**Which issue(s) this PR fixes**: #1023 

**Does this PR introduce a user-facing change?**: No

Sample:

```
services
    .AddRouting() 
    .AddTransient(sp => new CustomDelegatingHandler(tracer))
    .AddHealthChecksUI(setup =>
    {
        setup.AddHealthCheckEndpoint("endpoint1", "http://healthcheckurl");
        setup.AddWebhookNotification("webhook1", "https://webhookurl", "sample payload");
        setup.UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler>();
    })
   .AddInMemoryStorage();
```

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [x] Extended the documentation
- [x] Provided sample for the feature
