### PR TITLE
Feature - seq publisher- expose raw events to options

### DIFF
--- a/src/HealthChecks.Publisher.Seq/RawEvent.cs
+++ b/src/HealthChecks.Publisher.Seq/RawEvent.cs
@@ -1,0 +1,14 @@
+namespace HealthChecks.Publisher.Seq;
+
+public class RawEvent
+{
+    public DateTimeOffset Timestamp { get; set; }
+
+    public string Level { get; set; } = null!;
+
+    public string MessageTemplate { get; set; } = null!;
+
+    public string RawReport { get; set; } = null!; //TODO: remove?
+
+    public Dictionary<string, object?> Properties { get; set; } = null!;
+}

--- a/src/HealthChecks.Publisher.Seq/RawEvents.cs
+++ b/src/HealthChecks.Publisher.Seq/RawEvents.cs
@@ -1,0 +1,6 @@
+namespace HealthChecks.Publisher.Seq;
+
+public class RawEvents
+{
+    public RawEvent[] Events { get; set; } = null!;
+}

--- a/src/HealthChecks.Publisher.Seq/SeqOptions.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqOptions.cs
@@ -9,4 +9,10 @@ public class SeqOptions
     public string? ApiKey { get; set; }
 
     public SeqInputLevel DefaultInputLevel { get; set; }
+
+    /// <summary>
+    /// An optional action executed before the metrics are pushed to seq.
+    /// Useful to push additional static properties to seq.
+    /// </summary>
+    public Action<RawEvents>? Configure { get; set; } = null;
 }

--- a/src/HealthChecks.Publisher.Seq/SeqOptions.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqOptions.cs
@@ -11,8 +11,8 @@ public class SeqOptions
     public SeqInputLevel DefaultInputLevel { get; set; }
 
     /// <summary>
-    /// An optional action executed before the metrics are pushed to seq.
-    /// Useful to push additional static properties to seq.
+    /// An optional action executed before the metrics are pushed to Seq.
+    /// Useful to push additional static properties to Seq.
     /// </summary>
     public Action<RawEvents>? Configure { get; set; } = null;
 }

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -57,6 +57,8 @@ public class SeqPublisher : IHealthCheckPublisher
             }
         };
 
+        _options.Configure?.Invoke(events);
+
         await PushMetricsAsync(JsonConvert.SerializeObject(events), cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
+++ b/src/HealthChecks.Publisher.Seq/SeqPublisher.cs
@@ -100,21 +100,4 @@ public class SeqPublisher : IHealthCheckPublisher
         return uriBuilder.Uri;
     }
 
-    private class RawEvents
-    {
-        public RawEvent[] Events { get; set; } = null!;
-    }
-
-    private class RawEvent
-    {
-        public DateTimeOffset Timestamp { get; set; }
-
-        public string Level { get; set; } = null!;
-
-        public string MessageTemplate { get; set; } = null!;
-
-        public string RawReport { get; set; } = null!; //TODO: remove?
-
-        public Dictionary<string, object?> Properties { get; set; } = null!;
-    }
 }

--- a/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
+++ b/test/HealthChecks.Publisher.Seq.Tests/Functional/SeqPublisherTests.cs
@@ -72,12 +72,7 @@ public class seq_publisher_should
 
         handler.Request.ShouldNotBeNull();
         handler.Request.Content.ShouldNotBeNull();
-
-        if (handler.StringContent != null)
-        {
-            string content = handler.StringContent;
-            content.ShouldContain("\"Application\":\"MyApplication\"");
-        }
+        handler.StringContent.ShouldNotBeNull().ShouldContain("\"Application\":\"MyApplication\"");
     }
 
     private class MockClientHandler : HttpClientHandler

--- a/test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.approved.txt
+++ b/test/HealthChecks.Publisher.Seq.Tests/HealthChecks.Publisher.Seq.approved.txt
@@ -1,5 +1,19 @@
 namespace HealthChecks.Publisher.Seq
 {
+    public class RawEvent
+    {
+        public RawEvent() { }
+        public string Level { get; set; }
+        public string MessageTemplate { get; set; }
+        public System.Collections.Generic.Dictionary<string, object?> Properties { get; set; }
+        public string RawReport { get; set; }
+        public System.DateTimeOffset Timestamp { get; set; }
+    }
+    public class RawEvents
+    {
+        public RawEvents() { }
+        public HealthChecks.Publisher.Seq.RawEvent[] Events { get; set; }
+    }
     public enum SeqInputLevel
     {
         Information = 0,
@@ -25,6 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public SeqOptions() { }
         public string? ApiKey { get; set; }
+        public System.Action<HealthChecks.Publisher.Seq.RawEvents>? Configure { get; set; }
         public HealthChecks.Publisher.Seq.SeqInputLevel DefaultInputLevel { get; set; }
         public string Endpoint { get; set; }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
It adds the ability to configure an action defined in SeqOptions, which enables to add/modify the properties of RawEvents which are sent to Seq.
This feature would enable users to add contextual information to the health check logs in Seq, which could be helpful for filtering and analyzing health check data across multiple applications or environments.

**Which issue(s) this PR fixes**:
HealthChecks.Publisher.Seq - Add dictionary of additional static properties to SeqPublisherOptions

Please reference the issue this PR will close: #_[issue number]_
#1811

**Special notes for your reviewer**:
It's my very first PR for this project, please let me know if I missed something important.

**Does this PR introduce a user-facing change?**:
Yes, it adds an additional configuration option. But it's backwards compatible.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
