### PR TITLE
Introduce support for timing out redis healthcheck

### DIFF
--- a/src/HealthChecks.Redis/RedisHealthCheck.cs
+++ b/src/HealthChecks.Redis/RedisHealthCheck.cs
@@ -81,6 +81,7 @@ public class RedisHealthCheck : IHealthCheck
         }
     }
 
+    // Remove when https://github.com/StackExchange/StackExchange.Redis/issues/1039 is done
     private static async Task<ConnectionMultiplexer> TimeoutAsync(Task<ConnectionMultiplexer> task, CancellationToken cancellationToken)
     {
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -85,19 +85,19 @@ namespace HealthChecks.Redis.Tests.Functional
         public async Task be_unhealthy_if_redis_is_not_available_within_specified_timeout()
         {
             var webHostBuilder = new WebHostBuilder()
-             .ConfigureServices(services =>
-             {
-                 services.AddHealthChecks()
-                     .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
+                .ConfigureServices(services =>
+                {
+                    services.AddHealthChecks()
+                        .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
 
-             })
-             .Configure(app =>
-             {
-                 app.UseHealthChecks("/health", new HealthCheckOptions
-                 {
-                     Predicate = r => r.Tags.Contains("redis")
-                 });
-             });
+                })
+                .Configure(app =>
+                {
+                    app.UseHealthChecks("/health", new HealthCheckOptions
+                    {
+                        Predicate = r => r.Tags.Contains("redis")
+                    });
+                });
 
             using var server = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -95,7 +95,7 @@ namespace HealthChecks.Redis.Tests.Functional
                     app.UseHealthChecks("/health", new HealthCheckOptions
                     {
                         Predicate = r => r.Tags.Contains("redis"),
-                        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse,
+                        ResponseWriter = HealthChecks.UI.Client.UIResponseWriter.WriteHealthCheckUIResponse,
                     });
                 });
 

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -88,7 +88,8 @@ namespace HealthChecks.Redis.Tests.Functional
              .ConfigureServices(services =>
              {
                  services.AddHealthChecks()
-                  .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
+                     .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
+
              })
              .Configure(app =>
              {

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -80,5 +80,29 @@ namespace HealthChecks.Redis.Tests.Functional
 
             response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
         }
+
+        [Fact]
+        public async Task be_unhealthy_if_redis_is_not_available_within_specified_timeout()
+        {
+            var webHostBuilder = new WebHostBuilder()
+             .ConfigureServices(services =>
+             {
+                 services.AddHealthChecks()
+                  .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
+             })
+             .Configure(app =>
+             {
+                 app.UseHealthChecks("/health", new HealthCheckOptions
+                 {
+                     Predicate = r => r.Tags.Contains("redis")
+                 });
+             });
+
+            using var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"/health").GetAsync().ConfigureAwait(false);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        }
     }
 }

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -103,6 +103,7 @@ namespace HealthChecks.Redis.Tests.Functional
             var response = await server.CreateRequest($"/health").GetAsync().ConfigureAwait(false);
 
             response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+            (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).ShouldContain("Healthcheck timed out");
         }
     }
 }

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -89,7 +89,6 @@ namespace HealthChecks.Redis.Tests.Functional
                 {
                     services.AddHealthChecks()
                         .AddRedis("nonexistinghost:6379,allowAdmin=true,connectRetry=2147483647", tags: new string[] { "redis" }, timeout: TimeSpan.FromSeconds(2));
-
                 })
                 .Configure(app =>
                 {

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -94,7 +94,8 @@ namespace HealthChecks.Redis.Tests.Functional
                 {
                     app.UseHealthChecks("/health", new HealthCheckOptions
                     {
-                        Predicate = r => r.Tags.Contains("redis")
+                        Predicate = r => r.Tags.Contains("redis"),
+                        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse,
                     });
                 });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Add support for respecting the cancellation token provided by the healthcheck

**Which issue(s) this PR fixes**: #1658 

Please reference the issue this PR will close: #1658 

**Special notes for your reviewer**:
I only handled the case with a new connection not respecting the healthcheck timeout. 
I'm not sure how I would write an integration test for the case where the connection is made but the rest of the commands time out. So I would prefer to add only the code I can test for. 

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
