### PR TITLE
Fix versioning for preview releases

### DIFF
--- a/src/HealthChecks.ApplicationStatus/HealthChecks.ApplicationStatus.csproj
+++ b/src/HealthChecks.ApplicationStatus/HealthChecks.ApplicationStatus.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);ApplicationStatus</PackageTags>
     <Description>HealthChecks.ApplicationStatus is the health check package for detection graceful shutdown.</Description>
-    <Version>$(HealthCheckApplicationStatus)</Version>
+    <VersionPrefix>$(HealthCheckApplicationStatus)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
+++ b/src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);ArangoDb</PackageTags>
     <Description>HealthChecks.ArangoDb is the health check package for ArangoDb.</Description>
-    <Version>$(HealthCheckArangoDb)</Version>
+    <VersionPrefix>$(HealthCheckArangoDb)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
+++ b/src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;S3;Simple Storage Service</PackageTags>
     <Description>HealthChecks.Aws.S3 is the health check package for S3 Buckets and files.</Description>
-    <Version>$(HealthCheckAWSS3)</Version>
+    <VersionPrefix>$(HealthCheckAWSS3)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Aws.SecretsManager/HealthChecks.Aws.SecretsManager.csproj
+++ b/src/HealthChecks.Aws.SecretsManager/HealthChecks.Aws.SecretsManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;Secrets Manager;</PackageTags>
     <Description>HealthChecks.Aws.SecretsManager is the health check package for Secrets Manager.</Description>
-    <Version>$(HealthCheckAWSSecretsManager)</Version>
+    <VersionPrefix>$(HealthCheckAWSSecretsManager)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Aws.Sns/HealthChecks.Aws.Sns.csproj
+++ b/src/HealthChecks.Aws.Sns/HealthChecks.Aws.Sns.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;SNS;Amazon Simple Notification Service</PackageTags>
     <Description>HealthChecks.Aws.Sns is the health check package for Amazon Simple Notification Service.</Description>
-    <Version>$(HealthCheckAWSSns)</Version>
+    <VersionPrefix>$(HealthCheckAWSSns)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Aws.Sqs/HealthChecks.Aws.Sqs.csproj
+++ b/src/HealthChecks.Aws.Sqs/HealthChecks.Aws.Sqs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;SQS;Simple Queue Service</PackageTags>
     <Description>HealthChecks.Aws.Sqs is the health check package for SQS queues.</Description>
-    <Version>$(HealthCheckAWSSqs)</Version>
+    <VersionPrefix>$(HealthCheckAWSSqs)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Aws.SystemsManager/HealthChecks.Aws.SystemsManager.csproj
+++ b/src/HealthChecks.Aws.SystemsManager/HealthChecks.Aws.SystemsManager.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;Systems Manager;Parameter Store</PackageTags>
     <Description>HealthChecks.Aws.SystemsManager is the health check package for Systems Manager for Parameter Store.</Description>
-    <Version>$(HealthCheckAWSSystemsManager)</Version>
+    <VersionPrefix>$(HealthCheckAWSSystemsManager)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
+++ b/src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;IoT Hub</PackageTags>
     <Description>HealthChecks.Azure.IoTHub is the health check package for Azure IoT Hub.</Description>
-    <Version>$(HealthCheckIoTHub)</Version>
+    <VersionPrefix>$(HealthCheckIoTHub)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
+++ b/src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;DigitalTwin</PackageTags>
     <Description>HealthChecks.AzureDigitalTwin is the health check package for Azure DigitalTwin.</Description>
-    <Version>$(HealthCheckAzureDigitalTwin)</Version>
+    <VersionPrefix>$(HealthCheckAzureDigitalTwin)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+++ b/src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure Key Vault;Secrets</PackageTags>
     <Description>HealthChecks.AzureKeyVault is the health check package for Azure Key Vault secrets</Description>
-    <Version>$(HealthCheckKeyVault)</Version>
+    <VersionPrefix>$(HealthCheckKeyVault)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
+++ b/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;ServiceBus;EventHub</PackageTags>
     <Description>HealthChecks.AzureServiceBus is the health check package for Azure EventHub, and Azure Service Bus Queues and Topics.</Description>
