### PR TITLE
Add extension for CosmosDb/TableService that accepts TokenCredential for authentication

### DIFF
--- a/src/HealthChecks.CosmosDb/DependencyInjection/CosmosDbHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.CosmosDb/DependencyInjection/CosmosDbHealthCheckBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Azure.Core;
 using Azure.Data.Tables;
 using HealthChecks.CosmosDb;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -44,6 +45,39 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Add a health check for Azure CosmosDb database.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="accountEndpoint">Uri to the CosmosDb account</param>
+        /// <param name="tokenCredential">An instance of <see cref="TokenCredential"/> to be used for authentication</param>
+        /// <param name="database">Database to check for existence.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'cosmosdb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddCosmosDb(
+            this IHealthChecksBuilder builder,
+            string accountEndpoint,
+            TokenCredential tokenCredential,
+            string? database = default,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+               name ?? COSMOS_NAME,
+               sp => new CosmosDbHealthCheck(accountEndpoint, tokenCredential, database, Enumerable.Empty<string>()),
+               failureStatus,
+               tags,
+               timeout));
+        }
+
+        /// <summary>
         /// Add a health check for Azure CosmosDb database and specified collections.
         /// </summary>
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
@@ -71,6 +105,41 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                name ?? COSMOS_NAME,
                sp => new CosmosDbHealthCheck(connectionString, database, collections),
+               failureStatus,
+               tags,
+               timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for Azure CosmosDb database and specified collections using Managed identity.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="accountEndpoint">Uri to the CosmosDb account</param>
+        /// <param name="tokenCredential">An instance of <see cref="TokenCredential"/> to be used for authentication</param>
+        /// <param name="database">Database to check for existence.</param>
+        /// <param name="collections">Cosmos DB collections to check for existence.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'cosmosdb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddCosmosDbCollection(
+            this IHealthChecksBuilder builder,
+            string accountEndpoint,
+            TokenCredential tokenCredential,
+            string? database = default,
+            IEnumerable<string>? collections = default,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+               name ?? COSMOS_NAME,
+               sp => new CosmosDbHealthCheck(accountEndpoint, tokenCredential, database, collections),
                failureStatus,
                tags,
                timeout));
@@ -135,6 +204,39 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.Add(new HealthCheckRegistration(
                name ?? TABLE_NAME,
                sp => new TableServiceHealthCheck(endpoint, credentials, tableName),
+               failureStatus,
+               tags,
+               timeout));
+        }
+
+        /// <summary>
+        /// Add a health check for Azure CosmosDb/ Azure Storage table.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="endpoint">The CosmosDB Table or Azure Storage Table uri endopoint.</param>
+        /// <param name="tokenCredential">An instance of <see cref="TokenCredential"/> to be used for authentication</param>
+        /// <param name="tableName">Table name to check for existence.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'cosmosdb' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddAzureTable(
+            this IHealthChecksBuilder builder,
+            Uri endpoint,
+            TokenCredential tokenCredential,
+            string tableName,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+               name ?? TABLE_NAME,
+               sp => new TableServiceHealthCheck(endpoint, tokenCredential, tableName),
                failureStatus,
                tags,
                timeout));

--- a/src/HealthChecks.CosmosDb/TableServiceHealthCheck.cs
+++ b/src/HealthChecks.CosmosDb/TableServiceHealthCheck.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Azure;
+using Azure.Core;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -14,6 +15,8 @@ namespace HealthChecks.CosmosDb
 
         private readonly Uri? _endpoint;
         private readonly TableSharedKeyCredential? _credentials;
+        private readonly TokenCredential? _tokenCredential;
+
 
         public TableServiceHealthCheck(string connectionString, string tableName)
         {
@@ -25,6 +28,13 @@ namespace HealthChecks.CosmosDb
         {
             _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
             _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+        }
+
+        public TableServiceHealthCheck(Uri endpoint, TokenCredential tokenCredential, string tableName)
+        {
+            _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            _tokenCredential = tokenCredential ?? throw new ArgumentNullException(nameof(tokenCredential));
             _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
         }
 
@@ -61,7 +71,9 @@ namespace HealthChecks.CosmosDb
         {
             return !string.IsNullOrEmpty(_connectionString)
                 ? new TableServiceClient(_connectionString)
-                : new TableServiceClient(_endpoint, _credentials);
+                : (_credentials != null
+                    ? new TableServiceClient(_endpoint, _credentials)
+                    : new TableServiceClient(_endpoint, _tokenCredential));
         }
     }
 }

--- a/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -58,7 +58,7 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddCosmosDb("cosmosdbaccounturi", new MockTokenCredential(), "dabasename");
+                .AddCosmosDb("cosmosdbaccounturi", new MockTokenCredential(), "databasename");
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();

--- a/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -155,7 +155,7 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddAzureTable(new Uri("mytableuri"), new TableSharedKeyCredential("mytableuri", "testKey"), "tableName");
+                .AddAzureTable(new Uri("http://localhost"), new TableSharedKeyCredential("mystorageaccount", "dGVzdEtleQ=="), "tableName");
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -171,7 +171,7 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddAzureTable(new Uri("mytableuri"), new MockTokenCredential(), "tableName");
+                .AddAzureTable(new Uri("http://localhost"), new MockTokenCredential(), "tableName");
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();

--- a/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -90,7 +90,7 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
-                .AddCosmosDbCollection("cosmosdbaccounturi", new MockTokenCredential(), "dabasename", collections: new[] { "first-collection", "second_collections" });
+                .AddCosmosDbCollection("cosmosdbaccounturi", new MockTokenCredential(), "databasename", collections: new[] { "first-collection", "second_collections" });
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();

