### PR TITLE
use existing connection multiplexer for redis

### DIFF
--- a/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using HealthChecks.Redis;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -60,6 +61,61 @@ public static class RedisHealthCheckBuilderExtensions
         return builder.Add(new HealthCheckRegistration(
            name ?? NAME,
            sp => new RedisHealthCheck(connectionStringFactory(sp)),
+           failureStatus,
+           tags,
+           timeout));
+    }
+
+    /// <summary>
+    /// Add a health check for Redis services.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="connectionMultiplexer">The Redis connection to be used.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'redis' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddRedis(
+        this IHealthChecksBuilder builder,
+        IConnectionMultiplexer connectionMultiplexer,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.AddRedis(_ => connectionMultiplexer, name, failureStatus, tags, timeout);
+    }
+
+    /// <summary>
+    /// Add a health check for Redis services.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="connectionMultiplexerFactory">A factory to build the Redis connection to use.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'redis' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddRedis(
+        this IHealthChecksBuilder builder,
+        Func<IServiceProvider, IConnectionMultiplexer> connectionMultiplexerFactory,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        Guard.ThrowIfNull(connectionMultiplexerFactory);
+
+        return builder.Add(new HealthCheckRegistration(
+           name ?? NAME,
+           sp => new RedisHealthCheck(connectionMultiplexerFactory(sp)),
            failureStatus,
            tags,
            timeout));

--- a/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using StackExchange.Redis;
 
 namespace HealthChecks.Redis.Tests.DependencyInjection;
@@ -65,12 +65,12 @@ public class redis_registration_should
     [Fact]
     public void add_named_health_check_with_connection_multiplexer_when_properly_configured()
     {
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
 
         var services = new ServiceCollection();
 
         services.AddHealthChecks()
-            .AddRedis(connectionMultiplexerMock.Object, name: "my-redis");
+            .AddRedis(connectionMultiplexer, name: "my-redis");
 
         using var serviceProvider = services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -85,10 +85,10 @@ public class redis_registration_should
     [Fact]
     public void add_health_check_with_connection_multiplexer_when_properly_configured()
     {
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
         var services = new ServiceCollection();
 
-        services.AddSingleton(connectionMultiplexerMock.Object);
+        services.AddSingleton(connectionMultiplexer);
         var factoryCalled = false;
 
         services.AddHealthChecks()

--- a/test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj
+++ b/test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.18.4" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.Redis\HealthChecks.Redis.csproj" />
   </ItemGroup>
 

--- a/test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj
+++ b/test/HealthChecks.Redis.Tests/HealthChecks.Redis.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.Redis\HealthChecks.Redis.csproj" />
   </ItemGroup>
 

--- a/test/HealthChecks.Redis.Tests/HealthChecks.Redis.approved.txt
+++ b/test/HealthChecks.Redis.Tests/HealthChecks.Redis.approved.txt
@@ -2,6 +2,7 @@ namespace HealthChecks.Redis
 {
     public class RedisHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
+        public RedisHealthCheck(StackExchange.Redis.IConnectionMultiplexer connectionMultiplexer) { }
         public RedisHealthCheck(string redisConnectionString) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
@@ -10,6 +11,8 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class RedisHealthCheckBuilderExtensions
     {
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddRedis(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, StackExchange.Redis.IConnectionMultiplexer connectionMultiplexer, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddRedis(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, StackExchange.Redis.IConnectionMultiplexer> connectionMultiplexerFactory, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddRedis(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, string> connectionStringFactory, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddRedis(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string redisConnectionString, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
According to documentation Redis connection should be reused across application.

**Which issue(s) this PR fixes**:
#1773 

Please reference the issue this PR will close: 
#_[1773]_

**Does this PR introduce a user-facing change?**:
Yes.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ x] Code compiles correctly
- [ x] Created/updated tests
- [ x] Unit tests passing
- [ x] End-to-end tests passing

