### PR TITLE
Allow healthchecking multiple RabbitMQ connections

### DIFF
--- a/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -60,10 +60,9 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        var rabbitMQHalthCheck = new Lazy<RabbitMQHealthCheck>(() => new(rabbitConnectionString, sslOption));
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            _ => rabbitMQHalthCheck.Value,
+            _ => new RabbitMQHealthCheck(rabbitConnectionString, sslOption),
             failureStatus,
             tags,
             timeout));
@@ -73,6 +72,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// Add a health check for RabbitMQ services using <see cref="IConnection"/> from service provider
     /// or <see cref="IConnectionFactory"/> from service provider if none is found. At least one must be configured.
     /// </summary>
+    /// <remarks>
+    /// This method shouldn't be called more than once.
+    /// Each subsequent call will create a new connection, which overrides the previous ones.
+    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
     /// <param name="failureStatus">
@@ -137,24 +140,9 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        object rabbitMQHealthCheckLock = new();
-        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp =>
-            {
-                if (rabbitMQHealthCheck is null)
-                {
-                    lock (rabbitMQHealthCheckLock)
-                    {
-                        if (rabbitMQHealthCheck is null)
-                        {
-                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionFactory(sp));
-                        }
-                    }
-                }
-                return rabbitMQHealthCheck;
-            },
+            sp => new RabbitMQHealthCheck(connectionFactory(sp)),
             failureStatus,
             tags,
             timeout));
@@ -181,24 +169,9 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        object rabbitMQHealthCheckLock = new();
-        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp =>
-            {
-                if (rabbitMQHealthCheck is null)
-                {
-                    lock (rabbitMQHealthCheckLock)
-                    {
-                        if (rabbitMQHealthCheck is null)
-                        {
-                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionFactoryFactory(sp));
-                        }
-                    }
-                }
-                return rabbitMQHealthCheck;
-            },
+            sp => new RabbitMQHealthCheck(connectionFactoryFactory(sp)),
             failureStatus,
             tags,
             timeout));
@@ -227,24 +200,9 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        object rabbitMQHealthCheckLock = new();
-        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp =>
-            {
-                if (rabbitMQHealthCheck is null)
-                {
-                    lock (rabbitMQHealthCheckLock)
-                    {
-                        if (rabbitMQHealthCheck is null)
-                        {
-                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionStringFactory(sp), sslOption);
-                        }
-                    }
-                }
-                return rabbitMQHealthCheck;
-            },
+            sp => new RabbitMQHealthCheck(connectionStringFactory(sp), sslOption),
             failureStatus,
             tags,
             timeout));

--- a/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -60,12 +60,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        builder.Services
-            .AddSingleton(sp => new RabbitMQHealthCheck(rabbitConnectionString, sslOption));
-
+        var rabbitMQHalthCheck = new Lazy<RabbitMQHealthCheck>(() => new(rabbitConnectionString, sslOption));
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => sp.GetRequiredService<RabbitMQHealthCheck>(),
+            _ => rabbitMQHalthCheck.Value,
             failureStatus,
             tags,
             timeout));
@@ -139,12 +137,24 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        builder.Services
-            .AddSingleton(sp => new RabbitMQHealthCheck(connectionFactory(sp)));
-
+        object rabbitMQHealthCheckLock = new();
+        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => sp.GetRequiredService<RabbitMQHealthCheck>(),
+            sp =>
+            {
+                if (rabbitMQHealthCheck is null)
+                {
+                    lock (rabbitMQHealthCheckLock)
+                    {
+                        if (rabbitMQHealthCheck is null)
+                        {
+                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionFactory(sp));
+                        }
+                    }
+                }
+                return rabbitMQHealthCheck;
+            },
             failureStatus,
             tags,
             timeout));
@@ -171,12 +181,24 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        builder.Services
-            .AddSingleton(sp => new RabbitMQHealthCheck(connectionFactoryFactory(sp)));
-
+        object rabbitMQHealthCheckLock = new();
+        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => sp.GetRequiredService<RabbitMQHealthCheck>(),
+            sp =>
+            {
+                if (rabbitMQHealthCheck is null)
+                {
+                    lock (rabbitMQHealthCheckLock)
+                    {
+                        if (rabbitMQHealthCheck is null)
+                        {
+                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionFactoryFactory(sp));
+                        }
+                    }
+                }
+                return rabbitMQHealthCheck;
+            },
             failureStatus,
             tags,
             timeout));
