### PR TITLE
Use compatible version of npm

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Dockerfile
+++ b/build/docker-images/HealthChecks.UI.Image/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-lin
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 FROM sdk-with-node AS updated-npm
-RUN npm i -g npm
+RUN npm i -g npm@5
 
 FROM updated-npm AS build
 WORKDIR /src


### PR DESCRIPTION
The Dockerfile always installs the latest node version, failing the build using the specified Node 8 version since current versions of npm do not work with Node 8.

This changes to a npm 5.* version since these version were shipped with Node 8

**Special notes for your reviewer**:

Can a 6.* version be published to dockerhub?

**Does this PR introduce a user-facing change?**:

No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature

Validated that the built container is working using a local docker-compose setup that also worked with the 5.0.0 tag.