### PR TITLE
Documentation: Correction on initial demo namespace

### DIFF
--- a/doc/k8s-operator.md
+++ b/doc/k8s-operator.md
@@ -77,7 +77,7 @@ Note: The UI resources created by the operator (deployment, service, configmap, 
 
 Let's start by creating a demo namespace:
 
-`kubectl create ns lande`
+`kubectl create ns demo`
 
 And then, create a healthchecks-ui.yaml file with the following contents:
 


### PR DESCRIPTION
The remainder of the demo examples use `demo` namespace, but the first command was creating some namespace called `lande`

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: It simply corrects the documentation.

**Which issue(s) this PR fixes**: The first command on k8s sample was creating a different namespace

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:  NO

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