@@ -205,12 +227,24 @@ public static class RabbitMQHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        builder.Services
-            .AddSingleton(sp => new RabbitMQHealthCheck(connectionStringFactory(sp), sslOption));
-
+        object rabbitMQHealthCheckLock = new();
+        RabbitMQHealthCheck? rabbitMQHealthCheck = null;
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => sp.GetRequiredService<RabbitMQHealthCheck>(),
+            sp =>
+            {
+                if (rabbitMQHealthCheck is null)
+                {
+                    lock (rabbitMQHealthCheckLock)
+                    {
+                        if (rabbitMQHealthCheck is null)
+                        {
+                            rabbitMQHealthCheck = new RabbitMQHealthCheck(connectionStringFactory(sp), sslOption);
+                        }
+                    }
+                }
+                return rabbitMQHealthCheck;
+            },
             failureStatus,
             tags,
             timeout));

--- a/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -123,8 +123,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// Add a health check for RabbitMQ services using <see cref="IConnection"/> factory function.
     /// </summary>
     /// <remarks>
-    /// <paramref name="connectionFactory"/> will be called each time the healthcheck route is requested. However the
-    /// created <see cref="IConnection"/> will be reused.
+    /// <paramref name="connectionFactory"/> will be called each time the healthcheck route is requested.
+    /// Since RabbitMQ does not like frequent short connections, it is wise to not create a new connection
+    /// in this factory, but to retrive an existing connection.
+    /// If you don't have a connection to retrive consider using <see cref="AddRabbitMQ(IHealthChecksBuilder, Func{IServiceProvider, IConnectionFactory}, string?, HealthStatus?, IEnumerable{string}?, TimeSpan?)"/>
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionFactory"> A factory function to provide the rabbitMQ connection </param>

--- a/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -62,7 +62,7 @@ public static class RabbitMQHealthCheckBuilderExtensions
     {
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            _ => new RabbitMQHealthCheck(rabbitConnectionString, sslOption),
+            _ => new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { ConnectionUri = rabbitConnectionString, Ssl = sslOption }),
             failureStatus,
             tags,
             timeout));
@@ -99,11 +99,11 @@ public static class RabbitMQHealthCheckBuilderExtensions
 
             if (connection != null)
             {
-                return new RabbitMQHealthCheck(connection);
+                return new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { Connection = connection });
             }
             else if (connectionFactory != null)
             {
-                return new RabbitMQHealthCheck(connectionFactory);
+                return new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { ConnectionFactory = connectionFactory });
             }
             else
             {
@@ -148,7 +148,7 @@ public static class RabbitMQHealthCheckBuilderExtensions
     {
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => new RabbitMQHealthCheck(connectionFactory(sp)),
+            sp => new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { Connection = connectionFactory(sp) }),
             failureStatus,
             tags,
             timeout));
@@ -181,7 +181,7 @@ public static class RabbitMQHealthCheckBuilderExtensions
     {
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => new RabbitMQHealthCheck(connectionFactoryFactory(sp)),
+            sp => new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { ConnectionFactory = connectionFactoryFactory(sp) }),
             failureStatus,
             tags,
             timeout));
@@ -216,7 +216,7 @@ public static class RabbitMQHealthCheckBuilderExtensions
     {
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => new RabbitMQHealthCheck(connectionStringFactory(sp), sslOption),
+            sp => new RabbitMQHealthCheck(new RabbitMQHealthCheckOptions { ConnectionUri = connectionStringFactory(sp), Ssl = sslOption }),
             failureStatus,
             tags,
             timeout));

--- a/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Rabbitmq/DependencyInjection/RabbitMQHealthCheckBuilderExtensions.cs
@@ -122,6 +122,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// <summary>
     /// Add a health check for RabbitMQ services using <see cref="IConnection"/> factory function.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="connectionFactory"/> will be called each time the healthcheck route is requested. However the
