### PR TITLE
feat: allow passing the service-provider to the connection builder function

### DIFF
--- a/src/HealthChecks.SignalR/DependencyInjection/SignalRHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.SignalR/DependencyInjection/SignalRHealthCheckBuilderExtensions.cs
@@ -75,4 +75,34 @@ public static class SignalRHealthCheckBuilderExtensions
                 tags,
                 timeout));
     }
+
+    /// <summary>
+    /// Add a health check for SignalR.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="hubConnectionBuilderFactory">The SignalR hub connection builder factory to be used.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'signalr' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddSignalRHub(
+        this IHealthChecksBuilder builder,
+        Func<IServiceProvider, Func<HubConnection>> hubConnectionBuilderFactory,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.Add(
+            new HealthCheckRegistration(
+                name ?? NAME,
+                sp => new SignalRHealthCheck(hubConnectionBuilderFactory(sp)),
+                failureStatus,
+                tags,
+                timeout));
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR allows to use the IServiceProvider when build the signalr-hub-connection 

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

It gives the user another extension method
