### PR TITLE
Support basic auth of the endpoint uri in GetHealthReportAsync

### DIFF
--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -102,10 +102,7 @@ namespace HealthChecks.UI.Core.HostedService
                     var userInfoArr = absoluteUri.UserInfo.Split(':');
                     if (userInfoArr.Length == 2 && !string.IsNullOrEmpty(userInfoArr[0]) && !string.IsNullOrEmpty(userInfoArr[1]))
                     {
-                        _httpClient.DefaultRequestHeaders.Clear();
-                        _httpClient.DefaultRequestHeaders.Authorization =
-                            new System.Net.Http.Headers.AuthenticationHeaderValue("Basic",
-                            Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes($"{userInfoArr[0]}:{userInfoArr[1]}")));
+                        _httpClient.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(userInfoArr[0], userInfoArr[1]);
                     }
                 }
 

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -103,6 +103,14 @@ namespace HealthChecks.UI.Core.HostedService
                     if (userInfoArr.Length == 2 && !string.IsNullOrEmpty(userInfoArr[0]) && !string.IsNullOrEmpty(userInfoArr[1]))
                     {
                         _httpClient.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(userInfoArr[0], userInfoArr[1]);
+                        //if (_httpClient.DefaultRequestHeaders.Authorization is null)
+                        //{
+                        //    _httpClient.DefaultRequestHeaders.Add("Authorization", $"Basic {Convert.ToBase64String(System.Text.ASCIIEncoding.UTF8.GetBytes($"{userInfoArr[0]}:{userInfoArr[1]}"))}");
+                        //}
+                    }
+                    else if (_httpClient.DefaultRequestHeaders.Authorization is not null)
+                    {
+                        _httpClient.DefaultRequestHeaders.Authorization = null;
                     }
                 }
 

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -102,11 +102,16 @@ namespace HealthChecks.UI.Core.HostedService
                     var userInfoArr = absoluteUri.UserInfo.Split(':');
                     if (userInfoArr.Length == 2 && !string.IsNullOrEmpty(userInfoArr[0]) && !string.IsNullOrEmpty(userInfoArr[1]))
                     {
-                        _httpClient.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(userInfoArr[0], userInfoArr[1]);
-                        //if (_httpClient.DefaultRequestHeaders.Authorization is null)
-                        //{
-                        //    _httpClient.DefaultRequestHeaders.Add("Authorization", $"Basic {Convert.ToBase64String(System.Text.ASCIIEncoding.UTF8.GetBytes($"{userInfoArr[0]}:{userInfoArr[1]}"))}");
-                        //}
+                        //_httpClient.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(userInfoArr[0], userInfoArr[1]);
+
+                        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, absoluteUri);
+                        requestMessage.Headers.Authorization = new BasicAuthenticationHeaderValue(userInfoArr[0], userInfoArr[1]);
+
+                        using var aResponse = await _httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead);
+                        var aReport = await aResponse.Content.ReadFromJsonAsync<UIHealthReport>(_options);
+                        if (aReport == null)
+                            throw new InvalidOperationException($"{nameof(HttpContentJsonExtensions.ReadFromJsonAsync)} returned null");
+                        return aReport;
                     }
                     else if (_httpClient.DefaultRequestHeaders.Authorization is not null)
                     {

--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -97,6 +97,18 @@ namespace HealthChecks.UI.Core.HostedService
             {
                 var absoluteUri = GetEndpointUri(configuration);
 
+                if (!string.IsNullOrEmpty(absoluteUri.UserInfo))
+                {
+                    var userInfoArr = absoluteUri.UserInfo.Split(':');
+                    if (userInfoArr.Length == 2 && !string.IsNullOrEmpty(userInfoArr[0]) && !string.IsNullOrEmpty(userInfoArr[1]))
+                    {
+                        _httpClient.DefaultRequestHeaders.Clear();
+                        _httpClient.DefaultRequestHeaders.Authorization =
+                            new System.Net.Http.Headers.AuthenticationHeaderValue("Basic",
+                            Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes($"{userInfoArr[0]}:{userInfoArr[1]}")));
+                    }
+                }
+
                 using var response = await _httpClient.GetAsync(absoluteUri, HttpCompletionOption.ResponseHeadersRead);
 
                 var report = await response.Content.ReadFromJsonAsync<UIHealthReport>(_options);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: Add basic authentication to the httpclient request headers, from the endpoint URI (UserInfo string), in GetHealthReportAsync. Allows the UI to get reports from endpoints configured to require basic authentication, by including the basic authentication credentials in the endpoint confiuration URI (appsettings.json)

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
