### PR TITLE
Registration methods for EventStore TCP+gRPC passing in the ServiceProvider

### DIFF
--- a/src/HealthChecks.EventStore.gRPC/DependencyInjection/EventStoreHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.EventStore.gRPC/DependencyInjection/EventStoreHealthCheckBuilderExtensions.cs
@@ -39,4 +39,34 @@ public static class EventStoreHealthCheckBuilderExtensions
             tags,
             timeout));
     }
+
+    /// <summary>
+    /// Add a health check for EventStore services.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="connectionStringFactory">A function returning the EventStore connection string to be used.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'eventstore' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddEventStore(
+        this IHealthChecksBuilder builder,
+        Func<IServiceProvider, string> connectionStringFactory,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        builder.Services.AddSingleton(sp => new EventStoreHealthCheck(connectionStringFactory(sp)));
+        return builder.Add(new HealthCheckRegistration(
+            name ?? NAME,
+            sp => sp.GetRequiredService<EventStoreHealthCheck>(),
+            failureStatus,
+            tags,
+            timeout));
+    }
 }

--- a/src/HealthChecks.EventStore/DependencyInjection/EventStoreHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.EventStore/DependencyInjection/EventStoreHealthCheckBuilderExtensions.cs
@@ -42,5 +42,38 @@ namespace Microsoft.Extensions.DependencyInjection
                 tags,
                 timeout));
         }
+
+        /// <summary>
+        /// Add a health check for EventStore services.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="eventStoreConnectionFactory">A function returning the EventStore connection string to be used.</param>
+        /// <param name="login">The EventStore user login. Optional. If <c>null</c> the healthcheck will be processed without authentication.</param>
+        /// <param name="password">The EventStore user password. Optional. If <c>null</c> the healthcheck will be processed without authentication.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'eventstore' will be used for the name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <returns>The specified <paramref name="builder"/>.</returns>
+        public static IHealthChecksBuilder AddEventStore(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, string> eventStoreConnectionFactory,
+            string? login = default,
+            string? password = default,
+            string? name = default,
+            HealthStatus? failureStatus = default,
+            IEnumerable<string>? tags = default,
+            TimeSpan? timeout = default)
+        {
+            return builder.Add(new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new EventStoreHealthCheck(eventStoreConnectionFactory(sp), login, password),
+                failureStatus,
+                tags,
+                timeout));
+        }
     }
 }

--- a/src/HealthChecks.EventStore/EventStoreHealthCheck.cs
+++ b/src/HealthChecks.EventStore/EventStoreHealthCheck.cs
@@ -48,7 +48,7 @@ namespace HealthChecks.EventStore
                     connectionSettings,
                     CONNECTION_NAME))
                 {
-                    var tcs = new TaskCompletionSource<HealthCheckResult>();
+                    var tcs = new TaskCompletionSource<HealthCheckResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     //connected
                     connection.Connected += (s, e) => tcs.TrySetResult(HealthCheckResult.Healthy());

--- a/test/HealthChecks.EventStore.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.EventStore.Tests/DependencyInjection/RegistrationTests.cs
@@ -22,6 +22,23 @@ namespace HealthChecks.Consul.Tests.DependencyInjection
         }
 
         [Fact]
+        public void add_health_check_when_properly_configured_using_service_provider_overload()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddEventStore(sp => "connection-string");
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("eventstore");
+            check.GetType().Should().Be(typeof(EventStoreHealthCheck));
+        }
+
+        [Fact]
         public void add_named_health_check_when_properly_configured()
         {
             var services = new ServiceCollection();

--- a/test/HealthChecks.EventStore.Tests/Functional/EventStoreHealthCheckTests.cs
+++ b/test/HealthChecks.EventStore.Tests/Functional/EventStoreHealthCheckTests.cs
@@ -65,8 +65,9 @@ namespace HealthChecks.EventStore.Tests.Functional
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
+                    // Existing hostname, incorrect port. If the hostname cannot be reached, CreateRequest will hang.
                     services.AddHealthChecks()
-                    .AddEventStore("tcp://nonexistingdomain:1113", tags: new string[] { "eventstore" });
+                    .AddEventStore("ConnectTo=tcp://localhost:1114; UseSslConnection=false; HeartBeatTimeout=500", tags: new string[] { "eventstore" });
                 })
                 .Configure(app =>
                 {

--- a/test/HealthChecks.EventStore.Tests/HealthChecks.EventStore.approved.txt
+++ b/test/HealthChecks.EventStore.Tests/HealthChecks.EventStore.approved.txt
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class EventStoreHealthCheckBuilderExtensions
     {
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddEventStore(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, string> eventStoreConnectionFactory, string? login = null, string? password = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddEventStore(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string eventStoreConnection, string? login = null, string? password = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }

--- a/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
@@ -32,7 +32,7 @@ public class eventstore_registration_should
         var registration = options.Value.Registrations.First();
         var check = registration.Factory(serviceProvider);
 
-        registration.Name.Should().Be("eventstore");
+        registration.Name.ShouldBe("eventstore");
         check.ShouldBeOfType<ApplicationStatusHealthCheck>();
     }
 

--- a/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
@@ -33,7 +33,7 @@ public class eventstore_registration_should
         var check = registration.Factory(serviceProvider);
 
         registration.Name.ShouldBe("eventstore");
-        check.ShouldBeOfType<ApplicationStatusHealthCheck>();
+        check.ShouldBeOfType<EventStoreHealthCheck>();
     }
 
     [Fact]

--- a/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
@@ -20,6 +20,23 @@ public class eventstore_registration_should
     }
 
     [Fact]
+    public void add_health_check_when_properly_configured_using_service_provider_overload()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddEventStore(sp => "esdb://localhost:2113?tls=false");
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.Should().Be("eventstore");
+        check.GetType().Should().Be(typeof(EventStoreHealthCheck));
+    }
+
+    [Fact]
     public void add_named_health_check_when_properly_configured()
     {
         var services = new ServiceCollection();

--- a/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.EventStore.gRPC.Tests/DependencyInjection/RegistrationTests.cs
@@ -33,7 +33,7 @@ public class eventstore_registration_should
         var check = registration.Factory(serviceProvider);
 
         registration.Name.Should().Be("eventstore");
-        check.GetType().Should().Be(typeof(EventStoreHealthCheck));
+        check.ShouldBeOfType<ApplicationStatusHealthCheck>();
     }
 
     [Fact]

--- a/test/HealthChecks.EventStore.gRPC.Tests/HealthChecks.EventStore.gRPC.approved.txt
+++ b/test/HealthChecks.EventStore.gRPC.Tests/HealthChecks.EventStore.gRPC.approved.txt
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class EventStoreHealthCheckBuilderExtensions
     {
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddEventStore(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, string> connectionStringFactory, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddEventStore(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
This will allow creation of connection string to change depending on configuration.

I also fixed a test that was green for the wrong reason, and added `TaskCreationOptions.RunContinuationsAsynchronously` to a `TaskCompletionSource`. Let me know if you'd like these changes removed and/or put in a different PR.

**Which issue(s) this PR fixes**:
Not having access to the service provider when making a connection string.

Please reference the issue this PR will close: #1531 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No, just new overloads.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