+    /// created <see cref="IConnection"/> will be reused.
+    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionFactory"> A factory function to provide the rabbitMQ connection </param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
@@ -151,6 +155,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// <summary>
     /// Add a health check for RabbitMQ services using <see cref="IConnectionFactory"/> factory function.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="connectionFactoryFactory"/> will be called each time the healthcheck route is requested. However
+    /// the created <see cref="IConnection"/> will be reused.
+    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionFactoryFactory"> A factory function to provide the rabbitMQ connection factory</param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'rabbitmq' will be used for the name.</param>
@@ -180,6 +188,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// <summary>
     /// Add a health check for RabbitMQ services using connection string (amqp uri) factory.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="connectionStringFactory"/> will be called each time the healthcheck route is requested. However
+    /// the created <see cref="IConnection"/> will be reused.
+    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionStringFactory">A factory function to provide the RabbitMQ connection string (amqp uri).</param>
     /// <param name="sslOption">The RabbitMQ ssl options. Optional. If <c>null</c>, the ssl option will counted as disabled and not used.</param>
@@ -211,6 +223,10 @@ public static class RabbitMQHealthCheckBuilderExtensions
     /// <summary>
     /// Add a health check for RabbitMQ services using connection string (amqp uri) factory.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="connectionStringFactory"/> will be called each time the healthcheck route is requested. However
+    /// the created <see cref="IConnection"/> will be reused.
+    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionStringFactory">A factory function to provide the RabbitMQ connection string (amqp uri).</param>
     /// <param name="sslOption">The RabbitMQ ssl options. Optional. If <c>null</c>, the ssl option will counted as disabled and not used.</param>

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
@@ -28,7 +28,9 @@ public class RabbitMQHealthCheck : IHealthCheck
     {
         _factory = new ConnectionFactory()
         {
-            Uri = rabbitConnectionString, AutomaticRecoveryEnabled = true, UseBackgroundThreadsForIO = true,
+            Uri = rabbitConnectionString,
+            AutomaticRecoveryEnabled = true,
+            UseBackgroundThreadsForIO = true,
         };
 
         if (ssl!= null)

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
@@ -26,7 +26,7 @@ public class RabbitMQHealthCheck : IHealthCheck
 
     public RabbitMQHealthCheck(Uri rabbitConnectionString, SslOption? ssl)
     {
-        _factory = new ConnectionFactory()
+        _factory = new ConnectionFactory
         {
             Uri = rabbitConnectionString,
             AutomaticRecoveryEnabled = true,

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
@@ -33,7 +33,7 @@ public class RabbitMQHealthCheck : IHealthCheck
             UseBackgroundThreadsForIO = true,
         };
 
-        if (ssl!= null)
+        if (ssl != null)
             ((ConnectionFactory)_factory).Ssl = ssl;
     }
 

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
@@ -25,18 +25,6 @@ public class RabbitMQHealthCheck : IHealthCheck
         }
     }
 
-    [Obsolete("Please provide RabbitMQHealthCheckOptions")]
-    public RabbitMQHealthCheck(IConnection connection) : this(new RabbitMQHealthCheckOptions { Connection = connection })
-    { }
-
-    [Obsolete("Please provide RabbitMQHealthCheckOptions")]
-    public RabbitMQHealthCheck(IConnectionFactory factory) : this(new RabbitMQHealthCheckOptions { ConnectionFactory = factory })
-    { }
-
-    [Obsolete("Please provide RabbitMQHealthCheckOptions")]
-    public RabbitMQHealthCheck(Uri rabbitConnectionString, SslOption? ssl) : this(new RabbitMQHealthCheckOptions { ConnectionUri = rabbitConnectionString, Ssl = ssl })
-    { }
-
     /// <inheritdoc />
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheck.cs
@@ -9,22 +9,22 @@ namespace HealthChecks.RabbitMQ;
 /// </summary>
 public class RabbitMQHealthCheck : IHealthCheck
 {
-    private static readonly ConcurrentDictionary<RabbitMQOptions, IConnection> _connections = new();
+    private static readonly ConcurrentDictionary<RabbitMQHealthCheckOptions, IConnection> _connections = new();
 
     private IConnection? _connection;
     private readonly IConnectionFactory? _factory;
-    private readonly RabbitMQOptions _options;
+    private readonly RabbitMQHealthCheckOptions _options;
 
     public RabbitMQHealthCheck(IConnection connection)
     {
         _connection = Guard.ThrowIfNull(connection);
-        _options = new RabbitMQOptions(new Uri(connection.Endpoint.ToString()));
+        _options = new RabbitMQHealthCheckOptions(new Uri(connection.Endpoint.ToString()));
     }
 
     public RabbitMQHealthCheck(IConnectionFactory factory)
     {
         _factory = Guard.ThrowIfNull(factory);
-        _options = new RabbitMQOptions(factory.Uri);
+        _options = new RabbitMQHealthCheckOptions(factory.Uri);
     }
 
     public RabbitMQHealthCheck(Uri rabbitConnectionString, SslOption? ssl)
@@ -35,7 +35,7 @@ public class RabbitMQHealthCheck : IHealthCheck
             AutomaticRecoveryEnabled = true,
             UseBackgroundThreadsForIO = true,
         };
