### PR TITLE
Fix seq trailing slash, respect cancellation token, make SeqOptions.ApiKey nullable

### DIFF
--- a/src/HealthChecks.Publisher.Seq/SeqOptions.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public string Endpoint { get; set; } = null!;
 
-        public string ApiKey { get; set; } = null!;
+        public string? ApiKey { get; set; }
 
         public SeqInputLevel DefaultInputLevel { get; set; }
     }

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -9,7 +9,6 @@ namespace HealthChecks.Publisher.Seq
 {
     public class SeqPublisher : IHealthCheckPublisher
     {
-
         private readonly SeqOptions _options;
         private readonly Func<HttpClient> _httpClientFactory;
 
@@ -33,6 +32,8 @@ namespace HealthChecks.Publisher.Seq
                     break;
             }
 
+            string? assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
+
             var events = new RawEvents
             {
                 Events = new RawEvent[]
@@ -40,12 +41,12 @@ namespace HealthChecks.Publisher.Seq
                     new RawEvent
                     {
                         Timestamp = DateTimeOffset.UtcNow,
-                        MessageTemplate = $"[{Assembly.GetEntryAssembly()?.GetName().Name} - HealthCheck Result]",
+                        MessageTemplate = $"[{assemblyName} - HealthCheck Result]",
                         Level = level.ToString(),
                         Properties = new Dictionary<string, object?>
                         {
                             { nameof(Environment.MachineName), Environment.MachineName },
-                            { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name },
+                            { nameof(Assembly), assemblyName },
                             { "Status", report.Status.ToString() },
                             { "TimeElapsed", report.TotalDuration.TotalMilliseconds },
                             { "RawReport" , JsonConvert.SerializeObject(report)}
@@ -73,7 +74,7 @@ namespace HealthChecks.Publisher.Seq
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Exception is throwed publishing metrics to Seq with message: {ex.Message}");
+                Trace.WriteLine($"Exception thrown publishing metrics to Seq with message: {ex.Message}");
             }
         }
 

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -60,7 +60,7 @@ namespace HealthChecks.Publisher.Seq
             await PushMetricsAsync(JsonConvert.SerializeObject(events), cancellationToken);
         }
 
-        private async Task PushMetricsAsync(string json, CancellationToken token)
+        private async Task PushMetricsAsync(string json, CancellationToken cancellationToken)
         {
             try
             {
@@ -71,7 +71,11 @@ namespace HealthChecks.Publisher.Seq
                     Content = new StringContent(json, Encoding.UTF8, "application/json")
                 };
 
-                using var response = await httpClient.SendAsync(pushMessage, HttpCompletionOption.ResponseHeadersRead, token);
+                using var response = await httpClient.SendAsync(
+                    pushMessage,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+
                 response.EnsureSuccessStatusCode();
             }
             catch (Exception ex)

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -86,6 +86,9 @@ namespace HealthChecks.Publisher.Seq
 
         private static Uri BuildCheckUri(SeqOptions options)
         {
+            if (string.IsNullOrEmpty(options.Endpoint))
+                throw new ArgumentNullException(nameof(options.Endpoint));
+
             var uriBuilder = new UriBuilder(options.Endpoint)
             {
                 Path = "/api/events/raw",

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -95,7 +95,7 @@ namespace HealthChecks.Publisher.Seq
             };
 
             // Add api key if supplied
-            if (!string.IsNullOrWhiteSpace(options.ApiKey))
+            if (!string.IsNullOrEmpty(options.ApiKey))
                 uriBuilder.Query = "?apiKey=" + options.ApiKey;
 
             return uriBuilder.Uri;

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -62,7 +62,7 @@ namespace HealthChecks.Publisher.Seq
         {
             try
             {
-                var httpClient = _httpClientFactory();
+                using var httpClient = _httpClientFactory();
 
                 using var pushMessage = new HttpRequestMessage(HttpMethod.Post, $"{_options.Endpoint}/api/events/raw?apiKey={_options.ApiKey}")
                 {

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -92,8 +92,11 @@ namespace HealthChecks.Publisher.Seq
             var uriBuilder = new UriBuilder(options.Endpoint)
             {
                 Path = "/api/events/raw",
-                Query = "?apiKey=" + options.ApiKey
             };
+
+            // Add api key if supplied
+            if (!string.IsNullOrWhiteSpace(options.ApiKey))
+                uriBuilder.Query = "?apiKey=" + options.ApiKey;
 
             return uriBuilder.Uri;
         }

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -55,10 +55,10 @@ namespace HealthChecks.Publisher.Seq
                 }
             };
 
-            await PushMetricsAsync(JsonConvert.SerializeObject(events));
+            await PushMetricsAsync(JsonConvert.SerializeObject(events), cancellationToken);
         }
 
-        private async Task PushMetricsAsync(string json)
+        private async Task PushMetricsAsync(string json, CancellationToken token)
         {
             try
             {
@@ -69,7 +69,7 @@ namespace HealthChecks.Publisher.Seq
                     Content = new StringContent(json, Encoding.UTF8, "application/json")
                 };
 
-                using var response = await httpClient.SendAsync(pushMessage, HttpCompletionOption.ResponseHeadersRead);
+                using var response = await httpClient.SendAsync(pushMessage, HttpCompletionOption.ResponseHeadersRead, token);
                 response.EnsureSuccessStatusCode();
             }
             catch (Exception ex)

--- a/test/HealthChecks.Publisher.Seq.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/DependencyInjection/RegistrationTests.cs
@@ -9,12 +9,11 @@ namespace HealthChecks.Publisher.Datadog.Tests.DependencyInjection
             services
                 .AddHealthChecks()
                 .AddSeqPublisher(setup =>
-                    new SeqOptions()
-                    {
-                        ApiKey = "apiKey",
-                        DefaultInputLevel = Seq.SeqInputLevel.Information,
-                        Endpoint = "endpoint"
-                    });
+                {
+                    setup.Endpoint = "endpoint";
+                    setup.DefaultInputLevel = Seq.SeqInputLevel.Information;
+                    setup.ApiKey = "apiKey";
+                });
 
             using var serviceProvider = services.BuildServiceProvider();
             var publisher = serviceProvider.GetService<IHealthCheckPublisher>();

--- a/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
@@ -26,7 +26,22 @@ public class seq_publisher_should
         await publisher.PublishAsync(testReport, CancellationToken.None);
 
         handler.Request.ShouldNotBeNull();
-        handler.Request.RequestUri.ShouldBeEquivalentTo(expectedUri);
+        handler.Request.RequestUri.ShouldBe(expectedUri);
+    }
+
+    [Fact]
+    public void throw_exception_when_endpoint_is_null()
+    {
+        var options = new SeqOptions
+        {
+            ApiKey = "test-key",
+            Endpoint = null!
+        };
+
+        HttpClient HttpClientFactory() => new();
+
+        var ex = Should.Throw<ArgumentNullException>(() => new SeqPublisher(HttpClientFactory, options));
+        ex.ParamName.ShouldBe(nameof(SeqOptions.Endpoint));
     }
 
     private class MockClientHandler : HttpClientHandler

