### PR TITLE
Run tests only for CI workflows

### DIFF
--- a/.github/workflows/healthchecks_arangodb_cd.yml
+++ b/.github/workflows/healthchecks_arangodb_cd.yml
@@ -9,13 +9,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      arangodb:
-        image: arangodb/arangodb:latest
-        ports:
-          - 8529:8529
-        env:
-          ARANGO_ROOT_PASSWORD: strongArangoDbPassword
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.ArangoDb.Tests/HealthChecks.ArangoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_arangodb_cd_preview.yml
+++ b/.github/workflows/healthchecks_arangodb_cd_preview.yml
@@ -10,13 +10,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      arangodb:
-        image: arangodb/arangodb:latest
-        ports:
-          - 8529:8529
-        env:
-          ARANGO_ROOT_PASSWORD: strongArangoDbPassword
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.ArangoDb.Tests/HealthChecks.ArangoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_aws_s3_cd.yml
+++ b/.github/workflows/healthchecks_aws_s3_cd.yml
@@ -20,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Aws.S3.Tests/HealthChecks.Aws.S3.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_aws_s3_cd_preview.yml
+++ b/.github/workflows/healthchecks_aws_s3_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Aws.S3.Tests/HealthChecks.Aws.S3.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azure_digitaltwin_cd.yml
+++ b/.github/workflows/healthchecks_azure_digitaltwin_cd.yml
@@ -20,8 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azure_digitaltwin_cd_preview.yml
+++ b/.github/workflows/healthchecks_azure_digitaltwin_cd_preview.yml
@@ -21,8 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azure_iothub_cd .yml
+++ b/.github/workflows/healthchecks_azure_iothub_cd .yml
@@ -20,8 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azure_iothub_cd_preview.yml
+++ b/.github/workflows/healthchecks_azure_iothub_cd_preview.yml
@@ -21,8 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azurekeyvault_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd.yml
@@ -20,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azureservicebus_cd.yml
+++ b/.github/workflows/healthchecks_azureservicebus_cd.yml
@@ -20,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureServiceBus.Tests/HealthChecks.AzureServiceBus.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azureservicebus_cd_preview.yml
+++ b/.github/workflows/healthchecks_azureservicebus_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureServiceBus.Tests/HealthChecks.AzureServiceBus.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azurestorage_cd.yml
+++ b/.github/workflows/healthchecks_azurestorage_cd.yml
@@ -20,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureStorage.Tests/HealthChecks.AzureStorage.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_azurestorage_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurestorage_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.AzureStorage.Tests/HealthChecks.AzureStorage.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_consul_cd.yml
+++ b/.github/workflows/healthchecks_consul_cd.yml
@@ -10,12 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      consul:
-        image: consul:latest
-        ports:
-          - 8500:8500
-          - 8600:8600
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Consul.Tests/HealthChecks.Consul.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Consul/HealthChecks.Consul.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_consul_cd_preview.yml
+++ b/.github/workflows/healthchecks_consul_cd_preview.yml
@@ -10,12 +10,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      consul:
-        image: consul:latest
-        ports:
-          - 8500:8500
-          - 8600:8600
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Consul.Tests/HealthChecks.Consul.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Consul/HealthChecks.Consul.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_cosmosdb_cd.yml
+++ b/.github/workflows/healthchecks_cosmosdb_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.CosmosDb.Tests/HealthChecks.CosmosDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_cosmosdb_cd_preview.yml
+++ b/.github/workflows/healthchecks_cosmosdb_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.CosmosDb.Tests/HealthChecks.CosmosDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_documentdb_cd.yml
+++ b/.github/workflows/healthchecks_documentdb_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_documentdb_cd_preview.yml
+++ b/.github/workflows/healthchecks_documentdb_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_dynamodb_cd.yml
+++ b/.github/workflows/healthchecks_dynamodb_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.DynamoDb.Tests/HealthChecks.DynamoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_dynamodb_cd_preview.yml
+++ b/.github/workflows/healthchecks_dynamodb_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.DynamoDb.Tests/HealthChecks.DynamoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_elasticsearch_cd.yml
+++ b/.github/workflows/healthchecks_elasticsearch_cd.yml
@@ -11,12 +11,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
-        ports:
-          - 9300:9300
-          - 9200:9200
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_elasticsearch_cd_preview.yml
+++ b/.github/workflows/healthchecks_elasticsearch_cd_preview.yml
@@ -12,12 +12,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
-        ports:
-          - 9300:9300
-          - 9200:9200
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +23,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_gcp_cloudfirestore_cd.yml
+++ b/.github/workflows/healthchecks_gcp_cloudfirestore_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Gcp.CloudFirestore.Tests/HealthChecks.Gcp.CloudFirestore.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_gcp_cloudfirestore_cd_preview.yml
+++ b/.github/workflows/healthchecks_gcp_cloudfirestore_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Gcp.CloudFirestore.Tests/HealthChecks.Gcp.CloudFirestore.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_gremlin_cd.yml
+++ b/.github/workflows/healthchecks_gremlin_cd.yml
@@ -10,14 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      gremlin:
-        image: tinkerpop/gremlin-server
-        ports:
-          - 8182:8182
-        env:
-          VIRTUAL_HOST: gremlin.docker
-          VIRTUAL_PORT: 8182
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Gremlin.Tests/HealthChecks.Gremlin.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_gremlin_cd_preview.yml
+++ b/.github/workflows/healthchecks_gremlin_cd_preview.yml
@@ -11,14 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      gremlin:
-        image: tinkerpop/gremlin-server
-        ports:
-          - 8182:8182
-        env:
-          VIRTUAL_HOST: gremlin.docker
-          VIRTUAL_PORT: 8182
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -30,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Gremlin.Tests/HealthChecks.Gremlin.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_hangfire_cd.yml
+++ b/.github/workflows/healthchecks_hangfire_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Hangfire.Tests/HealthChecks.Hangfire.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_hangfire_cd_preview.yml
+++ b/.github/workflows/healthchecks_hangfire_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Hangfire.Tests/HealthChecks.Hangfire.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ibmmq_cd.yml
+++ b/.github/workflows/healthchecks_ibmmq_cd.yml
@@ -9,17 +9,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      ibmmq:
-        image: ibmcom/mq
-        ports:
-          - 1414:1414
-          - 9157:9157
-        env:
-          LICENSE: accept
-          MQ_QMGR_NAME: QM1
-          MQ_APP_PASSWORD: 12345678
-          MQ_ENABLE_METRICS: true
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -31,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.IbmMQ.Tests/HealthChecks.IbmMQ.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ibmmq_cd_preview.yml
+++ b/.github/workflows/healthchecks_ibmmq_cd_preview.yml
@@ -10,17 +10,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      ibmmq:
-        image: ibmcom/mq
-        ports:
-          - 1414:1414
-          - 9157:9157
-        env:
-          LICENSE: accept
-          MQ_QMGR_NAME: QM1
-          MQ_APP_PASSWORD: 12345678
-          MQ_ENABLE_METRICS: true
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -32,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.IbmMQ.Tests/HealthChecks.IbmMQ.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_kafka_cd.yml
+++ b/.github/workflows/healthchecks_kafka_cd.yml
@@ -10,19 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      kafka:
-        image: confluent/kafka
-        ports:
-          - 9092:9092
-        env:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_PORT: 9092
-      zookeeper:
-        image: confluent/zookeeper
-        ports:
-          - 2181:2181
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -34,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.Kafka.Tests/HealthChecks.Kafka.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_kafka_cd_preview.yml
+++ b/.github/workflows/healthchecks_kafka_cd_preview.yml
@@ -11,19 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      zookeeper:
-        image: confluent/zookeeper
-        ports:
-          - 2181:2181
-      kafka:
-        image: confluent/kafka
-        ports:
-          - 9092:9092
-        env:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_PORT: 9092
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -35,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
-    # - name: Test
-    #   run: dotnet test ./test/HealthChecks.Kafka.Tests/HealthChecks.Kafka.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_mongodb_cd.yml
+++ b/.github/workflows/healthchecks_mongodb_cd.yml
@@ -10,11 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -26,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.MongoDb.Tests/HealthChecks.MongoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_mongodb_cd_preview.yml
+++ b/.github/workflows/healthchecks_mongodb_cd_preview.yml
@@ -11,11 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.MongoDb.Tests/HealthChecks.MongoDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_mysql_cd.yml
+++ b/.github/workflows/healthchecks_mysql_cd.yml
@@ -10,13 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.MySql.Tests/HealthChecks.MySql.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.MySql/HealthChecks.MySql.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_mysql_cd_preview.yml
+++ b/.github/workflows/healthchecks_mysql_cd_preview.yml
@@ -11,13 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.MySql.Tests/HealthChecks.MySql.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.MySql/HealthChecks.MySql.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_nats_cd.yml
+++ b/.github/workflows/healthchecks_nats_cd.yml
@@ -10,13 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      nats:
-        image: nats:latest
-        ports:
-        - "4222:4222"
-        - "8222:8222"
-        - "6222:6222"
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Nats.Tests/HealthChecks.Nats.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Nats/HealthChecks.Nats.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_nats_cd_preview.yml
+++ b/.github/workflows/healthchecks_nats_cd_preview.yml
@@ -11,13 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-       nats:
-        image: nats:latest
-        ports:
-        - "4222:4222"
-        - "8222:8222"
-        - "6222:6222"
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Nats.Tests/HealthChecks.Nats.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Nats/HealthChecks.Nats.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_network_cd.yml
+++ b/.github/workflows/healthchecks_network_cd.yml
@@ -10,17 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    #services:
-    #  ftp:
-    #    image: bogem/ftp
-    #    ports:
-    #      - 21:21
-    #      - 47400-47470:47400-47470
-    #    env:
-    #      FTP_USER: bob
-    #      FTP_PASS: 12345
-    #      PASV_ADDRESS: 127.0.0.1
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -32,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Network/HealthChecks.Network.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Network/HealthChecks.Network.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.Network.Tests/HealthChecks.Network.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Network/HealthChecks.Network.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Network/HealthChecks.Network.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_network_cd_preview.yml
+++ b/.github/workflows/healthchecks_network_cd_preview.yml
@@ -11,17 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      ftp:
-        image: bogem/ftp
-        ports:
-          - 21:21
-          - 47400-47470:47400-47470
-        env:
-          FTP_USER: bob
-          FTP_PASS: 12345
-          PASV_ADDRESS: 127.0.0.1
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -33,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Network/HealthChecks.Network.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Network/HealthChecks.Network.csproj
-    # - name: Test
-    #   run: dotnet test ./test/HealthChecks.Network.Tests/HealthChecks.Network.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Network/HealthChecks.Network.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Network/HealthChecks.Network.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_npgsql_cd.yml
+++ b/.github/workflows/healthchecks_npgsql_cd.yml
@@ -9,14 +9,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      npgsql:
-        image: postgres
-        ports:
-          - 8010:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +20,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Npgsql.Tests/HealthChecks.Npgsql.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_npgsql_cd_preview.yml
+++ b/.github/workflows/healthchecks_npgsql_cd_preview.yml
@@ -10,14 +10,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      npgsql:
-        image: postgres
-        ports:
-          - 8010:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Npgsql.Tests/HealthChecks.Npgsql.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_openidconnectserver_cd.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_cd.yml
@@ -10,11 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      idsvr:
-        image: nakah/identityserver4
-        ports:
-          - 8888:80
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -26,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.OpenIdConnectServer.Tests/HealthChecks.OpenIdConnectServer.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_openidconnectserver_cd_preview.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_cd_preview.yml
@@ -11,11 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      idsvr:
-        image: nakah/identityserver4
-        ports:
-          - 8888:80
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.OpenIdConnectServer.Tests/HealthChecks.OpenIdConnectServer.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_oracle_cd.yml
+++ b/.github/workflows/healthchecks_oracle_cd.yml
@@ -10,18 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      oracle:
-        image: gvenzl/oracle-xe:18-slim
-        ports:
-          - 1521:1521
-        options: >-
-          --health-cmd healthcheck.sh
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          ORACLE_PASSWORD: oracle
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -33,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_oracle_cd_preview.yml
+++ b/.github/workflows/healthchecks_oracle_cd_preview.yml
@@ -11,18 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      oracle:
-        image: gvenzl/oracle-xe:18-slim
-        ports:
-          - 1521:1521
-        options: >-
-          --health-cmd healthcheck.sh
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          ORACLE_PASSWORD: oracle
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -34,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_prometheus_metrics_cd.yml
+++ b/.github/workflows/healthchecks_prometheus_metrics_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Prometheus.Metrics.Tests/HealthChecks.Prometheus.Metrics.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_prometheus_metrics_cd_preview.yml
+++ b/.github/workflows/healthchecks_prometheus_metrics_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Prometheus.Metrics.Tests/HealthChecks.Prometheus.Metrics.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_applicationinsights_cd.yml
+++ b/.github/workflows/healthchecks_publisher_applicationinsights_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_applicationinsights_cd_preview.yml
+++ b/.github/workflows/healthchecks_publisher_applicationinsights_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_datadog_cd.yml
+++ b/.github/workflows/healthchecks_publisher_datadog_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Datadog.Tests/HealthChecks.Publisher.Datadog.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_datadog_cd_preview.yml
+++ b/.github/workflows/healthchecks_publisher_datadog_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Datadog.Tests/HealthChecks.Publisher.Datadog.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_prometheus_cd.yml
+++ b/.github/workflows/healthchecks_publisher_prometheus_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Prometheus.Tests/HealthChecks.Publisher.Prometheus.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_prometheus_cd_preview.yml
+++ b/.github/workflows/healthchecks_publisher_prometheus_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Prometheus.Tests/HealthChecks.Publisher.Prometheus.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_seq_cd.yml
+++ b/.github/workflows/healthchecks_publisher_seq_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_publisher_seq_cd_preview.yml
+++ b/.github/workflows/healthchecks_publisher_seq_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_rabbitmq_cd.yml
+++ b/.github/workflows/healthchecks_rabbitmq_cd.yml
@@ -10,11 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -26,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.RabbitMQ.Tests/HealthChecks.RabbitMQ.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_rabbitmq_cd_preview.yml
+++ b/.github/workflows/healthchecks_rabbitmq_cd_preview.yml
@@ -11,11 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.RabbitMQ.Tests/HealthChecks.RabbitMQ.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ravendb_cd.yml
+++ b/.github/workflows/healthchecks_ravendb_cd.yml
@@ -10,13 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      ravendb:
-        image: ravendb/ravendb
-        ports:
-          - 9030:8080
-        env:
-          RAVEN_ARGS: --Setup.Mode=None
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -28,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.RavenDb.Tests/HealthChecks.RavenDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ravendb_cd_preview.yml
+++ b/.github/workflows/healthchecks_ravendb_cd_preview.yml
@@ -11,13 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      ravendb:
-        image: ravendb/ravendb
-        ports:
-          - 9030:8080
-        env:
-          RAVEN_ARGS: --Setup.Mode=None
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.RavenDb.Tests/HealthChecks.RavenDb.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_redis_cd.yml
+++ b/.github/workflows/healthchecks_redis_cd.yml
@@ -10,11 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:alpine
-        ports:
-          - 6379:6379
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -26,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Redis/HealthChecks.Redis.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_redis_cd_preview.yml
+++ b/.github/workflows/healthchecks_redis_cd_preview.yml
@@ -11,11 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:alpine
-        ports:
-          - 6379:6379
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Redis/HealthChecks.Redis.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sendgrid_cd.yml
+++ b/.github/workflows/healthchecks_sendgrid_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SendGrid.Tests/HealthChecks.SendGrid.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sendgrid_cd_preview.yml
+++ b/.github/workflows/healthchecks_sendgrid_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SendGrid.Tests/HealthChecks.SendGrid.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_signalr_cd.yml
+++ b/.github/workflows/healthchecks_signalr_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SignalR.Tests/HealthChecks.SignalR.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_signalr_cd_preview.yml
+++ b/.github/workflows/healthchecks_signalr_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SignalR.Tests/HealthChecks.SignalR.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SignalR/HealthChecks.SignalR.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_solr_cd.yml
+++ b/.github/workflows/healthchecks_solr_cd.yml
@@ -10,11 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      solr:
-        image: solr:8.4.1
-        ports:
-          - 8983:8983
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -26,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.Solr.Tests/HealthChecks.Solr.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Solr/HealthChecks.Solr.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_solr_cd_preview.yml
+++ b/.github/workflows/healthchecks_solr_cd_preview.yml
@@ -11,11 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      solr:
-        image: solr:8.4.1
-        ports:
-          - 8983:8983
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -27,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj
-    # - name: Test
-    #   run: dotnet test ./test/HealthChecks.SolR.Tests/HealthChecks.SolR.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Solr/HealthChecks.Solr.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sqlite_cd.yml
+++ b/.github/workflows/healthchecks_sqlite_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Sqlite.Tests/HealthChecks.Sqlite.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sqlite_cd_preview.yml
+++ b/.github/workflows/healthchecks_sqlite_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Sqlite.Tests/HealthChecks.Sqlite.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sqlserver_cd.yml
+++ b/.github/workflows/healthchecks_sqlserver_cd.yml
@@ -10,14 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server
-        ports:
-          - 5433:1433
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -29,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SqlServer.Tests/HealthChecks.SqlServer.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_sqlserver_cd_preview.yml
+++ b/.github/workflows/healthchecks_sqlserver_cd_preview.yml
@@ -11,14 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server
-        ports:
-          - 5433:1433
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -30,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.SqlServer.Tests/HealthChecks.SqlServer.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_system_cd.yml
+++ b/.github/workflows/healthchecks_system_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.System/HealthChecks.System.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.System/HealthChecks.System.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.System.Tests/HealthChecks.System.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.System/HealthChecks.System.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.System/HealthChecks.System.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_system_cd_preview.yml
+++ b/.github/workflows/healthchecks_system_cd_preview.yml
@@ -22,10 +22,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.System/HealthChecks.System.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.System/HealthChecks.System.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.System.Tests/HealthChecks.System.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.System/HealthChecks.System.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.System/HealthChecks.System.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ui_cd.yml
+++ b/.github/workflows/healthchecks_ui_cd.yml
@@ -10,27 +10,6 @@ jobs:
     env:
       BUILD_CONFIG: Release
     runs-on: ubuntu-latest
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server
-        ports:
-          - 5433:1433
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Password12!
-      npgsql:
-        image: postgres
-        ports:
-          - 8010:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: Password12!
-      mysql:
-        image: mysql
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -74,26 +53,24 @@ jobs:
       run: dotnet build --no-restore ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj
     - name: Build UI.K8s.Operator
       run: dotnet build --no-restore ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj --verbosity normal