-        _options = new RabbitMQOptions(rabbitConnectionString);
+        _options = new RabbitMQHealthCheckOptions(rabbitConnectionString);
 
         if (ssl != null)
         {

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheckOptions.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheckOptions.cs
@@ -7,11 +7,29 @@ namespace HealthChecks.RabbitMQ;
 /// </summary>
 public class RabbitMQHealthCheckOptions
 {
-    public Uri Uri { get; set; }
-    public SslOption? Ssl { get; set; }
+    /// <summary>
+    /// An already created connection to RabbitMQ.
+    /// </summary>
+    public IConnection? Connection { get; set; }
 
-    public RabbitMQHealthCheckOptions(Uri uri)
-    {
-        Uri = uri;
-    }
+    /// <summary>
+    /// A connection factory for RabbitMQ.
+    /// </summary>
+    public IConnectionFactory? ConnectionFactory { get; set; }
+
+    /// <summary>
+    /// An Uri representing a  connection string for RabbitMQ.
+    /// </summary>
+    /// <remarks>
+    /// Can be used in conjunction with the <see cref="SslOption"/> property.
+    /// </remarks>
+    public Uri? ConnectionUri { get; set; }
+
+    /// <summary>
+    /// The SSL options for a connection string.
+    /// </summary>
+    /// <remarks>
+    /// Must be used in conjunction with the <see cref="ConnectionUri"/> property.
+    /// </remarks>
+    public SslOption? Ssl { get; set; }
 }

--- a/src/HealthChecks.Rabbitmq/RabbitMQHealthCheckOptions.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQHealthCheckOptions.cs
@@ -5,12 +5,12 @@ namespace HealthChecks.RabbitMQ;
 /// <summary>
 /// Options for <see cref="RabbitMQHealthCheck"/>.
 /// </summary>
-public class RabbitMQOptions
+public class RabbitMQHealthCheckOptions
 {
     public Uri Uri { get; set; }
     public SslOption? Ssl { get; set; }
 
-    public RabbitMQOptions(Uri uri)
+    public RabbitMQHealthCheckOptions(Uri uri)
     {
         Uri = uri;
     }

--- a/src/HealthChecks.Rabbitmq/RabbitMQOptions.cs
+++ b/src/HealthChecks.Rabbitmq/RabbitMQOptions.cs
@@ -1,0 +1,17 @@
+using RabbitMQ.Client;
+
+namespace HealthChecks.RabbitMQ;
+
+/// <summary>
+/// Options for <see cref="RabbitMQHealthCheck"/>.
+/// </summary>
+public class RabbitMQOptions
+{
+    public Uri Uri { get; set; }
+    public SslOption? Ssl { get; set; }
+
+    public RabbitMQOptions(Uri uri)
+    {
+        Uri = uri;
+    }
+}

--- a/test/HealthChecks.RabbitMQ.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.RabbitMQ.Tests/DependencyInjection/RegistrationTests.cs
@@ -20,11 +20,6 @@ namespace HealthChecks.RabbitMQ.Tests.DependencyInjection
 
             registration.Name.ShouldBe(DEFAULT_CHECK_NAME);
             check.ShouldBeOfType<RabbitMQHealthCheck>();
-
-            ((RabbitMQHealthCheck)check).Dispose();
-            var result = check.CheckHealthAsync(new HealthCheckContext { Registration = new HealthCheckRegistration("", check, null, null) }).Result;
-            result.Status.ShouldBe(HealthStatus.Unhealthy);
-            result.Exception!.GetType().ShouldBe(typeof(ObjectDisposedException));
         }
 
         [Fact]
@@ -44,11 +39,6 @@ namespace HealthChecks.RabbitMQ.Tests.DependencyInjection
 
             registration.Name.ShouldBe(customCheckName);
             check.ShouldBeOfType<RabbitMQHealthCheck>();
-
-            ((RabbitMQHealthCheck)check).Dispose();
-            var result = check.CheckHealthAsync(new HealthCheckContext { Registration = new HealthCheckRegistration("", check, null, null) }).Result;
-            result.Status.ShouldBe(HealthStatus.Unhealthy);
-            result.Exception!.GetType().ShouldBe(typeof(ObjectDisposedException));
         }
 
         [Fact]

