### PR TITLE
MongoDB - Fix Unhealthy if no collections exists in the specified database

### DIFF
--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace HealthChecks.MongoDb
@@ -34,14 +35,13 @@ namespace HealthChecks.MongoDb
                 if (!string.IsNullOrEmpty(_specifiedDatabase))
                 {
                     // some users can't list all databases depending on database privileges, with
-                    // this you can list only collections on specified database.
-                    // Related with issue #43
+                    // this you can check a specified database.
+                    // Related with issue #43 and #617
 
-                    using var cursor = await mongoClient
+                    await mongoClient
                         .GetDatabase(_specifiedDatabase)
-                        .ListCollectionNamesAsync(cancellationToken: cancellationToken)
+                        .RunCommandAsync((Command<BsonDocument>)"{ping:1}", cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    await cursor.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
+++ b/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs
@@ -41,7 +41,7 @@ namespace HealthChecks.MongoDb
                         .GetDatabase(_specifiedDatabase)
                         .ListCollectionNamesAsync(cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    await cursor.FirstAsync(cancellationToken).ConfigureAwait(false);
+                    await cursor.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {

--- a/test/HealthChecks.MongoDb.Tests/Functional/MongoDbHealthCheckTests.cs
+++ b/test/HealthChecks.MongoDb.Tests/Functional/MongoDbHealthCheckTests.cs
@@ -81,8 +81,9 @@ namespace HealthChecks.MongoDb.Tests.Functional
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
         [Fact]
-        public async Task be_unhealthy_on_connectionstring_specified_database_if_mongodb_is_available_and_database_exist()
+        public async Task be_healthy_on_connectionstring_specified_database_if_mongodb_is_available_and_database_not_exist()
         {
+            // NOTE: with mongodb the database is created automatically the first time something is written to it
             var connectionString = "mongodb://localhost:27017/nonexisting";
 
             var webHostBuilder = new WebHostBuilder()
@@ -103,7 +104,7 @@ namespace HealthChecks.MongoDb.Tests.Functional
 
             var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
 
         [Fact]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
We are experiencing unhealthy checks if a specified mongo database has no collections yet.

```
System.InvalidOperationException: Sequence contains no elements at System.Linq.ThrowHelper.ThrowNoElementsException() at System.Linq.Enumerable.First[TSource](IEnumerable`1 source) at MongoDB.Driver.IAsyncCursorExtensions.FirstAsync[TDocument](IAsyncCursor`1 cursor, CancellationToken cancellationToken) at HealthChecks.MongoDb.MongoDbHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken) in /_/src/HealthChecks.MongoDb/MongoDbHealthCheck.cs:line 43
```

**Which issue(s) this PR fixes**:
#617

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
