### PR TITLE
Bumping apiVersion for healtchecks crd definition

### DIFF
--- a/deploy/operator/crd/healthcheck-crd-pre-v1.22.yaml
+++ b/deploy/operator/crd/healthcheck-crd-pre-v1.22.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: healthchecks.aspnetcore.ui
+spec:
+  group: aspnetcore.ui
+  names:
+    plural: healthchecks
+    singular: healthcheck
+    kind: HealthCheck
+    listKind: HealthChecks
+    shortNames:
+      - hc
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            name:
+              type: string
+            scope:
+             type: string
+             enum:
+               - Cluster
+               - Namespaced
+            serviceType:
+              type: string
+              enum:
+                - ClusterIP
+                - LoadBalancer
+                - NodePort
+            portNumber:
+              type: number
+            uiPath:
+              type: string
+              pattern: "^/"
+            uiApiPath:
+              type: string
+              pattern: "^/"
+            uiResourcesPath:
+              type: string
+              pattern: "^/"
+            uiWebhooksPath:
+              type: string
+              pattern: "^/"
+            uiNoRelativePaths:
+              type: boolean
+            servicesLabel:
+              type: string
+            healthChecksPath:
+              type: string
+            healthChecksScheme:
+              type: string
+            image:
+              type: string
+            imagePullPolicy:
+              type: string
+            stylesheetContent:
+              type: string
+            serviceAnnotations:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+            deployAnnotations:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                required:
+                  - name
+                  - value
+            webhooks:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  uri:
+                    type: string
+                  payload:
+                    type: string
+                  restoredPayload:
+                    type: string
+                required:
+                  - name
+                  - uri
+                  - payload
+                  - restoredPayload
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  value:
+                    type: string
+                  effect:
+                    type: string
+                  seconds:
+                    type: number
+          required:
+            - name
+            - scope
+            - servicesLabel

--- a/deploy/operator/crd/healthcheck-crd.yaml
+++ b/deploy/operator/crd/healthcheck-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: healthchecks.aspnetcore.ui
@@ -11,112 +11,100 @@ spec:
     listKind: HealthChecks
     shortNames:
       - hc
+  scope: Namespaced
   versions:
     - name: v1
       served: true
       storage: true
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            name:
-              type: string
-            scope:
-             type: string
-             enum:
-               - Cluster
-               - Namespaced
-            serviceType:
-              type: string
-              enum:
-                - ClusterIP
-                - LoadBalancer
-                - NodePort
-            portNumber:
-              type: number
-            uiPath:
-              type: string
-              pattern: "^/"
-            uiApiPath:
-              type: string
-              pattern: "^/"
-            uiResourcesPath:
-              type: string
-              pattern: "^/"
-            uiWebhooksPath:
-              type: string
-              pattern: "^/"
-            uiNoRelativePaths:
-              type: boolean
-            servicesLabel:
-              type: string
-            healthChecksPath:
-              type: string
-            healthChecksScheme:
-              type: string
-            image:
-              type: string
-            imagePullPolicy:
-              type: string
-            stylesheetContent:
-              type: string
-            serviceAnnotations:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-            deployAnnotations:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                required:
-                  - name
-                  - value
-            webhooks:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  uri:
-                    type: string
-                  payload:
-                    type: string
-                  restoredPayload:
-                    type: string
-                required:
-                  - name
-                  - uri
-                  - payload
-                  - restoredPayload
-            tolerations:
-              type: array
-              items:
-                type: object
-                properties:
-                  key:
-                    type: string
-                  operator:
-                    type: string
-                  value:
-                    type: string
-                  effect:
-                    type: string
-                  seconds:
-                    type: number
-          required:
-            - name
-            - scope
-            - servicesLabel
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                scope:
+                  type: string
+                  enum:
+                    - Cluster
+                    - Namespaced
+                serviceType:
+                  type: string
+                  enum:
+                    - ClusterIP
+                    - LoadBalancer
+                    - NodePort
+                portNumber:
+                  type: number
+                uiPath:
+                  type: string
+                  pattern: "^/"
+                uiApiPath:
+                  type: string
+                  pattern: "^/"
+                uiResourcesPath:
+                  type: string
+                  pattern: "^/"
+                uiWebhooksPath:
+                  type: string
+                  pattern: "^/"
+                uiNoRelativePaths:
+                  type: boolean
+                servicesLabel:
+                  type: string
+                healthChecksPath:
+                  type: string
+                healthChecksScheme:
+                  type: string
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                stylesheetContent:
+                  type: string
+                serviceAnnotations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                deployAnnotations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                      - name
+                      - value
+                webhooks:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      uri:
+                        type: string
+                      payload:
+                        type: string
+                      restoredPayload:
+                        type: string
+                    required:
+                      - name
+                      - uri
+                      - payload
+                      - restoredPayload
+
+              required:
+                - name
+                - scope
+                - servicesLabel


### PR DESCRIPTION
**What this PR does / why we need it**:

When deploying the healthchecks operator on the latest version of `kind` it will fail, because `apiextensions.k8s.io/v1beta1` is not supported any longer.
This bumps the `apiVersion` to the stable version and adds minimal changes to adhere to the specification.

**Which issue(s) this PR fixes**:

Fixes #723 

**Special notes for your reviewer**: -

**Does this PR introduce a user-facing change?**: No