-    - name: dotnet pack UI
-      run: dotnet pack ./src/HealthChecks.UI/HealthChecks.UI.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.Client
-      run: dotnet pack ./src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.Core
-      run: dotnet pack ./src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.InMemory.Storage
-      run: dotnet pack ./src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.MySql.Storage
-      run: dotnet pack ./src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.PostgreSQL.Storage
-      run: dotnet pack ./src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.SQLite.Storage
-      run: dotnet pack ./src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.SqlServer.Storage
-      run: dotnet pack ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.K8s.Operator
-      run: dotnet pack ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI
+      run: dotnet pack --no-restore ./src/HealthChecks.UI/HealthChecks.UI.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.Client
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.Core
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.InMemory.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.MySql.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.PostgreSQL.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.SQLite.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.SqlServer.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.K8s.Operator
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_ui_cd_preview.yml
+++ b/.github/workflows/healthchecks_ui_cd_preview.yml
@@ -11,27 +11,6 @@ jobs:
       BUILD_CONFIG: Release
       VERSION_SUFFIX: -rc2.${{ github.run_number }}
     runs-on: ubuntu-latest
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server
-        ports:
-          - 5433:1433
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Password12!
-      npgsql:
-        image: postgres
-        ports:
-          - 8010:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: Password12!
-      mysql:
-        image: mysql
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: Password12!
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -75,26 +54,24 @@ jobs:
       run: dotnet build --no-restore ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj
     #- name: Build UI.K8s.Operator
     #  run: dotnet build --no-restore ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