-    <Version>$(HealthCheckAzureServiceBus)</Version>
+    <VersionPrefix>$(HealthCheckAzureServiceBus)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
+++ b/src/HealthChecks.AzureStorage/HealthChecks.AzureStorage.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;AzureStorage</PackageTags>
     <Description>HealthChecks.AzureStorage is the health check package for Blobs, Tables and Queues.</Description>
-    <Version>$(HealthCheckAzureStorage)</Version>
+    <VersionPrefix>$(HealthCheckAzureStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Consul/HealthChecks.Consul.csproj
+++ b/src/HealthChecks.Consul/HealthChecks.Consul.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Consul</PackageTags>
     <Description>HealthChecks.Consul is the health check package for Consul Server.</Description>
-    <Version>$(HealthCheckConsul)</Version>
+    <VersionPrefix>$(HealthCheckConsul)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
+++ b/src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;CosmosDb</PackageTags>
     <Description>HealthChecks.CosmosDb is the health check package for Azure CosmosDb.</Description>
-    <Version>$(HealthCheckCosmosDb)</Version>
+    <VersionPrefix>$(HealthCheckCosmosDb)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
+++ b/src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;DocumentDb</PackageTags>
     <Description>HealthChecks.DocumentDb is the health check package for Azure DocumentDb.</Description>
-    <Version>$(HealthCheckDocumentDb)</Version>
+    <VersionPrefix>$(HealthCheckDocumentDb)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
+++ b/src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);DynamoDb;AWS</PackageTags>
     <Description>HealthChecks.DynamoDb is the health check package for AWS DynamoDb.</Description>
-    <Version>$(HealthCheckDynamoDb)</Version>
+    <VersionPrefix>$(HealthCheckDynamoDb)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
+++ b/src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Elasticsearch</PackageTags>
     <Description>HealthChecks.Elasticsearch is the health check package for Elasticsearch.</Description>
-    <Version>$(HealthCheckElasticsearch)</Version>
+    <VersionPrefix>$(HealthCheckElasticsearch)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
+++ b/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);EventStore;gRPC</PackageTags>
     <Description>HealthChecks.EventStore.gRPC is the health check package for EventStore, using the gRPC client.</Description>
-    <Version>$(HealthCheckEventStoregRPC)</Version>
+    <VersionPrefix>$(HealthCheckEventStoregRPC)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.EventStore/HealthChecks.EventStore.csproj
+++ b/src/HealthChecks.EventStore/HealthChecks.EventStore.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);EventStore</PackageTags>
     <Description>HealthChecks.EventStore is the health check package for EventStore, using the TCP Client.</Description>
-    <Version>$(HealthCheckEventStore)</Version>
+    <VersionPrefix>$(HealthCheckEventStore)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
+++ b/src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);CloudFirestore</PackageTags>
     <Description>HealthChecks.Gcp.CloudFirestore is the health check package for the Firebase Cloud Firebase realtime database.</Description>
-    <Version>$(HealthCheckCloudFirestore)</Version>
+    <VersionPrefix>$(HealthCheckCloudFirestore)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
+++ b/src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Gremlin;TinkerPop;GraphDB</PackageTags>
     <Description>HealthChecks.Gremlin is the health check package for Gremlin.</Description>
-    <Version>$(HealthCheckGremlin)</Version>
+    <VersionPrefix>$(HealthCheckGremlin)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
+++ b/src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Hangfire</PackageTags>
     <Description>HealthChecks.Hangfire is the health check package for Hangfire.</Description>
-    <Version>$(HealthCheckHangfire)</Version>
+    <VersionPrefix>$(HealthCheckHangfire)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
+++ b/src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);IbmMQ</PackageTags>
     <Description>HealthChecks.IbmMQ is the health check package for IbmMQ.</Description>
-    <Version>$(HealthCheckIbmMQ)</Version>
+    <VersionPrefix>$(HealthCheckIbmMQ)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
+++ b/src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Kafka;Confluent</PackageTags>
     <Description>HealthChecks.Kafka is the health check package for Kafka.</Description>
