### PR TITLE
Add overload to AddAzureBlobStorage to supply your own BlobServiceClient from delegate

### DIFF
--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -121,7 +121,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
            tags,
            timeout));
     }
-    
+
     /// <summary>
     /// Add a health check for Azure Blob Storage.
     /// </summary>
@@ -138,7 +138,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddAzureBlobStorage(
         this IHealthChecksBuilder builder,
-        Func<IServiceProvider,BlobServiceClient> clientFactory,
+        Func<IServiceProvider, BlobServiceClient> clientFactory,
         Action<AzureBlobStorageHealthCheckOptions>? configureOptions = default,
         string? name = default,
         HealthStatus? failureStatus = default,
@@ -194,7 +194,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
            tags,
            timeout));
     }
-    
+
     /// <summary>
     /// Add a health check for Azure Blob Storage.
     /// </summary>
@@ -214,7 +214,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddAzureBlobStorage(
         this IHealthChecksBuilder builder,
-        Func<IServiceProvider,BlobServiceClient> clientFactory,
+        Func<IServiceProvider, BlobServiceClient> clientFactory,
         Action<IServiceProvider, AzureBlobStorageHealthCheckOptions>? configureOptions = default,
         string? name = default,
         HealthStatus? failureStatus = default,

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -121,12 +121,48 @@ public static class AzureStorageHealthCheckBuilderExtensions
            tags,
            timeout));
     }
+    
+    /// <summary>
+    /// Add a health check for Azure Blob Storage.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="clientFactory">Delegate for creating a <see cref="BlobServiceClient"/>.</param>
+    /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>
+    /// <param name="name">The health check name. Optional. If <see langword="null"/> the type name 'azureblob' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <see langword="null"/> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddAzureBlobStorage(
+        this IHealthChecksBuilder builder,
+        Func<IServiceProvider,BlobServiceClient> clientFactory,
+        Action<AzureBlobStorageHealthCheckOptions>? configureOptions = default,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name ?? AZUREBLOB_NAME,
+            sp =>
+            {
+                var options = new AzureBlobStorageHealthCheckOptions();
+                configureOptions?.Invoke(options);
+                return new AzureBlobStorageHealthCheck(clientFactory(sp), options);
+            },
+            failureStatus,
+            tags,
+            timeout));
+    }
 
     /// <summary>
     /// Add a health check for Azure Blob Storage.
     /// </summary>
     /// <remarks>
-    /// A <see cref="BlobServiceClient"/> service must be registered in the service container.
+    /// A <see cref="BlobServiceClient"/> service must be registered in the service container if clientFactory is not set.
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>
@@ -157,6 +193,45 @@ public static class AzureStorageHealthCheckBuilderExtensions
            failureStatus,
            tags,
            timeout));
