### PR TITLE
Optimize EventStore gRPC HealthCheck

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -17,7 +17,7 @@
     <HealthCheckDocumentDb>7.0.0</HealthCheckDocumentDb>
     <HealthCheckDynamoDb>7.0.0</HealthCheckDynamoDb>
     <HealthCheckElasticsearch>7.0.0</HealthCheckElasticsearch>
-    <HealthCheckEventStoregRPC>7.0.1</HealthCheckEventStoregRPC>
+    <HealthCheckEventStoregRPC>7.0.0</HealthCheckEventStoregRPC>
     <HealthCheckEventStore>7.0.0</HealthCheckEventStore>
     <HealthCheckGremlin>7.0.0</HealthCheckGremlin>
     <HealthCheckHangfire>7.0.0</HealthCheckHangfire>

--- a/build/versions.props
+++ b/build/versions.props
@@ -17,7 +17,7 @@
     <HealthCheckDocumentDb>7.0.0</HealthCheckDocumentDb>
     <HealthCheckDynamoDb>7.0.0</HealthCheckDynamoDb>
     <HealthCheckElasticsearch>7.0.0</HealthCheckElasticsearch>
-    <HealthCheckEventStoregRPC>7.0.0</HealthCheckEventStoregRPC>
+    <HealthCheckEventStoregRPC>7.0.1</HealthCheckEventStoregRPC>
     <HealthCheckEventStore>7.0.0</HealthCheckEventStore>
     <HealthCheckGremlin>7.0.0</HealthCheckGremlin>
     <HealthCheckHangfire>7.0.0</HealthCheckHangfire>


### PR DESCRIPTION
Replaced subscription to the $all stream with a simple read, which is more performant.

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
This PR optimizes the EventStore gRPC HealthCheck by utilizing a faster method for verifying a healthy connection.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature

Link to the issue that lead to this change: https://github.com/EventStore/EventStore-Client-Dotnet/issues/241