-    <Version>$(HealthCheckKafka)</Version>
+    <VersionPrefix>$(HealthCheckKafka)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Kubernetes/HealthChecks.Kubernetes.csproj
+++ b/src/HealthChecks.Kubernetes/HealthChecks.Kubernetes.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Kubernetes;k8s;Cluster</PackageTags>
     <Description>HealthChecks.HealthChecks is the health check package for Kubernetes clusters.</Description>
-    <Version>$(HealthCheckKubernetes)</Version>
+    <VersionPrefix>$(HealthCheckKubernetes)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
+++ b/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);MongoDb</PackageTags>
     <Description>HealthChecks.MongoDb is the health check package for MongoDb.</Description>
-    <Version>$(HealthCheckMongoDB)</Version>
+    <VersionPrefix>$(HealthCheckMongoDB)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.MySql/HealthChecks.MySql.csproj
+++ b/src/HealthChecks.MySql/HealthChecks.MySql.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);MySQL</PackageTags>
     <Description>HealthChecks.MySql is the health check package for MySQL.</Description>
-    <Version>$(HealthCheckMySql)</Version>
+    <VersionPrefix>$(HealthCheckMySql)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Nats/HealthChecks.Nats.csproj
+++ b/src/HealthChecks.Nats/HealthChecks.Nats.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Nats</PackageTags>
     <Description>HealthChecks.Nats is the health check package for Nats.</Description>
-    <Version>$(HealthCheckNats)</Version>
+    <VersionPrefix>$(HealthCheckNats)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Network/HealthChecks.Network.csproj
+++ b/src/HealthChecks.Network/HealthChecks.Network.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Network;Sftp;Ftp;Tcp;DNS</PackageTags>
     <Description>HealthChecks.Network is the health check package for network services.</Description>
-    <Version>$(HealthCheckNetwork)</Version>
+    <VersionPrefix>$(HealthCheckNetwork)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
+++ b/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Beat;Postgress</PackageTags>
     <Description>HealthChecks.NpgSql is a health check for Postgress Sql.</Description>
-    <Version>$(HealthCheckNpgSql)</Version>
+    <VersionPrefix>$(HealthCheckNpgSql)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
+++ b/src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);IdentityServer;IdSvr;OpenId;OpenIdConnect</PackageTags>
     <Description>HealthChecks.OpenIdConnectServer is the health check package for OpenIdConnect servers</Description>
-    <Version>$(HealthCheckOpenIdConnectServer)</Version>
+    <VersionPrefix>$(HealthCheckOpenIdConnectServer)</VersionPrefix>
     <RootNamespace>HealthChecks.IdSvr</RootNamespace> <!--For backward naming compatibility-->
   </PropertyGroup>
 

--- a/src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
+++ b/src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion);netstandard2.1</TargetFrameworks>
     <PackageTags>$(PackageTags);Oracle</PackageTags>
     <Description>HealthChecks.Oracle is the health check package for Oracle Database.</Description>
-    <Version>$(HealthCheckOracle)</Version>
+    <VersionPrefix>$(HealthCheckOracle)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
+++ b/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Prometheus;Prometheus Exporter;Metrics</PackageTags>
     <Description>HealthChecks.Publisher.Prometheus is a health check prometheus metrics exporter.</Description>
-    <Version>$(HealthCheckPrometheusMetrics)</Version>
+    <VersionPrefix>$(HealthCheckPrometheusMetrics)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
+++ b/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Application Insights</PackageTags>
     <Description>HealthChecks.Publisher.ApplicationInsights is the health check publisher for Application Insights.</Description>
-    <Version>$(HealthCheckPublisherAppplicationInsights)</Version>
+    <VersionPrefix>$(HealthCheckPublisherAppplicationInsights)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Publisher.CloudWatch/HealthChecks.Publisher.CloudWatch.csproj
+++ b/src/HealthChecks.Publisher.CloudWatch/HealthChecks.Publisher.CloudWatch.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;AWS;CloudWatch</PackageTags>
     <Description>HealthChecks.Publisher.CloudWatch is the health check publisher for AWS CloudWatch.</Description>
