### PR TITLE
Fix kafka producer usage

### DIFF
--- a/src/HealthChecks.Kafka/KafkaHealthCheck.cs
+++ b/src/HealthChecks.Kafka/KafkaHealthCheck.cs
@@ -7,7 +7,6 @@ namespace HealthChecks.Kafka
     {
         private readonly ProducerConfig _configuration;
         private readonly string _topic;
-        private IProducer<string, string>? _producer;
 
         public KafkaHealthCheck(ProducerConfig configuration, string? topic)
         {
@@ -19,19 +18,20 @@ namespace HealthChecks.Kafka
         {
             try
             {
-                _producer ??= new ProducerBuilder<string, string>(_configuration).Build();
-
-                var message = new Message<string, string>
+                using (var producer = new ProducerBuilder<string, string>(_configuration).Build())
                 {
-                    Key = "healthcheck-key",
-                    Value = $"Check Kafka healthy on {DateTime.UtcNow}"
-                };
+                    var message = new Message<string, string>
+                    {
+                        Key = "healthcheck-key",
+                        Value = $"Check Kafka healthy on {DateTime.UtcNow}"
+                    };
 
-                var result = await _producer.ProduceAsync(_topic, message, cancellationToken);
+                    var result = await producer.ProduceAsync(_topic, message, cancellationToken);
 
-                if (result.Status == PersistenceStatus.NotPersisted)
-                {
-                    return new HealthCheckResult(context.Registration.FailureStatus, description: $"Message is not persisted or a failure is raised on health check for kafka.");
+                    if (result.Status == PersistenceStatus.NotPersisted)
+                    {
+                        return new HealthCheckResult(context.Registration.FailureStatus, description: $"Message is not persisted or a failure is raised on health check for kafka.");
+                    }
                 }
 
                 return HealthCheckResult.Healthy();


### PR DESCRIPTION
This pull request is fixing the usage of the producer for the kafka health check. Without this "using" the producer will create threads that never get deleted anymore every time the health check is executed. I suppose this is due to the fact that according to a gcdump that i created there were 2 producer<String, String> instances (which are only used by the health check).

It should be possible to reproduce this issue by creating a project with the health check, observing the number of threads for this process (e. g.: in the task manager) and calling the health check multiple times.