### PR TITLE
Remove InstrumentationKey from Application Insights publisher

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace HealthChecks.Publisher.ApplicationInsights;
 
-internal class ApplicationInsightsPublisher : IHealthCheckPublisher
+public class ApplicationInsightsPublisher : IHealthCheckPublisher
 {
     private const string EVENT_NAME = "AspNetCoreHealthCheck";
     private const string METRIC_STATUS_NAME = "AspNetCoreHealthCheckStatus";
@@ -17,20 +17,17 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
     private static readonly object _syncRoot = new object();
     private readonly TelemetryConfiguration? _telemetryConfiguration;
     private readonly string? _connectionString;
-    private readonly string? _instrumentationKey;
     private readonly bool _saveDetailedReport;
     private readonly bool _excludeHealthyReports;
 
     public ApplicationInsightsPublisher(
         IOptions<TelemetryConfiguration>? telemetryConfiguration,
         string? connectionString = default,
-        string? instrumentationKey = default,
         bool saveDetailedReport = false,
         bool excludeHealthyReports = false)
     {
         _telemetryConfiguration = telemetryConfiguration?.Value;
         _connectionString = connectionString;
-        _instrumentationKey = instrumentationKey;
         _saveDetailedReport = saveDetailedReport;
         _excludeHealthyReports = excludeHealthyReports;
     }
@@ -114,14 +111,11 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
                 if (_client == null)
                 {
                     // Create TelemetryConfiguration
-                    // Hierachy: _connectionString > _instrumentationKey > _telemetryConfiguration
-#pragma warning disable CS0618 // Type or member is obsolete
-                    var configuration = string.IsNullOrWhiteSpace(_connectionString)
-                        ? string.IsNullOrWhiteSpace(_instrumentationKey)
-                            ? _telemetryConfiguration
-                            : new TelemetryConfiguration(_instrumentationKey)
-                        : new TelemetryConfiguration { ConnectionString = _connectionString };
-#pragma warning restore CS0618 // Type or member is obsolete
+                    // Hierachy: _connectionString > _telemetryConfiguration
+                    var configuration = (!string.IsNullOrWhiteSpace(_connectionString)
+                        ? new TelemetryConfiguration { ConnectionString = _connectionString }
+                        : _telemetryConfiguration)
+                            ?? throw new ArgumentException("A connection string or TelemetryConfiguration must be set!");
 
                     _client = new TelemetryClient(configuration);
                 }

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace HealthChecks.Publisher.ApplicationInsights;
 
-public class ApplicationInsightsPublisher : IHealthCheckPublisher
+internal class ApplicationInsightsPublisher : IHealthCheckPublisher
 {
     private const string EVENT_NAME = "AspNetCoreHealthCheck";
     private const string METRIC_STATUS_NAME = "AspNetCoreHealthCheckStatus";

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -15,15 +15,13 @@ public static class ApplicationInsightsHealthCheckBuilderExtensions
     /// indicating the health check status (1 - Healthy, 0 - Unhealthy) and the total time the health check took to execute in milliseconds.
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-    /// <param name="connectionString">Specified Application Insights connection string. Optional. If <c>null</c> <paramref name="instrumentationKey"/> is used.</param>
-    /// <param name="instrumentationKey">Specified Application Insights instrumentation key. Optional. If <c>null</c> <see cref="TelemetryConfiguration"/> is resolved from DI container.</param>
+    /// <param name="connectionString">Specified Application Insights connection string. Optional. If <c>null</c> <see cref="TelemetryConfiguration"/> is resolved from DI container.</param>
     /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional.</param>
     /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddApplicationInsightsPublisher(
         this IHealthChecksBuilder builder,
         string? connectionString = default,
-        string? instrumentationKey = default,
         bool saveDetailedReport = false,
         bool excludeHealthyReports = false)
     {
@@ -31,7 +29,7 @@ public static class ApplicationInsightsHealthCheckBuilderExtensions
            .AddSingleton<IHealthCheckPublisher>(sp =>
            {
                var telemetryConfigurationOptions = sp.GetService<IOptions<TelemetryConfiguration>>();
-               return new ApplicationInsightsPublisher(telemetryConfigurationOptions, connectionString, instrumentationKey, saveDetailedReport, excludeHealthyReports);
+               return new ApplicationInsightsPublisher(telemetryConfigurationOptions, connectionString, saveDetailedReport, excludeHealthyReports);
            });
 
         return builder;

--- a/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
+++ b/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.9" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="HealthChecks.Publisher.ApplicationInsights.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/DependencyInjection/RegistrationTests.cs
@@ -5,20 +5,6 @@ namespace HealthChecks.Publisher.ApplicationInsights.Tests.DependencyInjection;
 public class application_insights_publisher_registration_should
 {
     [Fact]
-    public void add_healthcheck_when_properly_configured_with_instrumentation_key_parameter()
-    {
-        var services = new ServiceCollection();
-        services
-            .AddHealthChecks()
-            .AddApplicationInsightsPublisher(instrumentationKey: "telemetrykey");
-
-        using var serviceProvider = services.BuildServiceProvider();
-        var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
-
-        Assert.NotNull(publisher);
-    }
-
-    [Fact]
     public void add_healthcheck_when_properly_configured_with_connection_string_parameter()
     {
         var services = new ServiceCollection();
@@ -29,16 +15,14 @@ public class application_insights_publisher_registration_should
         using var serviceProvider = services.BuildServiceProvider();
         var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
 
-        Assert.NotNull(publisher);
+        publisher.ShouldNotBeNull();
     }
 
     [Fact]
     public void add_healthcheck_when_application_insights_is_properly_configured_with_IOptions()
     {
         var services = new ServiceCollection();
-#pragma warning disable CS0618 // Type or member is obsolete
-        services.Configure<TelemetryConfiguration>(config => config.InstrumentationKey = "telemetrykey");
-#pragma warning restore CS0618 // Type or member is obsolete
+        services.Configure<TelemetryConfiguration>(config => config.ConnectionString = "InstrumentationKey=telemetrykey;EndpointSuffix=example.com;");
 
         services
             .AddHealthChecks()
@@ -47,6 +31,6 @@ public class application_insights_publisher_registration_should
         using var serviceProvider = services.BuildServiceProvider();
         var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
 
-        Assert.NotNull(publisher);
+        publisher.ShouldNotBeNull();
     }
 }

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
@@ -6,7 +6,7 @@ namespace HealthChecks.Publisher.ApplicationInsights.Tests.Functional;
 public class application_insights_publisher_should
 {
     [Fact]
-    public void throw_when_neither_connection_string_nor_telemetry_configuration_provided()
+    public void throw_when_neither_connection_string_nor_telemetry_configuration_is_provided()
     {
         var options = Substitute.For<IOptions<TelemetryConfiguration>>();
         var publisher = new ApplicationInsightsPublisher(options, connectionString: null);

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.ApplicationInsights.Extensibility;
+using NSubstitute;
+
+namespace HealthChecks.Publisher.ApplicationInsights.Tests.Functional;
+
+public class application_insights_publisher_should
+{
+    [Fact]
+    public void throw_when_neither_connection_string_nor_telemetry_configuration_provided()
+    {
+        var options = Substitute.For<IOptions<TelemetryConfiguration>>();
+        var publisher = new ApplicationInsightsPublisher(options, connectionString: null);
+        var report = new HealthReport(new Dictionary<string, HealthReportEntry>(), TimeSpan.Zero);
+
+        var publish = () => publisher.PublishAsync(report, default);
+
+        publish.ShouldThrow<ArgumentException>();
+    }
+}

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
@@ -14,6 +14,7 @@ public class application_insights_publisher_should
 
         var publish = () => publisher.PublishAsync(report, default);
 
-        publish.ShouldThrow<ArgumentException>();
+        publish.ShouldThrow<ArgumentException>()
+            .Message.ShouldBe("A connection string or TelemetryConfiguration must be set!");
     }
 }

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
@@ -1,7 +1,15 @@
+namespace HealthChecks.Publisher.ApplicationInsights
+{
+    public class ApplicationInsightsPublisher : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher
+    {
+        public ApplicationInsightsPublisher(Microsoft.Extensions.Options.IOptions<Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration>? telemetryConfiguration, string? connectionString = null, bool saveDetailedReport = false, bool excludeHealthyReports = false) { }
+        public System.Threading.Tasks.Task PublishAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport report, System.Threading.CancellationToken cancellationToken) { }
+    }
+}
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ApplicationInsightsHealthCheckBuilderExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddApplicationInsightsPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string? connectionString = null, string? instrumentationKey = null, bool saveDetailedReport = false, bool excludeHealthyReports = false) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddApplicationInsightsPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string? connectionString = null, bool saveDetailedReport = false, bool excludeHealthyReports = false) { }
     }
 }

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
@@ -1,11 +1,3 @@
-namespace HealthChecks.Publisher.ApplicationInsights
-{
-    public class ApplicationInsightsPublisher : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher
-    {
-        public ApplicationInsightsPublisher(Microsoft.Extensions.Options.IOptions<Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration>? telemetryConfiguration, string? connectionString = null, bool saveDetailedReport = false, bool excludeHealthyReports = false) { }
-        public System.Threading.Tasks.Task PublishAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport report, System.Threading.CancellationToken cancellationToken) { }
-    }
-}
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ApplicationInsightsHealthCheckBuilderExtensions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
- Application Insights is obsoleting InstrumentationKey - it should be removed from HC API

**Which issue(s) this PR fixes**: #1939 

**Special notes for your reviewer**:
- Removed InstrumentationKey
- Updated registration tests
- Added functional test

**Does this PR introduce a user-facing change?**: Yes.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
