### PR TITLE
Set LogHandler when ILogger<KafkaHealthCheck> is provided

### DIFF
--- a/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Kafka/DependencyInjection/KafkaHealthCheckBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using HealthChecks.Kafka;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -24,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <param name="logger">An optional <see cref="ILogger"/> used to set the LogHandler for the producer .</param>
         /// <returns>The specified <paramref name="builder"/>.</returns>
         public static IHealthChecksBuilder AddKafka(
             this IHealthChecksBuilder builder,
@@ -32,11 +34,12 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
-            TimeSpan? timeout = default)
+            TimeSpan? timeout = default,
+            ILogger? logger = default)
         {
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                new KafkaHealthCheck(config, topic),
+                new KafkaHealthCheck(config, topic, logger),
                 failureStatus,
                 tags,
                 timeout));
@@ -55,6 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <param name="logger">An optional <see cref="ILogger"/> used to set the LogHandler for the producer .</param>
         /// <returns>The specified <paramref name="builder"/>.</returns>
         public static IHealthChecksBuilder AddKafka(
             this IHealthChecksBuilder builder,
@@ -63,14 +67,15 @@ namespace Microsoft.Extensions.DependencyInjection
             string? name = default,
             HealthStatus? failureStatus = default,
             IEnumerable<string>? tags = default,
-            TimeSpan? timeout = default)
+            TimeSpan? timeout = default,
+            ILogger? logger = default)
         {
             var config = new ProducerConfig();
             setup?.Invoke(config);
 
             return builder.Add(new HealthCheckRegistration(
                 name ?? NAME,
-                new KafkaHealthCheck(config, topic),
+                new KafkaHealthCheck(config, topic, logger),
                 failureStatus,
                 tags,
                 timeout));

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -24,7 +24,14 @@ namespace HealthChecks.Kafka
             {
                 if (_producer == null)
                 {
-                    _producer = new ProducerBuilder<string, string>(_configuration).Build();
+                    var producerBuilder = new ProducerBuilder<string, string>(_configuration);
+                    if (_logger != null)
+                    {
+                        _logger.LogInformation("Setting up KafkaLogger for the producer");
+                        var kafkaLogger = new KafkaLogger(_logger);
+                        producerBuilder.SetLogHandler(kafkaLogger.Handler);
+                    }
+                    _producer = producerBuilder.Build();
                 }
 
                 var message = new Message<string, string>

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -9,9 +9,9 @@ namespace HealthChecks.Kafka
         private readonly ProducerConfig _configuration;
         private readonly string _topic;
         private readonly IProducer<string, string> _producer;
-        private readonly ILogger? _logger;
+        private readonly ILogger<KafkaHealthCheck>? _logger;
 
-        public KafkaHealthCheck(ProducerConfig configuration, string? topic, ILogger? logger = null)
+        public KafkaHealthCheck(ProducerConfig configuration, string? topic, ILogger<KafkaHealthCheck>? logger = null)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _topic = topic ?? "healthchecks-topic";

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -24,14 +24,7 @@ namespace HealthChecks.Kafka
             {
                 if (_producer == null)
                 {
-                    var producerBuilder = new ProducerBuilder<string, string>(_configuration);
-                    if (_logger != null)
-                    {
-                        _logger.LogInformation("Setting up KafkaLogger for the producer");
-                        var kafkaLogger = new KafkaLogger(_logger);
-                        producerBuilder.SetLogHandler(kafkaLogger.Handler);
-                    }
-                    _producer = producerBuilder.Build();
+                    _producer = ProducerBuilderFactory().Build();
                 }
 
                 var message = new Message<string, string>
@@ -57,6 +50,18 @@ namespace HealthChecks.Kafka
                 _logger?.LogError("Exception occurred message: {message}", ex.Message);
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
+        }
+
+        private ProducerBuilder<string, string> ProducerBuilderFactory()
+        {
+            var producerBuilder = new ProducerBuilder<string, string>(_configuration);
+            if (_logger != null)
+            {
+                _logger.LogInformation("Setting up KafkaLogger for the producer");
+                var kafkaLogger = new KafkaLogger(_logger);
+                producerBuilder.SetLogHandler(kafkaLogger.Handler);
+            }
+            return producerBuilder;
         }
     }
 }

--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -8,7 +8,7 @@ namespace HealthChecks.Kafka
     {
         private readonly ProducerConfig _configuration;
         private readonly string _topic;
-        private IProducer<string, string>? _producer;
+        private readonly IProducer<string, string> _producer;
         private readonly ILogger? _logger;
 
         public KafkaHealthCheck(ProducerConfig configuration, string? topic, ILogger? logger = null)
@@ -16,16 +16,13 @@ namespace HealthChecks.Kafka
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _topic = topic ?? "healthchecks-topic";
             _logger = logger;
+            _producer = ProducerBuilderFactory().Build();
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                if (_producer == null)
-                {
-                    _producer = ProducerBuilderFactory().Build();
-                }
 
                 var message = new Message<string, string>
                 {

--- a/src/HealthChecks.Kafka/KafkaLogger.cs
+++ b/src/HealthChecks.Kafka/KafkaLogger.cs
@@ -1,0 +1,23 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace HealthChecks.Kafka
+{
+    public class KafkaLogger
+    {
+        private readonly ILogger _logger;
+
+        public KafkaLogger(ILogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Handler(IClient _, LogMessage logMessage)
+        {
+            var level = (LogLevel)logMessage.LevelAs(LogLevelType.MicrosoftExtensionsLogging);
+
+            _logger.Log(level, "Name={Name},Facility={Facility},Message={Message}",
+                logMessage.Name, logMessage.Facility, logMessage.Message);
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR's add the possibility to use the ILogger reference to set:
- Set Kafka LogHandler
- Adding Info and Error Log messages for the inner steps

**Which issue(s) this PR fixes**:
close: #1265 

**Special notes for your reviewer**:

I'm using the `HealthCheckRegistration` that uses the ServiceProvider to manage the DI, because of that I did create a `KafkaHealthCheckFactory` to gets a reference for the `ILogger<KafkaHealthCheck>`

I also added an optional parameter on `KafkaHealthCheck` constructor, to receive the logger.

Applied a small refactor at the constructor to create a reference of a _producer `IProducer<string, string>` instead of using the lazy loading, as no connection is made until execute the ProduceAsync.


Usage sample:

``` csharp
var lf = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
var logger = lf.CreateLogger<KafkaHealthCheck>();
services.AddSingleton(logger);
services.AddHealthChecks()
AddKafka(configkafka, name: "kafka", topic: "operations.health-check", timeout: TimeSpan.FromSeconds(5));
``` 

**Does this PR introduce a user-facing change?**:
It does change the constructor, but it is not a `breaking change`.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [x] Provided sample for the feature
