### PR TITLE
Try fix #1712

### DIFF
--- a/.github/workflows/healthchecks_ui_ci.yml
+++ b/.github/workflows/healthchecks_ui_ci.yml
@@ -103,6 +103,8 @@ jobs:
 
       - name: Build UI
         run: dotnet build --no-restore ./src/HealthChecks.UI/HealthChecks.UI.csproj
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
       - name: Build UI.Client
         run: dotnet build --no-restore ./src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj
       - name: Build UI.Core


### PR DESCRIPTION
For issue https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1712, I found that there are two ways that may work
1. Modify script in [src/HealthChecks.UI/package.json](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.UI/package.json):
use this script
`
"build": "export NODE_OPTIONS=--openssl-legacy-provider && npm run build:dll && npm run build:prod"
`
to replace the origin one
`
"build": "npm run build:dll && npm run build:prod"
`

2. Add environment parameter in [.github/workflows/healthchecks_ui_ci.yml](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/.github/workflows/healthchecks_ui_ci.yml)

I personally prefer the second one because the first approach hides an environment parameter inside a script, it might be very hard to maintain, So I took the second one in this PR.

This may not be the final answer, any advice would be greatly appreciated.