--- a/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
@@ -25,8 +25,8 @@ public class seq_publisher_should
         var publisher = new SeqPublisher(HttpClientFactory, options);
         await publisher.PublishAsync(testReport, CancellationToken.None);
 
-        Assert.NotNull(handler.Request);
-        Assert.Equal(expectedUri, handler.Request!.RequestUri);
+        handler.Request.ShouldNotBeNull();
+        handler.Request.RequestUri.ShouldBeEquivalentTo(expectedUri);
     }
 
     private class MockClientHandler : HttpClientHandler

--- a/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+
+namespace HealthChecks.Publisher.Seq.Tests.Functional;
+
+public class seq_publisher_should
+{
+    [Fact]
+    public async Task handle_trailing_slash_in_endpoint()
+    {
+        var options = new SeqOptions
+        {
+            ApiKey = "test-key",
+            Endpoint = "http://localhost:5341/"
+        };
+
+        var expectedUri = new Uri("http://localhost:5341/api/events/raw?apiKey=test-key");
+
+        // Setup mocks
+        using var handler = new MockClientHandler();
+        HttpClient HttpClientFactory() => new(handler);
+
+        var testReport = new HealthReport(new Dictionary<string, HealthReportEntry>(), TimeSpan.Zero);
+
+        // Create publisher and publish
+        var publisher = new SeqPublisher(HttpClientFactory, options);
+        await publisher.PublishAsync(testReport, CancellationToken.None);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(expectedUri, handler.Request!.RequestUri);
+    }
+
+    private class MockClientHandler : HttpClientHandler
+    {
+        public HttpRequestMessage? Request;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 
 namespace HealthChecks.Publisher.Seq.Tests.Functional;
 

--- a/test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.approved.txt
+++ b/test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.approved.txt
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public class SeqOptions
     {
         public SeqOptions() { }
-        public string ApiKey { get; set; }
+        public string? ApiKey { get; set; }
         public HealthChecks.Publisher.Seq.SeqInputLevel DefaultInputLevel { get; set; }
         public string Endpoint { get; set; }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
- Fixes a bug where the Seq publisher does not handle trailing slashes
- Fixed Seq publisher not respecting the cancellation token
- Throw exception on null/empty endpoint in `SeqOptions`
- `SeqOptions.ApiKey` is now nullable to handle cases where no api key is required
- Fixed `seq_publisher_registration_should.add_healthcheck_when_properly_configured` options configured incorrectly

**Which issue(s) this PR fixes**:
#1171

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