--- a/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
+++ b/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
@@ -249,8 +249,8 @@ namespace HealthChecks.RabbitMQ.Tests.Functional
                 .ConfigureServices(services =>
                 {
                     services.AddHealthChecks()
-                     .AddRabbitMQ(rabbitConnectionString: connectionString1, name: "rabbitmq1")
-                     .AddRabbitMQ(rabbitConnectionString: connectionString2, name: "rabbitmq2");
+                        .AddRabbitMQ(rabbitConnectionString: connectionString1, name: "rabbitmq1")
+                        .AddRabbitMQ(rabbitConnectionString: connectionString2, name: "rabbitmq2");
                 })
                 .Configure(app =>
                 {

--- a/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
+++ b/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
@@ -266,8 +266,8 @@ namespace HealthChecks.RabbitMQ.Tests.Functional
 
             using var server = new TestServer(webHostBuilder);
 
-            var response1 = await server.CreateRequest($"/health1").GetAsync().ConfigureAwait(false);
-            var response2 = await server.CreateRequest($"/health2").GetAsync().ConfigureAwait(false);
+            var response1 = await server.CreateRequest("/health1").GetAsync().ConfigureAwait(false);
+            var response2 = await server.CreateRequest("/health2").GetAsync().ConfigureAwait(false);
 
             response1.StatusCode.ShouldBe(HttpStatusCode.OK);
             response2.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);

--- a/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
+++ b/test/HealthChecks.RabbitMQ.Tests/Functional/RabbitHealthCheckTests.cs
@@ -238,5 +238,39 @@ namespace HealthChecks.RabbitMQ.Tests.Functional
 
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
+
+        [Fact]
+        public async Task two_rabbitmq_health_check()
+        {
+            var connectionString1 = "amqp://admin:password@localhost:5672/%2f";
+            var connectionString2 = "amqp://localhost:6672/";
+
+            var webHostBuilder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                     .AddRabbitMQ(rabbitConnectionString: connectionString1, name: "rabbitmq1")
+                     .AddRabbitMQ(rabbitConnectionString: connectionString2, name: "rabbitmq2");
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health1", new HealthCheckOptions
+                    {
+                        Predicate = r => r.Name.Equals("rabbitmq1")
+                    });
+                    app.UseHealthChecks("/health2", new HealthCheckOptions
+                    {
+                        Predicate = r => r.Name.Equals("rabbitmq2")
+                    });
+                });
+
+            using var server = new TestServer(webHostBuilder);
+
+            var response1 = await server.CreateRequest($"/health1").GetAsync().ConfigureAwait(false);
+            var response2 = await server.CreateRequest($"/health2").GetAsync().ConfigureAwait(false);
+
+            response1.StatusCode.ShouldBe(HttpStatusCode.OK);
+            response2.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        }
     }
 }

--- a/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
+++ b/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
@@ -7,6 +7,12 @@ namespace HealthChecks.RabbitMQ
         public RabbitMQHealthCheck(System.Uri rabbitConnectionString, RabbitMQ.Client.SslOption? ssl) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    public class RabbitMQOptions
