### PR TITLE
PR To support DbDataSource for Postgresql

### DIFF
--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -1,5 +1,3 @@
-using System.Data.Common;
-using System.Runtime.CompilerServices;
 using HealthChecks.NpgSql;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Npgsql;
@@ -69,7 +67,7 @@ public static class NpgSqlHealthCheckBuilderExtensions
     {
         return builder.AddNpgSql(e => new NpgsqlDataSourceBuilder(connectionStringFactory(e)).Build(), healthQuery, configure, name, failureStatus, tags, timeout);
     }
-    
+
     public static IHealthChecksBuilder AddNpgSql(
         this IHealthChecksBuilder builder,
         Func<IServiceProvider, NpgsqlDataSource> dbDataSourceFactory,

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -68,6 +68,21 @@ public static class NpgSqlHealthCheckBuilderExtensions
         return builder.AddNpgSql(sp => new NpgsqlDataSourceBuilder(connectionStringFactory(sp)).Build(), healthQuery, configure, name, failureStatus, tags, timeout);
     }
 
+    /// <summary>
+    /// Add a health check for Postgres databases.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="dbDataSourceFactory">A factory to build the NpgsqlDataSource to use.</param>
+    /// <param name="healthQuery">The query to be used in check.</param>
+    /// <param name="configure">An optional action to allow additional Npgsql specific configuration.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddNpgSql(
         this IHealthChecksBuilder builder,
         Func<IServiceProvider, NpgsqlDataSource> dbDataSourceFactory,

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class NpgSqlHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        return builder.AddNpgSql(e => new NpgsqlDataSourceBuilder(connectionStringFactory(e)).Build(), healthQuery, configure, name, failureStatus, tags, timeout);
+        return builder.AddNpgSql(sp => new NpgsqlDataSourceBuilder(connectionStringFactory(sp)).Build(), healthQuery, configure, name, failureStatus, tags, timeout);
     }
 
     public static IHealthChecksBuilder AddNpgSql(

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
@@ -12,7 +12,7 @@ public class NpgSqlHealthCheck : IHealthCheck
 
     public NpgSqlHealthCheck(NpgSqlHealthCheckOptions options)
     {
-        Guard.ThrowIfNull(options.ConnectionString, true);
+        Guard.ThrowIfNull(options.DataSource, true);
         Guard.ThrowIfNull(options.CommandText, true);
         _options = options;
     }
@@ -22,7 +22,7 @@ public class NpgSqlHealthCheck : IHealthCheck
     {
         try
         {
-            using var connection = new NpgsqlConnection(_options.ConnectionString);
+            await using var connection = _options.DataSource.CreateConnection();
 
             _options.Configure?.Invoke(connection);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
@@ -11,7 +11,7 @@ public class NpgSqlHealthCheck : IHealthCheck
 
     public NpgSqlHealthCheck(NpgSqlHealthCheckOptions options)
     {
-        Guard.ThrowIfNull(options.DataSource, true);
+        Guard.ThrowIfNull(options.DataSource);
         Guard.ThrowIfNull(options.CommandText, true);
         _options = options;
     }
@@ -21,7 +21,7 @@ public class NpgSqlHealthCheck : IHealthCheck
     {
         try
         {
-            await using var connection = _options.DataSource.CreateConnection();
+            await using var connection = _options.DataSource!.CreateConnection();
 
             _options.Configure?.Invoke(connection);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Npgsql;
 
 namespace HealthChecks.NpgSql;
 

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -10,9 +10,19 @@ namespace HealthChecks.NpgSql;
 public class NpgSqlHealthCheckOptions
 {
     /// <summary>
+    /// The Postgres connection string to be used.
     /// The Postgres data source to be used.
     /// </summary>
-    public NpgsqlDataSource DataSource { get; set; } = null!;
+    public string? ConnectionString
+    {
+        get => DataSource?.ConnectionString;
+        set => DataSource = NpgsqlDataSource.Create(value);
+    }
+
+    /// <summary>
+    /// The Postgres data source to be used.
+    /// </summary>
+    public NpgsqlDataSource? DataSource { get; set; }
 
     /// <summary>
     /// The query to be executed.

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -1,4 +1,3 @@
-using System.Data.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Npgsql;

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Npgsql;
@@ -10,9 +11,9 @@ namespace HealthChecks.NpgSql;
 public class NpgSqlHealthCheckOptions
 {
     /// <summary>
-    /// The Postgres connection string to be used.
+    /// The Postgres data source to be used.
     /// </summary>
-    public string ConnectionString { get; set; } = null!;
+    public NpgsqlDataSource DataSource { get; set; } = null!;
 
     /// <summary>
     /// The query to be executed.

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -11,7 +11,6 @@ public class NpgSqlHealthCheckOptions
 {
     /// <summary>
     /// The Postgres connection string to be used.
-    /// The Postgres data source to be used.
     /// </summary>
     public string? ConnectionString
     {

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -11,6 +11,7 @@ public class NpgSqlHealthCheckOptions
 {
     /// <summary>
     /// The Postgres connection string to be used.
+    /// Use <see cref="DataSource"/> property for advanced configuration.
     /// </summary>
     public string? ConnectionString
     {

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -16,7 +16,7 @@ public class NpgSqlHealthCheckOptions
     public string? ConnectionString
     {
         get => DataSource?.ConnectionString;
-        set => DataSource = NpgsqlDataSource.Create(value);
+        set => DataSource = value is not null ? NpgsqlDataSource.Create(value) : null;
     }
 
     /// <summary>

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -9,7 +9,7 @@ public class npgsql_registration_should
     {
         var services = new ServiceCollection();
         services.AddHealthChecks()
-            .AddNpgSql("connectionstring");
+            .AddNpgSql("Server=localhost");
 
         using var serviceProvider = services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -27,7 +27,7 @@ public class npgsql_registration_should
     {
         var services = new ServiceCollection();
         services.AddHealthChecks()
-            .AddNpgSql("connectionstring", name: "my-npg-1");
+            .AddNpgSql("Server=localhost", name: "my-npg-1");
 
         using var serviceProvider = services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
@@ -48,7 +48,7 @@ public class npgsql_registration_should
             .AddNpgSql(_ =>
             {
                 factoryCalled = true;
-                return "connectionstring";
+                return "Server=localhost";
             }, name: "my-npg-1");
 
         using var serviceProvider = services.BuildServiceProvider();

--- a/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
+++ b/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
@@ -10,7 +10,8 @@ namespace HealthChecks.NpgSql
         public NpgSqlHealthCheckOptions() { }
         public string CommandText { get; set; }
         public System.Action<Npgsql.NpgsqlConnection>? Configure { get; set; }
-        public string ConnectionString { get; set; }
+        public string? ConnectionString { get; set; }
+        public Npgsql.NpgsqlDataSource? DataSource { get; set; }
         public System.Func<object?, Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult>? HealthCheckResultBuilder { get; set; }
     }
 }
@@ -19,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class NpgSqlHealthCheckBuilderExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, HealthChecks.NpgSql.NpgSqlHealthCheckOptions options, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, Npgsql.NpgsqlDataSource> dbDataSourceFactory, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, string> connectionStringFactory, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }


### PR DESCRIPTION
This PR adds DbDataSource support for postgresql to allow password rotation using UsePeriodicPasswordProvider


This PR allows the following:

```
var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);

dataSourceBuilder.UsePeriodicPasswordProvider(async (settings, cancellationToken) =>
{
    var sqlServerTokenProvider = new DefaultAzureCredential();
    var tokenAsync = await sqlServerTokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { "https://ossrdbms-aad.database.windows.net/.default" }), cancellationToken);
    return tokenAsync.Token;
},
TimeSpan.FromMinutes(55), // Interval for refreshing the token
TimeSpan.FromSeconds(5));
        
var dbDataSource = dataSourceBuilder.Build();


builder.Services.AddHealthChecks()
    .AddNpgSql(e => dbDataSource);
```

closes #1813