### PR TITLE
Support for using OracleCredential with Oracle HealthCheck

### DIFF
--- a/src/HealthChecks.Oracle/OracleHealthCheck.cs
+++ b/src/HealthChecks.Oracle/OracleHealthCheck.cs
@@ -22,7 +22,9 @@ public class OracleHealthCheck : IHealthCheck
     {
         try
         {
-            using var connection = new OracleConnection(_options.ConnectionString);
+            using var connection = _options.Credential == null
+                ? new OracleConnection(_options.ConnectionString)
+                : new OracleConnection(_options.ConnectionString, _options.Credential);
 
             _options.Configure?.Invoke(connection);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/HealthChecks.Oracle/OracleHealthCheckOptions.cs
+++ b/src/HealthChecks.Oracle/OracleHealthCheckOptions.cs
@@ -15,7 +15,7 @@ public class OracleHealthCheckOptions
     public string ConnectionString { get; set; } = null!;
 
     /// <summary>
-    /// Optional credential to use when connecting to the database.
+    /// Optional credential to use when connecting to the Oracle database.
     /// </summary>
     public OracleCredential? Credential { get; set; }
 

--- a/src/HealthChecks.Oracle/OracleHealthCheckOptions.cs
+++ b/src/HealthChecks.Oracle/OracleHealthCheckOptions.cs
@@ -15,6 +15,11 @@ public class OracleHealthCheckOptions
     public string ConnectionString { get; set; } = null!;
 
     /// <summary>
+    /// Optional credential to use when connecting to the database.
+    /// </summary>
+    public OracleCredential? Credential { get; set; }
+
+    /// <summary>
     /// The query to be executed.
     /// </summary>
     public string CommandText { get; set; } = OracleHealthCheckBuilderExtensions.HEALTH_QUERY;

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Security;
 using HealthChecks.UI.Client;
 using Oracle.ManagedDataAccess.Client;
 

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Security;
 using HealthChecks.UI.Client;
+using Oracle.ManagedDataAccess.Client;
 
 namespace HealthChecks.Oracle.Tests.Functional;
 
@@ -94,6 +96,38 @@ public class oracle_healthcheck_should
                     return connectionString;
 
                 }, tags: new string[] { "oracle" });
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("oracle")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+        using var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+        factoryCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task be_healthy_with_connection_string_and_credential_when_oracle_is_available()
+    {
+        bool factoryCalled = false;
+        string connectionString = "Data Source=localhost:1521/XEPDB1";
+        var password = new NetworkCredential("oracle", "system").SecurePassword;
+        password.MakeReadOnly();
+        var credential = new OracleCredential("system", password);
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddHealthChecks()
+                    .AddOracle(connectionString, tags: new string[] { "oracle" },
+                        configure: options => options.Credential = credential
+                    );
             })
             .Configure(app =>
             {

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -115,7 +115,7 @@ public class oracle_healthcheck_should
     {
         bool factoryCalled = false;
         string connectionString = "Data Source=localhost:1521/XEPDB1";
-        var password = new NetworkCredential("oracle", "system").SecurePassword;
+        var password = new NetworkCredential("system", "oracle").SecurePassword;
         password.MakeReadOnly();
         var credential = new OracleCredential("system", password);
 

--- a/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
+++ b/test/HealthChecks.Oracle.Tests/Functional/OracleHealthCheckTests.cs
@@ -125,7 +125,11 @@ public class oracle_healthcheck_should
                 services
                     .AddHealthChecks()
                     .AddOracle(connectionString, tags: new string[] { "oracle" },
-                        configure: options => options.Credential = credential
+                        configure: options =>
+                        {
+                            factoryCalled = true;
+                            options.Credential = credential;
+                        }
                     );
             })
             .Configure(app =>

--- a/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.approved.txt
+++ b/test/HealthChecks.Oracle.Tests/HealthChecks.Oracle.approved.txt
@@ -11,6 +11,7 @@ namespace HealthChecks.Oracle
         public string CommandText { get; set; }
         public System.Action<Oracle.ManagedDataAccess.Client.OracleConnection>? Configure { get; set; }
         public string ConnectionString { get; set; }
+        public Oracle.ManagedDataAccess.Client.OracleCredential? Credential { get; set; }
         public System.Func<object?, Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult>? HealthCheckResultBuilder { get; set; }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using pooled connections with Oracle, it is necessary to use a singleton OracleCredential.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
It adds a new Credential property to OracleHealthCheckOptions

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
