### PR TITLE
Health Check for AzureBlobStorage & AzureQueueStorage calls GetProperties twice

### DIFF
--- a/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureBlobStorageHealthCheck.cs
@@ -49,8 +49,6 @@ namespace HealthChecks.AzureStorage
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: $"Container '{_containerName}' not exists");
                     }
-
-                    await containerClient.GetPropertiesAsync(cancellationToken: cancellationToken);
                 }
 
                 return HealthCheckResult.Healthy();

--- a/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
@@ -43,8 +43,6 @@ namespace HealthChecks.AzureStorage
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: $"Queue '{_queueName}' not exists");
                     }
-
-                    await queueClient.GetPropertiesAsync(cancellationToken);
                 }
 
                 return HealthCheckResult.Healthy();


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the redundant call to `GetPropertiesAsync` within `AzureQueueStorageHealthCheck` and `AzureBlobStorageHealthCheck`. It is called internally by the Azure SDK during the `ExistsAsync` check.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #1322 

**Special notes for your reviewer**:
I have attached a before and after trace captured from App Insights.

![image](https://user-images.githubusercontent.com/33640950/179805533-def7714e-45e6-474d-886f-aaa8b8d7e44f.png)

![image](https://user-images.githubusercontent.com/33640950/179805997-1b16819a-e09b-4526-bdbd-bab22268c60b.png)

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [X] Extended the documentation
- [X] Provided sample for the feature