-    #- name: Test
-    #  run: dotnet test ./test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj --verbosity normal
-    - name: dotnet pack UI
-      run: dotnet pack ./src/HealthChecks.UI/HealthChecks.UI.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.Client
-      run: dotnet pack ./src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.Core
-      run: dotnet pack ./src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.InMemory.Storage
-      run: dotnet pack ./src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.MySql.Storage
-      run: dotnet pack ./src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.PostgreSQL.Storage
-      run: dotnet pack ./src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.SQLite.Storage
-      run: dotnet pack ./src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    - name: dotnet pack UI.SqlServer.Storage
-      run: dotnet pack ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
-    #- name: dotnet pack UI.K8s.Operator
-    #  run: dotnet pack ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI
+      run: dotnet pack --no-restore ./src/HealthChecks.UI/HealthChecks.UI.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.Client
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.Core
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.InMemory.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.MySql.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.PostgreSQL.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.SQLite.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack UI.SqlServer.Storage
+      run: dotnet pack --no-restore ./src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    #- name: Pack UI.K8s.Operator
+    #  run: dotnet pack --no-restore ./src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_uris_cd.yml
+++ b/.github/workflows/healthchecks_uris_cd.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Uris.Tests/HealthChecks.Uris.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Uris/HealthChecks.Uris.csproj --version-suffix $VERSION_SUFFIX  -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj --version-suffix $VERSION_SUFFIX  -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:

--- a/.github/workflows/healthchecks_uris_cd_preview.yml
+++ b/.github/workflows/healthchecks_uris_cd_preview.yml
@@ -21,10 +21,8 @@ jobs:
       run: dotnet restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj
     - name: Build
       run: dotnet build --no-restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj
-    - name: Test
-      run: dotnet test ./test/HealthChecks.Uris.Tests/HealthChecks.Uris.Tests.csproj --verbosity normal
-    - name: dotnet pack
-      run: dotnet pack ./src/HealthChecks.Uris/HealthChecks.Uris.csproj --version-suffix $VERSION_SUFFIX  -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
+    - name: Pack
+      run: dotnet pack --no-restore ./src/HealthChecks.Uris/HealthChecks.Uris.csproj --version-suffix $VERSION_SUFFIX  -c $BUILD_CONFIG --include-source --include-symbols -o ./artifacts
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
       env:


### PR DESCRIPTION
fixes #1022

Also adds `--no-restore` to `dotnet pack`.