### PR TITLE
Added Microsoft.Bcl.AsyncInterfaces to allow EventStore.gRPC to work on net6.0

### DIFF
--- a/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
+++ b/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
+++ b/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackageTags>$(PackageTags);EventStore;gRPC</PackageTags>
     <Description>HealthChecks.EventStore.gRPC is the health check package for EventStore, using the gRPC client.</Description>
     <VersionPrefix>$(HealthCheckEventStoregRPC)</VersionPrefix>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' != 'net7.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
+++ b/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' != 'net7.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added Microsoft.Bcl.AsyncInterfaces to allow EventStore.gRPC to work on net6.0

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
The 7.0.0 versions of EventStore gRPC do not work on net6.0 at the moment: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/1692#issuecomment-1441406963

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
