### PR TITLE
Fix SMTP health checks not respecting timeout

### DIFF
--- a/src/HealthChecks.Network/Core/SmtpConnection.cs
+++ b/src/HealthChecks.Network/Core/SmtpConnection.cs
@@ -26,9 +26,9 @@ internal class SmtpConnection : MailConnection
         ComputeDefaultValues();
     }
 
-    public new async Task<bool> ConnectAsync()
+    public new async Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
     {
-        await base.ConnectAsync().ConfigureAwait(false);
+        await base.ConnectAsync(cancellationToken).ConfigureAwait(false);
         var result = await ExecuteCommand(SmtpCommands.EHLO(Host)).ConfigureAwait(false);
         return result.Contains(SmtpResponse.ACTION_OK);
     }

--- a/src/HealthChecks.Network/SmtpHealthCheck.cs
+++ b/src/HealthChecks.Network/SmtpHealthCheck.cs
@@ -20,7 +20,7 @@ public class SmtpHealthCheck : IHealthCheck
         {
             using var smtpConnection = new SmtpConnection(_options);
 
-            if (await smtpConnection.ConnectAsync().ConfigureAwait(false))
+            if (await smtpConnection.ConnectAsync().WithCancellationTokenAsync(cancellationToken).ConfigureAwait(false))
             {
                 if (_options.AccountOptions.Login)
                 {

--- a/src/HealthChecks.Network/SmtpHealthCheck.cs
+++ b/src/HealthChecks.Network/SmtpHealthCheck.cs
@@ -1,5 +1,4 @@
 using HealthChecks.Network.Core;
-using HealthChecks.Network.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.Network;
@@ -20,13 +19,13 @@ public class SmtpHealthCheck : IHealthCheck
         {
             using var smtpConnection = new SmtpConnection(_options);
 
-            if (await smtpConnection.ConnectAsync().WithCancellationTokenAsync(cancellationToken).ConfigureAwait(false))
+            if (await smtpConnection.ConnectAsync(cancellationToken).ConfigureAwait(false))
             {
                 if (_options.AccountOptions.Login)
                 {
                     var (user, password) = _options.AccountOptions.Account;
 
-                    if (!await smtpConnection.AuthenticateAsync(user, password).WithCancellationTokenAsync(cancellationToken).ConfigureAwait(false))
+                    if (!await smtpConnection.AuthenticateAsync(user, password).ConfigureAwait(false))
                         return new HealthCheckResult(context.Registration.FailureStatus, description: $"Error login to smtp server {_options.Host}:{_options.Port} with configured credentials");
                 }
 

--- a/test/HealthChecks.Network.Tests/Functional/SmtpHealthCheckTests.cs
+++ b/test/HealthChecks.Network.Tests/Functional/SmtpHealthCheckTests.cs
@@ -248,13 +248,12 @@ public class smtp_healthcheck_should
         var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
-
     }
 
     [Fact]
     public async Task respect_configured_timeout_and_throw_operation_cancelled_exception()
     {
-        var options = new SmtpHealthCheckOptions() { Host = "invalid", Port = 25 };
+        var options = new SmtpHealthCheckOptions() { Host = "github.com", Port = 25 };
         options.LoginWith("user", "pass");
 
         var smtpHealthCheck = new SmtpHealthCheck(options);
@@ -267,7 +266,7 @@ public class smtp_healthcheck_should
                 failureStatus: HealthStatus.Degraded,
                 null,
                 timeout: null)
-        }, new CancellationTokenSource(TimeSpan.FromSeconds(2)).Token).ConfigureAwait(false);
+        }, new CancellationTokenSource(TimeSpan.FromMilliseconds(100)).Token).ConfigureAwait(false);
 
         result.Exception.ShouldBeOfType<OperationCanceledException>();
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
The cancellation token in an SMTP handshake will be passed to the initial TCP connection as well, making it respect a given timeout.
It seems like this has already been an issue for IMAP connections, as there is a [Test](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/a3c8294bd4edbd1658152971fd8aac4f12e4f01f/test/HealthChecks.Network.Tests/Functional/ImapHealthCheckTests.cs#L280) and the same [Fix](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/a3c8294bd4edbd1658152971fd8aac4f12e4f01f/src/HealthChecks.Network/ImapHealthCheck.cs#L30) for that type of checks.

**Which issue(s) this PR fixes**:
#1738

**Does this PR introduce a user-facing change?**
At least I'm not aware of any.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