-    <Version>$(HealthCheckPublisherCloudWatch)</Version>
+    <VersionPrefix>$(HealthCheckPublisherCloudWatch)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
+++ b/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Datadog</PackageTags>
     <Description>HealthChecks.Publisher.Datadog is the health check publisher for Datadog.</Description>
-    <Version>$(HealthCheckPublisherDatadog)</Version>
+    <VersionPrefix>$(HealthCheckPublisherDatadog)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
+++ b/src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Prometheus;Prometheus Gateway</PackageTags>
     <Description>[Deprecated! Use pull model with AspNetCore.HealthChecks.Prometheus.Metrics package instead] HealthChecks.Publisher.PrometheusGateway is the health check publisher for Prometheus Gateway.</Description>
-    <Version>$(HealthCheckPublisherPrometheus)</Version>
+    <VersionPrefix>$(HealthCheckPublisherPrometheus)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
+++ b/src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Seq</PackageTags>
     <Description>HealthChecks.Publisher.Seq is the health check publisher for Seq.</Description>
-    <Version>$(HealthCheckPublisherSeq)</Version>
+    <VersionPrefix>$(HealthCheckPublisherSeq)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
+++ b/src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);RabbitMQ</PackageTags>
     <Description>HealthChecks.RabbitMQ is the health check package for RabbitMQ.</Description>
-    <Version>$(HealthCheckRabbitMQ)</Version>
+    <VersionPrefix>$(HealthCheckRabbitMQ)</VersionPrefix>
     <RootNamespace>HealthChecks.RabbitMQ</RootNamespace> <!--For backward naming compatibility-->
   </PropertyGroup>
 

--- a/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
+++ b/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);RavenDB</PackageTags>
     <Description>HealthChecks.RavenDB is the health check package for RavenDB.</Description>
-    <Version>$(HealthCheckRavenDB)</Version>
+    <VersionPrefix>$(HealthCheckRavenDB)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Redis/HealthChecks.Redis.csproj
+++ b/src/HealthChecks.Redis/HealthChecks.Redis.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Redis</PackageTags>
     <Description>HealthChecks.Redis is the health check package for Redis.</Description>
-    <Version>$(HealthCheckRedis)</Version>
+    <VersionPrefix>$(HealthCheckRedis)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
+++ b/src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);SendGrid</PackageTags>
     <Description>HealthChecks.SendGrid is the health check package for SendGrid.</Description>
-    <Version>$(HealthCheckSendGrid)</Version>
+    <VersionPrefix>$(HealthCheckSendGrid)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
+++ b/src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);SignalR</PackageTags>
     <Description>HealthChecks.SignalR is the health check package for SignalR.</Description>
-    <Version>$(HealthCheckSignalR)</Version>
+    <VersionPrefix>$(HealthCheckSignalR)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Solr/HealthChecks.Solr.csproj
+++ b/src/HealthChecks.Solr/HealthChecks.Solr.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);solr</PackageTags>
     <Description>HealthChecks.solr is the health check package for solr.</Description>
-    <Version>$(HealthCheckSolr)</Version>
+    <VersionPrefix>$(HealthCheckSolr)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
+++ b/src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Sql Server</PackageTags>
     <Description>HealthChecks.SqlServer is the health check package for SqlServer.</Description>
-    <Version>$(HealthCheckSqlServer)</Version>
+    <VersionPrefix>$(HealthCheckSqlServer)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
+++ b/src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Sqlite</PackageTags>
     <Description>HealthChecks.Sqlite is the health check package for Sqlite.</Description>
-    <Version>$(HealthCheckSqlite)</Version>
+    <VersionPrefix>$(HealthCheckSqlite)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.System/HealthChecks.System.csproj
+++ b/src/HealthChecks.System/HealthChecks.System.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Beat;System;Ping;Disk Storage</PackageTags>
     <Description>HealthChecks.System is the system health check package.</Description>