+    {
+        public RabbitMQOptions(System.Uri uri) { }
+        public RabbitMQ.Client.SslOption? Ssl { get; set; }
+        public System.Uri Uri { get; set; }
+    }
 }
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
+++ b/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
@@ -2,16 +2,22 @@ namespace HealthChecks.RabbitMQ
 {
     public class RabbitMQHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
+        public RabbitMQHealthCheck(HealthChecks.RabbitMQ.RabbitMQHealthCheckOptions options) { }
+        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
         public RabbitMQHealthCheck(RabbitMQ.Client.IConnection connection) { }
+        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
         public RabbitMQHealthCheck(RabbitMQ.Client.IConnectionFactory factory) { }
+        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
         public RabbitMQHealthCheck(System.Uri rabbitConnectionString, RabbitMQ.Client.SslOption? ssl) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class RabbitMQHealthCheckOptions
     {
-        public RabbitMQOptions(System.Uri uri) { }
+        public RabbitMQHealthCheckOptions() { }
+        public RabbitMQ.Client.IConnection? Connection { get; set; }
+        public RabbitMQ.Client.IConnectionFactory? ConnectionFactory { get; set; }
+        public System.Uri? ConnectionUri { get; set; }
         public RabbitMQ.Client.SslOption? Ssl { get; set; }
-        public System.Uri Uri { get; set; }
     }
 }
 namespace Microsoft.Extensions.DependencyInjection

--- a/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
+++ b/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
@@ -7,7 +7,7 @@ namespace HealthChecks.RabbitMQ
         public RabbitMQHealthCheck(System.Uri rabbitConnectionString, RabbitMQ.Client.SslOption? ssl) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public class RabbitMQOptions
+    public class RabbitMQHealthCheckOptions
     {
         public RabbitMQOptions(System.Uri uri) { }
         public RabbitMQ.Client.SslOption? Ssl { get; set; }

--- a/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
+++ b/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
@@ -1,13 +1,11 @@
 namespace HealthChecks.RabbitMQ
 {
-    public class RabbitMQHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck, System.IDisposable
+    public class RabbitMQHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
         public RabbitMQHealthCheck(RabbitMQ.Client.IConnection connection) { }
         public RabbitMQHealthCheck(RabbitMQ.Client.IConnectionFactory factory) { }
         public RabbitMQHealthCheck(System.Uri rabbitConnectionString, RabbitMQ.Client.SslOption? ssl) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
     }
 }
 namespace Microsoft.Extensions.DependencyInjection

--- a/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
+++ b/test/HealthChecks.RabbitMQ.Tests/HealthChecks.Rabbitmq.approved.txt
@@ -3,12 +3,6 @@ namespace HealthChecks.RabbitMQ
     public class RabbitMQHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
         public RabbitMQHealthCheck(HealthChecks.RabbitMQ.RabbitMQHealthCheckOptions options) { }
-        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
-        public RabbitMQHealthCheck(RabbitMQ.Client.IConnection connection) { }
-        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
-        public RabbitMQHealthCheck(RabbitMQ.Client.IConnectionFactory factory) { }
-        [System.Obsolete("Please provide RabbitMQHealthCheckOptions")]
-        public RabbitMQHealthCheck(System.Uri rabbitConnectionString, RabbitMQ.Client.SslOption? ssl) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class RabbitMQHealthCheckOptions


### PR DESCRIPTION
**What this PR does / why we need it**:
As emerged from #764, it is now impossible to obtain reports from two (or more) RabbitMQ connections. This is due to the fact RabbitMQ connections are singleton instantiated, and so the last added connection overrides the previous ones.

This PR solves this by changing singleton instantiation by lazy initialization. A detailed description is available in a comment on the previous cited issue: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/764#issuecomment-1406389241 

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #764 

**Special notes for your reviewer**:

Another possibility would be using the multiton pattern. It would be feasible with connections strings, but no so easy with connection factories. 

**Does this PR introduce a user-facing change?**:

No: the old behavior of registering one health check for RabbitMQ is preserved. This only allows registering more than one health report.  
If someone already registered more than one health check report for RabbitMQ, he will notice a different behavior. This is not important since he was doing something which was not supported by this library, and indeed he was probably not obtaining what he meant to obtain. In this scenario this PR also solves these misunderstandings.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation (not needed*)
- [ ] Provided sample for the feature (not needed)

* Perhaps it would be better to document health checks registers which can be used only once, instead of documenting those which can be added more times. This because it is perfectly valid to call the add extension method more times, and one would normally expect this to add another health check, and not overriding the previous one.