### PR TITLE
Allow to add config.json to docker

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Program.cs
+++ b/build/docker-images/HealthChecks.UI.Image/Program.cs
@@ -23,6 +23,7 @@ namespace HealthChecks.UI.Image
                         {
                             builder.UseAzureAppConfiguration();
                         }
+                        builder.AddJsonFile("/config/config.json", true);
 
                     })
                     .UseStartup<Startup>();

--- a/doc/ui-docker.md
+++ b/doc/ui-docker.md
@@ -123,6 +123,8 @@ services:
       - Logging:LogLevel:HealthChecks=Debug
     ports:
       - 5000:80
+    volumes:
+      - config:/config
   sqlserver:
     image: mcr.microsoft.com/mssql/server
     environment:
@@ -136,4 +138,6 @@ services:
       timeout: 3s
       retries: 10
       start_period: 10s
+volumes:
+  config:
 ```


### PR DESCRIPTION
By allowing the user to map a config.json file from outside the docker container into the application the user can configure the application using a json file instead of environment variables


    - 'HealthChecksUI:HealthChecks:0:Name=HTTP-Api-Basic'
    - 'HealthChecksUI:HealthChecks:0:Uri=http://host.docker.internal:5001/health'

He can write the classical way like in appsettings.json:

    {
      "HealthChecksUI": {
        "HealthChecks": [
          {
            "Name": "HTTP-Api-Basic",
            "Uri": "http://host.docker.internal:5001/health"
          }
        ],
        ...
    }

Note: this PR is untested, since the docker image will not compile on my maschine regarding some old node version required for this to buid.