--- a/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.CosmosDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,3 +1,6 @@
+using Azure.Core;
+using Azure.Data.Tables;
+
 namespace HealthChecks.CosmosDb.Tests.DependencyInjection
 {
     public class cosmosdb_registration_should
@@ -8,6 +11,22 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
             var services = new ServiceCollection();
             services.AddHealthChecks()
                 .AddCosmosDb("myconnectionstring");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("cosmosdb");
+            check.GetType().Should().Be(typeof(CosmosDbHealthCheck));
+        }
+        [Fact]
+        public void add_cosmosdb_health_check_when_properly_configured_using_token_credential()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddCosmosDb("cosmosdbaccounturi", new MockTokenCredential());
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -35,11 +54,43 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
             check.GetType().Should().Be(typeof(CosmosDbHealthCheck));
         }
         [Fact]
+        public void add_cosmosdb_health_check_when_properly_configured_using_token_credential_with_database()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddCosmosDb("cosmosdbaccounturi", new MockTokenCredential(), "dabasename");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("cosmosdb");
+            check.GetType().Should().Be(typeof(CosmosDbHealthCheck));
+        }
+        [Fact]
         public void add_cosmosdb_health_check_when_properly_configured_with_database_and_collections()
         {
             var services = new ServiceCollection();
             services.AddHealthChecks()
                 .AddCosmosDbCollection("myconnectionstring", "dabasename", collections: new[] { "first-collection", "second_collections" });
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("cosmosdb");
+            check.GetType().Should().Be(typeof(CosmosDbHealthCheck));
+        }
+        [Fact]
+        public void add_cosmosdb_health_check_when_properly_configured_using_token_credential_with_database_and_collections()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddCosmosDbCollection("cosmosdbaccounturi", new MockTokenCredential(), "dabasename", collections: new[] { "first-collection", "second_collections" });
 
             using var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -100,6 +151,38 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
             check.GetType().Should().Be(typeof(TableServiceHealthCheck));
         }
         [Fact]
+        public void add_azuretable_health_check_when_properly_configured_using_table_shared_key_credential()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureTable(new Uri("mytableuri"), new TableSharedKeyCredential("mytableuri", "testKey"), "tableName");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretable");
+            check.GetType().Should().Be(typeof(TableServiceHealthCheck));
+        }
+        [Fact]
+        public void add_azuretable_health_check_when_properly_configured_using_token_credential()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddAzureTable(new Uri("mytableuri"), new MockTokenCredential(), "tableName");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("azuretable");
+            check.GetType().Should().Be(typeof(TableServiceHealthCheck));
+        }
+        [Fact]
         public void add_azuretable_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();
@@ -114,6 +197,19 @@ namespace HealthChecks.CosmosDb.Tests.DependencyInjection
 
             registration.Name.Should().Be("my-azuretable-group");
             check.GetType().Should().Be(typeof(TableServiceHealthCheck));
+        }
+    }
+
+    public class MockTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/HealthChecks.CosmosDb.Tests/HealthChecks.CosmosDb.approved.txt
+++ b/test/HealthChecks.CosmosDb.Tests/HealthChecks.CosmosDb.approved.txt
@@ -4,12 +4,15 @@ namespace HealthChecks.CosmosDb
     {
         public CosmosDbHealthCheck(string connectionString) { }
         public CosmosDbHealthCheck(string connectionString, string database) { }
+        public CosmosDbHealthCheck(string accountEndpoint, Azure.Core.TokenCredential tokenCredential, string database) { }
         public CosmosDbHealthCheck(string connectionString, string? database, System.Collections.Generic.IEnumerable<string>? containers) { }
+        public CosmosDbHealthCheck(string accountEndpoint, Azure.Core.TokenCredential tokenCredential, string? database, System.Collections.Generic.IEnumerable<string>? containers) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class TableServiceHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
         public TableServiceHealthCheck(string connectionString, string tableName) { }
+        public TableServiceHealthCheck(System.Uri endpoint, Azure.Core.TokenCredential tokenCredential, string tableName) { }
         public TableServiceHealthCheck(System.Uri endpoint, Azure.Data.Tables.TableSharedKeyCredential credentials, string tableName) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
@@ -19,8 +22,11 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class CosmosDbHealthCheckBuilderExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddAzureTable(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string tableName, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddAzureTable(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Uri endpoint, Azure.Core.TokenCredential tokenCredential, string tableName, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddAzureTable(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Uri endpoint, Azure.Data.Tables.TableSharedKeyCredential credentials, string tableName, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddCosmosDb(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string? database = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddCosmosDb(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string accountEndpoint, Azure.Core.TokenCredential tokenCredential, string? database = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddCosmosDbCollection(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string? database = null, System.Collections.Generic.IEnumerable<string>? collections = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddCosmosDbCollection(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string accountEndpoint, Azure.Core.TokenCredential tokenCredential, string? database = null, System.Collections.Generic.IEnumerable<string>? collections = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Adds a new builder extension for registering CosmosDb/TableService health check, that accepts a `TokenCredential` for authentication using managed identities.

**Which issue(s) this PR fixes**:
Currently we have to pass a connection string to the cosmos account, which includes the authorization key. This is not best practice in Azure, and managed identity use is recommended.

Please reference the issue this PR will close: #1298, #1134 
