### PR TITLE
Add overload for private key authentication on sftp configuration builder

### DIFF
--- a/src/HealthChecks.Network/SftpConfiguration.cs
+++ b/src/HealthChecks.Network/SftpConfiguration.cs
@@ -44,6 +44,12 @@ public class SftpConfigurationBuilder
 
         return this;
     }
+    public SftpConfigurationBuilder AddPrivateKeyAuthentication(PrivateKeyFile privateKey)
+    {
+        AuthenticationMethods.Add(new PrivateKeyAuthenticationMethod(_userName, privateKey));
+        
+        return this;
+    }
     public SftpConfigurationBuilder CreateFileOnConnect(string remoteFilePath)
     {
         _fileCreationOptions = (true, remoteFilePath);

--- a/src/HealthChecks.Network/SftpConfiguration.cs
+++ b/src/HealthChecks.Network/SftpConfiguration.cs
@@ -48,7 +48,7 @@ public class SftpConfigurationBuilder
     public SftpConfigurationBuilder AddPrivateKeyAuthentication(PrivateKeyFile privateKey)
     {
         AuthenticationMethods.Add(new PrivateKeyAuthenticationMethod(_userName, privateKey));
-        
+
         return this;
     }
 

--- a/src/HealthChecks.Network/SftpConfiguration.cs
+++ b/src/HealthChecks.Network/SftpConfiguration.cs
@@ -44,12 +44,14 @@ public class SftpConfigurationBuilder
 
         return this;
     }
+
     public SftpConfigurationBuilder AddPrivateKeyAuthentication(PrivateKeyFile privateKey)
     {
         AuthenticationMethods.Add(new PrivateKeyAuthenticationMethod(_userName, privateKey));
         
         return this;
     }
+
     public SftpConfigurationBuilder CreateFileOnConnect(string remoteFilePath)
     {
         _fileCreationOptions = (true, remoteFilePath);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: related to: it allows private key file authentication for sftp configuration also when keyfile has no password

Please reference the issue this PR will close: #_[1833]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: not really it just extends functionallity

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
