### PR TITLE
Fixes #716 ui settings api query failing.

### DIFF
--- a/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/HealthChecks.UI/Extensions/ApplicationBuilderExtensions.cs
@@ -28,12 +28,11 @@ namespace Microsoft.AspNetCore.Builder
             {
                 appBuilder
                 .UseMiddleware<UIApiRequestLimitingMidleware>()
+                .Map($"/{Keys.HEALTHCHECKSUI_SETTINGS_PATH}", appBuilder => appBuilder.UseMiddleware<UISettingsMiddleware>())
                 .UseMiddleware<UIApiEndpointMiddleware>();
             });
 
             app.Map(options.WebhookPath, appBuilder => appBuilder.UseMiddleware<UIWebHooksApiMiddleware>());
-
-            app.Map($"{options.ApiPath}/{Keys.HEALTHCHECKSUI_SETTINGS_PATH}", appBuilder => appBuilder.UseMiddleware<UISettingsMiddleware>());
 
             new UIResourcesMapper(
                 new UIEmbeddedResourcesReader(embeddedResourcesAssembly))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
When using the ApplicationBuilder.UseHealthChecksUI, the ui settings middleware is never executed.  The ui api endpoint middleware is currently handling all requests to "healthchecks-api/*".  Moving the mapping of the ui settings middleware to before the ui api endpoint middleware mapping allows the ui settings to handle requests to "healthchecks-api/ui-settings".

This does put the ui-settings behind the request limiter, if that was not the intention then the ui settings mapping should happen before the api path is mapped.
**Which issue(s) this PR fixes**: 
716

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
no

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
