### PR TITLE
Fix (Again) Erroneous Usage of Owner Azure Storage Permissions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,7 +15,7 @@
     <HealthCheckAWSSystemsManager>6.0.0</HealthCheckAWSSystemsManager>
     <HealthCheckAzureDigitalTwin>6.0.0</HealthCheckAzureDigitalTwin>
     <HealthCheckAzureServiceBus>6.0.4</HealthCheckAzureServiceBus>
-    <HealthCheckAzureStorage>6.1.0</HealthCheckAzureStorage>
+    <HealthCheckAzureStorage>6.1.1</HealthCheckAzureStorage>
     <HealthCheckCloudFirestore>6.0.2</HealthCheckCloudFirestore>
     <HealthCheckConsul>6.0.2</HealthCheckConsul>
     <HealthCheckCosmosDb>6.0.3</HealthCheckCosmosDb>

--- a/src/HealthChecks.AzureStorage/AzureFileShareHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureFileShareHealthCheck.cs
@@ -1,5 +1,4 @@
 using Azure.Storage.Files.Shares;
-using Azure.Storage.Queues;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.AzureStorage

--- a/src/HealthChecks.AzureStorage/AzureFileShareHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureFileShareHealthCheck.cs
@@ -1,4 +1,5 @@
 using Azure.Storage.Files.Shares;
+using Azure.Storage.Queues;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.AzureStorage
@@ -24,7 +25,14 @@ namespace HealthChecks.AzureStorage
         {
             try
             {
-                await _shareServiceClient.GetPropertiesAsync(cancellationToken);
+                // Note: ShareServiceClient does not support TokenCredentials as of writing, so only SAS tokens and
+                // Account keys may be used to authenticate. However, like the health checks for Azure Blob Storage and
+                // Azure Queue Storage, the AzureFileShareHealthCheck similarly enumerates the shares to probe service health.
+                await _shareServiceClient
+                    .GetSharesAsync(cancellationToken: cancellationToken)
+                    .AsPages(pageSizeHint: 1)
+                    .GetAsyncEnumerator(cancellationToken)
+                    .MoveNextAsync();
 
                 if (!string.IsNullOrEmpty(_options.ShareName))
                 {

--- a/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
@@ -1,5 +1,4 @@
 using Azure.Core;
-using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 

--- a/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
+++ b/src/HealthChecks.AzureStorage/AzureQueueStorageHealthCheck.cs
@@ -1,4 +1,5 @@
 using Azure.Core;
+using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -31,7 +32,14 @@ namespace HealthChecks.AzureStorage
         {
             try
             {
-                await _queueServiceClient.GetPropertiesAsync(cancellationToken);
+                // Note: QueueServiceClient.GetPropertiesAsync() cannot be used with only the role assignment
+                // "Storage Queue Data Contributor," so QueueServiceClient.GetQueuesAsync() is used instead to probe service health.
+                // However, QueueClient.GetPropertiesAsync() does have sufficient permissions.
+                await _queueServiceClient
+                    .GetQueuesAsync(cancellationToken: cancellationToken)
+                    .AsPages(pageSizeHint: 1)
+                    .GetAsyncEnumerator(cancellationToken)
+                    .MoveNextAsync();
 
                 if (!string.IsNullOrEmpty(_options.QueueName))
                 {


### PR DESCRIPTION
**What this PR does / why we need it**:  In the PR https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/1372, I mistakenly used `GetProperties()` on the various Azure Storage service clients to probe service health, but these require more permissions than typically is assigned to a user. Instead, each service now uses different service-specific data-plane APIs to probe health.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: Relates to https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/806

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