+    }
+    
+    /// <summary>
+    /// Add a health check for Azure Blob Storage.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="BlobServiceClient"/> service must be registered in the service container if clientFactory is not set.
+    /// </remarks>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="clientFactory">Delegate for creating a <see cref="BlobServiceClient"/>. Optional.</param>
+    /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>
+    /// <param name="name">The health check name. Optional. If <see langword="null"/> the type name 'azureblob' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <see langword="null"/> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddAzureBlobStorage(
+        this IHealthChecksBuilder builder,
+        Func<IServiceProvider,BlobServiceClient> clientFactory,
+        Action<IServiceProvider, AzureBlobStorageHealthCheckOptions>? configureOptions = default,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name ?? AZUREBLOB_NAME,
+            sp =>
+            {
+                var options = new AzureBlobStorageHealthCheckOptions();
+                configureOptions?.Invoke(sp, options);
+                return new AzureBlobStorageHealthCheck(clientFactory(sp), options);
+            },
+            failureStatus,
+            tags,
+            timeout));
     }
 
     /// <summary>

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -145,7 +145,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-    return builder.Add(new HealthCheckRegistration(
+        return builder.Add(new HealthCheckRegistration(
             name ?? AZUREBLOB_NAME,
             sp =>
             {

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -164,7 +164,6 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// <remarks>
     /// A <see cref="BlobServiceClient"/> service must be registered in the service container. For named instances
     /// you may use other overload with <see cref="Func<IServiceProvider, BlobServiceClient>"/> argument.
-
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -162,7 +162,9 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// Add a health check for Azure Blob Storage.
     /// </summary>
     /// <remarks>
-    /// A <see cref="BlobServiceClient"/> service must be registered in the service container if clientFactory is not set.
+    /// A <see cref="BlobServiceClient"/> service must be registered in the service container. For named instances
+    /// you may use other overload with <see cref="Func<IServiceProvider, BlobServiceClient>"/> argument.
+
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -145,7 +145,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
         IEnumerable<string>? tags = default,
         TimeSpan? timeout = default)
     {
-        return builder.Add(new HealthCheckRegistration(
+    return builder.Add(new HealthCheckRegistration(
             name ?? AZUREBLOB_NAME,
             sp =>
             {

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -163,7 +163,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// </summary>
     /// <remarks>
     /// A <see cref="BlobServiceClient"/> service must be registered in the service container. For named instances
-    /// you may use other overload with <see cref="Func<IServiceProvider, BlobServiceClient>"/> argument.
+    /// you may use other overload with <see cref="Func{IServiceProvider, BlobServiceClient}"/> argument.
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -199,9 +199,6 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// <summary>
     /// Add a health check for Azure Blob Storage.
     /// </summary>
-    /// <remarks>
-    /// A <see cref="BlobServiceClient"/> service must be registered in the service container if clientFactory is not set.
-    /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="clientFactory">Delegate for creating a <see cref="BlobServiceClient"/>. Optional.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>

--- a/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.AzureStorage/DependencyInjection/AzureStorageHealthCheckBuilderExtensions.cs
@@ -200,7 +200,7 @@ public static class AzureStorageHealthCheckBuilderExtensions
     /// Add a health check for Azure Blob Storage.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-    /// <param name="clientFactory">Delegate for creating a <see cref="BlobServiceClient"/>. Optional.</param>
+    /// <param name="clientFactory">Delegate for creating a <see cref="BlobServiceClient"/>.</param>
     /// <param name="configureOptions">Delegate for configuring the health check. Optional.</param>
     /// <param name="name">The health check name. Optional. If <see langword="null"/> the type name 'azureblob' will be used for the name.</param>
     /// <param name="failureStatus">

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -174,6 +174,4 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
-    
-   
 }

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -145,7 +145,6 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
-    
     [Theory]
     [InlineData(null, null, null)]
     [InlineData("container", null, null)]

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -90,6 +90,7 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
+
     [Theory]
     [InlineData(null, null, null)]
     [InlineData("container", null, null)]

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -146,6 +146,7 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
+
     [Theory]
     [InlineData(null, null, null)]
     [InlineData("container", null, null)]

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -90,7 +90,6 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
-    
     [Theory]
     [InlineData(null, null, null)]
     [InlineData("container", null, null)]

--- a/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
+++ b/test/HealthChecks.AzureStorage.Tests/DependencyInjection/AzureBlobStorageRegistrationTests.cs
@@ -90,6 +90,34 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
+    
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("container", null, null)]
+    [InlineData(null, "my-azureblob-group", null)]
+    [InlineData(null, null, HealthStatus.Degraded)]
+    [InlineData("container", "my-azureblob-group", HealthStatus.Degraded)]
+    public void add_health_check_with_client_from_delegate(string? containerName, string? registrationName, HealthStatus? failureStatus)
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddHealthChecks()
+            .AddAzureBlobStorage(
+                clientFactory: sp => Substitute.For<BlobServiceClient>(),
+                o => o.ContainerName = containerName,
+                name: registrationName,
+                failureStatus: failureStatus)
+            .Services
+            .BuildServiceProvider();
+
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.ShouldBe(registrationName ?? "azureblob");
+        registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
+        check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
+    }
 
     [Theory]
     [InlineData(null, null, null)]
@@ -118,4 +146,34 @@ public class azureblobstorage_registration_should
         registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
         check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
     }
+    
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("container", null, null)]
+    [InlineData(null, "my-azureblob-group", null)]
+    [InlineData(null, null, HealthStatus.Degraded)]
+    [InlineData("container", "my-azureblob-group", HealthStatus.Degraded)]
+    public void add_health_check_with_client_from_delegate_and_advanced_delegate(string? containerName, string? registrationName, HealthStatus? failureStatus)
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddHealthChecks()
+            .AddAzureBlobStorage(
+                clientFactory: sp => Substitute.For<BlobServiceClient>(),
+                (sp, o) => o.ContainerName = containerName,
+                name: registrationName,
+                failureStatus: failureStatus)
+            .Services
+            .BuildServiceProvider();
+
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.ShouldBe(registrationName ?? "azureblob");
+        registration.FailureStatus.ShouldBe(failureStatus ?? HealthStatus.Unhealthy);
+        check.ShouldBeOfType<AzureBlobStorageHealthCheck>();
+    }
+    
+   
 }


### PR DESCRIPTION
BlobServiceClient

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
If the application needs to monitor a `BlobServiceClient` which is registered ie. using named instances (see https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection)
```
builder.Services.AddAzureClients(clientBuilder =>
{
    clientBuilder.AddBlobServiceClient(builder.Configuration.GetSection("PublicStorage"));
    clientBuilder.AddBlobServiceClient(builder.Configuration.GetSection("PrivateStorage"))
        .WithName("PrivateStorage");
});
```
then this PR tries to solve that issue by overloading the `AddAzureBlobStorage` extension method with a `Func<IServiceProvider,BlobServiceClient>` function argument to be able to supply your own way of resolving the `BlobServiceClient` instance.

**Which issue(s) this PR fixes**:
No issue created, should I make one?

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Only if the user should wish to use these new methods

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
