### PR TITLE
Add livenessName to notification callback functions

### DIFF
--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -49,13 +49,13 @@ setup
 .AddWebhookNotification("webhook1",
     uri: "status/200?code=ax3rt56s", payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
     restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
-    shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23
-    customMessageFunc: (report) =>
+    shouldNotifyFunc: (livenessName, report) => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23
+    customMessageFunc: (livenessName, report) =>
     {
         var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
         return $"{failing.Count()} healthchecks are failing";
     },
-    customDescriptionFunc: report =>
+    customDescriptionFunc: (livenessName, report) =>
     {
         var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
         return $"HealthChecks with names {string.Join("/", failing.Select(f => f.Key))} are failing";

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -31,12 +31,12 @@ namespace HealthChecks.UI.Branding
                     setup.AddWebhookNotification("webhook1", uri: "https://healthchecks2.requestcatcher.com/",
                             payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
                                 restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
-                                shouldNotifyFunc: report => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
-                                customMessageFunc: (report) =>
+                                shouldNotifyFunc: (livenessName, report) => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
+                                customMessageFunc: (livenessName, report) =>
                                {
                                    var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
                                    return $"{failing.Count()} healthchecks are failing";
-                               }, customDescriptionFunc: report =>
+                               }, customDescriptionFunc: (livenessName, report) =>
                                {
                                    var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
                                    return $"{string.Join(" - ", failing.Select(f => f.Key))} healthchecks are failing";

--- a/src/HealthChecks.UI/Configuration/Settings.cs
+++ b/src/HealthChecks.UI/Configuration/Settings.cs
@@ -30,7 +30,7 @@ namespace HealthChecks.UI.Configuration
             return this;
         }
 
-        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "", Func<UIHealthReport, bool>? shouldNotifyFunc = null, Func<UIHealthReport, string>? customMessageFunc = null, Func<UIHealthReport, string>? customDescriptionFunc = null)
+        public Settings AddWebhookNotification(string name, string uri, string payload, string restorePayload = "", Func<string, UIHealthReport, bool>? shouldNotifyFunc = null, Func<string, UIHealthReport, string>? customMessageFunc = null, Func<string, UIHealthReport, string>? customDescriptionFunc = null)
         {
             Webhooks.Add(new WebHookNotification
             {
@@ -135,8 +135,8 @@ namespace HealthChecks.UI.Configuration
         public string Uri { get; set; } = null!;
         public string Payload { get; set; } = null!;
         public string RestoredPayload { get; set; } = null!;
-        internal Func<UIHealthReport, bool>? ShouldNotifyFunc { get; set; }
-        internal Func<UIHealthReport, string>? CustomMessageFunc { get; set; }
-        internal Func<UIHealthReport, string>? CustomDescriptionFunc { get; set; }
+        internal Func<string, UIHealthReport, bool>? ShouldNotifyFunc { get; set; }
+        internal Func<string, UIHealthReport, string>? CustomMessageFunc { get; set; }
+        internal Func<string, UIHealthReport, string>? CustomDescriptionFunc { get; set; }
     }
 }

--- a/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/HealthChecks.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -57,7 +57,7 @@ namespace HealthChecks.UI.Core.Notifications
 
                 foreach (var webHook in _settings.Webhooks)
                 {
-                    bool shouldNotify = webHook.ShouldNotifyFunc?.Invoke(report) ?? true;
+                    bool shouldNotify = webHook.ShouldNotifyFunc?.Invoke(name, report) ?? true;
 
                     if (!shouldNotify)
                     {
@@ -67,8 +67,8 @@ namespace HealthChecks.UI.Core.Notifications
 
                     if (!isHealthy)
                     {
-                        failure = webHook.CustomMessageFunc?.Invoke(report) ?? GetFailedMessageFromContent(report);
-                        description = webHook.CustomDescriptionFunc?.Invoke(report) ?? GetFailedDescriptionsFromContent(report);
+                        failure = webHook.CustomMessageFunc?.Invoke(name, report) ?? GetFailedMessageFromContent(report);
+                        description = webHook.CustomDescriptionFunc?.Invoke(name, report) ?? GetFailedDescriptionsFromContent(report);
                     }
 
                     var payload = isHealthy ? webHook.RestoredPayload : webHook.Payload;


### PR DESCRIPTION
**What this PR does / why we need it**: Adds the liveness name to the custom notification functions to increase customizability of notifications.

**Which issue(s) this PR fixes**:  This is a partial solution to #1114. I think that the functions can be further improved but this is a first step that will increase the ability to customise the custom notifications.

Please reference the issue this PR will close: #1114 

**Does this PR introduce a user-facing change?**: No
