### PR TITLE
Reduce the transient creation of the event hub producer

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,7 +13,7 @@
     <HealthCheckAWSSqs>6.0.0</HealthCheckAWSSqs>
     <HealthCheckAWSSystemsManager>6.0.0</HealthCheckAWSSystemsManager>
     <HealthCheckAzureDigitalTwin>6.0.0</HealthCheckAzureDigitalTwin>
-    <HealthCheckAzureServiceBus>6.0.3</HealthCheckAzureServiceBus>
+    <HealthCheckAzureServiceBus>6.0.4</HealthCheckAzureServiceBus>
     <HealthCheckAzureStorage>6.0.4</HealthCheckAzureStorage>
     <HealthCheckCloudFirestore>6.0.2</HealthCheckCloudFirestore>
     <HealthCheckConsul>6.0.2</HealthCheckConsul>

--- a/src/HealthChecks.AzureServiceBus/AzureEventHubHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureEventHubHealthCheck.cs
@@ -25,7 +25,11 @@ namespace HealthChecks.AzureServiceBus
             }
 
             _eventHubConnectionString = connectionString.Contains(ENTITY_PATH_SEGMENT) ? connectionString : $"{connectionString};{ENTITY_PATH_SEGMENT}{eventHubName}";
-            _eventHubConnections.TryAdd(_eventHubConnectionString, new EventHubProducerClient(_eventHubConnectionString));
+
+            if (!_eventHubConnections.ContainsKey(_eventHubConnectionString))
+            {
+                _eventHubConnections.TryAdd(_eventHubConnectionString, new EventHubProducerClient(_eventHubConnectionString));
+            }
         }
 
         public AzureEventHubHealthCheck(EventHubConnection connection)
@@ -36,7 +40,11 @@ namespace HealthChecks.AzureServiceBus
             }
 
             _eventHubConnectionString = $"{connection.FullyQualifiedNamespace};{ENTITY_PATH_SEGMENT}{connection.EventHubName}";
-            _eventHubConnections.TryAdd(_eventHubConnectionString, new EventHubProducerClient(connection));
+
+            if (!_eventHubConnections.ContainsKey(_eventHubConnectionString))
+            {
+                _eventHubConnections.TryAdd(_eventHubConnectionString, new EventHubProducerClient(connection));
+            }
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)


### PR DESCRIPTION

** Fix leak on producer creation ** 

After some investigations, I notice that the event hub health check can leak some memory ( consistently ) due to creation of the event hub producer clients, after check the code these are transient but these also create unamanaged resources and not disposes resources produce the leak...

This bug is related with the issue https://github.com/Azure/azure-sdk-for-net/issues/30119#issuecomment-1195502902 
