### PR TITLE
Added elasticsearch api key authentication

### DIFF
--- a/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchHealthCheck.cs
@@ -36,6 +36,10 @@ namespace HealthChecks.Elasticsearch
                     {
                         settings = settings.ClientCertificate(_options.Certificate);
                     }
+                    else if (_options.AuthenticateWithApiKey)
+                    {
+                        settings = settings.ApiKeyAuthentication(_options.ApiKeyAuthenticationCredentials);
+                    }
 
                     if (_options.CertificateValidationCallback != null)
                     {

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -59,6 +59,7 @@ namespace HealthChecks.Elasticsearch
 
             UserName = string.Empty;
             Password = string.Empty;
+            Certificate = null;
             AuthenticateWithBasicCredentials = false;
             AuthenticateWithCertificate = false;
             AuthenticateWithApiKey = true;

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -59,7 +59,6 @@ namespace HealthChecks.Elasticsearch
 
             UserName = string.Empty;
             Password = string.Empty;
-            Certificate = null;
             AuthenticateWithBasicCredentials = false;
             AuthenticateWithCertificate = false;
             AuthenticateWithApiKey = true;

--- a/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
+++ b/src/HealthChecks.Elasticsearch/ElasticsearchOptions.cs
@@ -1,5 +1,6 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using Elasticsearch.Net;
 
 namespace HealthChecks.Elasticsearch
 {
@@ -16,9 +17,13 @@ namespace HealthChecks.Elasticsearch
 
         public X509Certificate? Certificate { get; private set; }
 
+        public ApiKeyAuthenticationCredentials? ApiKeyAuthenticationCredentials { get; set; }
+
         public bool AuthenticateWithBasicCredentials { get; private set; }
 
         public bool AuthenticateWithCertificate { get; private set; }
+
+        public bool AuthenticateWithApiKey { get; private set; }
 
         public Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool>? CertificateValidationCallback { get; private set; }
 
@@ -30,6 +35,7 @@ namespace HealthChecks.Elasticsearch
             Password = password ?? throw new ArgumentNullException(nameof(password));
 
             Certificate = null;
+            AuthenticateWithApiKey = false;
             AuthenticateWithCertificate = false;
             AuthenticateWithBasicCredentials = true;
             return this;
@@ -41,8 +47,23 @@ namespace HealthChecks.Elasticsearch
 
             UserName = string.Empty;
             Password = string.Empty;
+            AuthenticateWithApiKey = false;
             AuthenticateWithBasicCredentials = false;
             AuthenticateWithCertificate = true;
+            return this;
+        }
+
+        public ElasticsearchOptions UseApiKey(ApiKeyAuthenticationCredentials apiKey)
+        {
+            ApiKeyAuthenticationCredentials = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+
+            UserName = string.Empty;
+            Password = string.Empty;
+            Certificate = null;
+            AuthenticateWithBasicCredentials = false;
+            AuthenticateWithCertificate = false;
+            AuthenticateWithApiKey = true;
+
             return this;
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
This PR adds authentication by API Key to Elastic healthcheck.

**Which issue(s) this PR fixes**:
#1117 

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**: I did not created or updated any tests because there were not any tests for the other types of authorization for Elastic. I actually tried settings up some tests but I could not set up a docker container that had an initial API Key in Elastic Search for me to try, so I only tested manually. I also did not update the documentation and I have not provided a sample for the feature because I could not find documentation or sample of the other authentication methods

**Does this PR introduce a user-facing change?**:  I am not sure what you mean, but it does introduce another option for the user of the elastic Health Check library

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests \* 
- [x] Unit tests passing 
- [x] End-to-end tests passing
- [x] Extended the documentation \* 
- [x] Provided sample for the feature \* 