-    <Version>$(HealthCheckSystem)</Version>
+    <VersionPrefix>$(HealthCheckSystem)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj
+++ b/src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);UI;Client</PackageTags>
     <Description>HealthChecks.UI.Client contains some mandatory abstractions to work with HealthChecks.UI.</Description>
-    <Version>$(HealthCheckUIClient)</Version>
+    <VersionPrefix>$(HealthCheckUIClient)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj
+++ b/src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);Core</PackageTags>
     <Description>HealthChecks.UI.Core package containing builder and model definitions</Description>
-    <Version>$(HealthCheckUICore)</Version>
+    <VersionPrefix>$(HealthCheckUICore)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj
+++ b/src/HealthChecks.UI.InMemory.Storage/HealthChecks.UI.InMemory.Storage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);InMemory</PackageTags>
     <Description>HealthChecks.UI.InMemory.Storage package contains the required classes to use InMemory provider in the UI</Description>
-    <Version>$(HealthCheckUIInMemoryStorage)</Version>
+    <VersionPrefix>$(HealthCheckUIInMemoryStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
+++ b/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
-    <Version>$(HealthChecksUIK8sOperator)</Version>
+    <VersionPrefix>$(HealthChecksUIK8sOperator)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj
+++ b/src/HealthChecks.UI.MySql.Storage/HealthChecks.UI.MySql.Storage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);MySql</PackageTags>
     <Description>HealthChecks.UI.MySql.Storage package contains the required classes to use the MySql database provider in the UI</Description>
-    <Version>$(HealthCheckUIMySqlStorage)</Version>
+    <VersionPrefix>$(HealthCheckUIMySqlStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj
+++ b/src/HealthChecks.UI.PostgreSQL.Storage/HealthChecks.UI.PostgreSQL.Storage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);PostgreSQL</PackageTags>
     <Description>HealthChecks.UI.PostgreSQL.Storage package contains the required classes to use Postgres NpgSql provider in the UI</Description>
-    <Version>$(HealthChecksUIPostgreSQLStorage)</Version>
+    <VersionPrefix>$(HealthChecksUIPostgreSQLStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj
+++ b/src/HealthChecks.UI.SQLite.Storage/HealthChecks.UI.SQLite.Storage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
     <Description>HealthChecks.UI.SQLite.Storage package contains the required classes to use SQLite provider in the UI</Description>
-    <Version>$(HealthCheckUISQLiteStorage)</Version>
+    <VersionPrefix>$(HealthCheckUISQLiteStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj
+++ b/src/HealthChecks.UI.SqlServer.Storage/HealthChecks.UI.SqlServer.Storage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);SqlServer</PackageTags>
     <Description>HealthChecks.UI.SqlServer.Storage package contains the required classes to use SqlServer provider in the UI</Description>
-    <Version>$(HealthCheckUISqlServerStorage)</Version>
+    <VersionPrefix>$(HealthCheckUISqlServerStorage)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HealthChecks.UI/HealthChecks.UI.csproj
+++ b/src/HealthChecks.UI/HealthChecks.UI.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
     <PackageTags>$(PackageTags);UI</PackageTags>
     <Description>HealthChecks.UI Is a ASP.NET Core UI viewer of ASP.NET Core HealthChecks.For more information see https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks</Description>
-    <Version>$(HealthCheckUI)</Version>
+    <VersionPrefix>$(HealthCheckUI)</VersionPrefix>
     <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
   </PropertyGroup>
 

--- a/src/HealthChecks.Uris/HealthChecks.Uris.csproj
+++ b/src/HealthChecks.Uris/HealthChecks.Uris.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardVersion)</TargetFrameworks>
     <PackageTags>$(PackageTags);Uri;Url;Uris;Urls</PackageTags>
     <Description>HealthChecks.Uris is a simple health check package for Uri groups.</Description>
-    <Version>$(HealthCheckUri)</Version>
+    <VersionPrefix>$(HealthCheckUri)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
From https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack:
![изображение](https://user-images.githubusercontent.com/21261007/204648449-80f59e07-92d6-4363-9205-d52306c51a5c.png)
Need to fix all csprojs to use `<VersionPrefix>` instead of `<Version>`.