### PR TITLE
Do not run CI workflows when preview-* tag was pushed

### DIFF
--- a/.github/workflows/healthchecks_applicationstatus_ci.yml
+++ b/.github/workflows/healthchecks_applicationstatus_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_arangodb_ci.yml
+++ b/.github/workflows/healthchecks_arangodb_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_aws_s3_ci.yml
+++ b/.github/workflows/healthchecks_aws_s3_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_aws_secretsmanager_ci.yml
+++ b/.github/workflows/healthchecks_aws_secretsmanager_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_aws_sns_ci.yml
+++ b/.github/workflows/healthchecks_aws_sns_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_aws_sqs_ci.yml
+++ b/.github/workflows/healthchecks_aws_sqs_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_aws_systemsmanager_ci.yml
+++ b/.github/workflows/healthchecks_aws_systemsmanager_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_azure_digitaltwin_ci.yml
+++ b/.github/workflows/healthchecks_azure_digitaltwin_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_azure_iothub_ci.yml
+++ b/.github/workflows/healthchecks_azure_iothub_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_azurekeyvault_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_azureservicebus_ci.yml
+++ b/.github/workflows/healthchecks_azureservicebus_ci.yml
@@ -12,6 +12,8 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_azurestorage_ci.yml
+++ b/.github/workflows/healthchecks_azurestorage_ci.yml
@@ -12,6 +12,7 @@ on:
     - Directory.Build.targets
    tags-ignore:
     - release-*
+    - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_consul_ci.yml
+++ b/.github/workflows/healthchecks_consul_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_cosmosdb_ci.yml
+++ b/.github/workflows/healthchecks_cosmosdb_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_documentdb_ci.yml
+++ b/.github/workflows/healthchecks_documentdb_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_dynamodb_ci.yml
+++ b/.github/workflows/healthchecks_dynamodb_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_elasticsearch_ci.yml
+++ b/.github/workflows/healthchecks_elasticsearch_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -11,6 +11,7 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_gcp_cloudfirestore_ci.yml
+++ b/.github/workflows/healthchecks_gcp_cloudfirestore_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_gremlin_ci.yml
+++ b/.github/workflows/healthchecks_gremlin_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_hangfire_ci.yml
+++ b/.github/workflows/healthchecks_hangfire_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_ibmmq_ci.yml
+++ b/.github/workflows/healthchecks_ibmmq_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_kafka_ci.yml
+++ b/.github/workflows/healthchecks_kafka_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_mongodb_ci.yml
+++ b/.github/workflows/healthchecks_mongodb_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_mysql_ci.yml
+++ b/.github/workflows/healthchecks_mysql_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_nats_ci.yml
+++ b/.github/workflows/healthchecks_nats_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_network_ci.yml
+++ b/.github/workflows/healthchecks_network_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_npgsql_ci.yml
+++ b/.github/workflows/healthchecks_npgsql_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_openidconnectserver_ci.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_prometheus_metrics_ci.yml
+++ b/.github/workflows/healthchecks_prometheus_metrics_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_publisher_applicationinsights_ci.yml
+++ b/.github/workflows/healthchecks_publisher_applicationinsights_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
+++ b/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_publisher_datadog_ci.yml
+++ b/.github/workflows/healthchecks_publisher_datadog_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_publisher_prometheus_ci.yml
+++ b/.github/workflows/healthchecks_publisher_prometheus_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_publisher_seq_ci.yml
+++ b/.github/workflows/healthchecks_publisher_seq_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_rabbitmq_ci.yml
+++ b/.github/workflows/healthchecks_rabbitmq_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_ravendb_ci.yml
+++ b/.github/workflows/healthchecks_ravendb_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_redis_ci.yml
+++ b/.github/workflows/healthchecks_redis_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_sendgrid_ci.yml
+++ b/.github/workflows/healthchecks_sendgrid_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_signalr_ci.yml
+++ b/.github/workflows/healthchecks_signalr_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_solr_ci.yml
+++ b/.github/workflows/healthchecks_solr_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_sqlite_ci.yml
+++ b/.github/workflows/healthchecks_sqlite_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_sqlserver_ci.yml
+++ b/.github/workflows/healthchecks_sqlserver_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_system_ci.yml
+++ b/.github/workflows/healthchecks_system_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_ui_ci.yml
+++ b/.github/workflows/healthchecks_ui_ci.yml
@@ -13,6 +13,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/healthchecks_uris_ci.yml
+++ b/.github/workflows/healthchecks_uris_ci.yml
@@ -12,6 +12,8 @@ on:
       - Directory.Build.targets
     tags-ignore:
       - release-*
+      - preview-*
+
   pull_request:
     branches: [ master ]
     paths:

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -34,7 +34,7 @@
     <HealthCheckMongoDB>6.0.2</HealthCheckMongoDB>
     <HealthCheckMySql>6.0.2</HealthCheckMySql>
     <HealthCheckNetwork>6.0.4</HealthCheckNetwork>
-    <HealthCheckNats>6.0.3</HealthCheckNats>
+    <HealthCheckNats>6.0.4</HealthCheckNats>
     <HealthCheckNpgSql>6.0.2</HealthCheckNpgSql>
     <HealthCheckOpenIdConnectServer>6.0.2</HealthCheckOpenIdConnectServer>
     <HealthCheckOracle>6.0.3</HealthCheckOracle>


### PR DESCRIPTION
Today I tried to publish preview version of package for the first time. I noticed that tagging commit with `preview-nats-6.0.4` triggered all workflows.