### PR TITLE
UIResponseWriter - Do not encode non-ASCII characters

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -55,7 +55,7 @@
     <HealthChecksUIPostgreSQLStorage>7.0.0</HealthChecksUIPostgreSQLStorage>
     <HealthCheckSystem>7.0.0</HealthCheckSystem>
     <HealthCheckUI>7.0.1</HealthCheckUI>
-    <HealthCheckUIClient>7.0.0</HealthCheckUIClient>
+    <HealthCheckUIClient>7.1.0</HealthCheckUIClient>
     <HealthCheckUICore>7.0.0</HealthCheckUICore>
     <HealthCheckUIData>7.0.0</HealthCheckUIData>
     <HealthCheckUIInMemoryStorage>7.0.0</HealthCheckUIInMemoryStorage>

--- a/src/HealthChecks.UI.Client/UIResponseWriter.cs
+++ b/src/HealthChecks.UI.Client/UIResponseWriter.cs
@@ -1,5 +1,7 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using HealthChecks.UI.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -55,6 +57,7 @@ public static class UIResponseWriter
         {
             AllowTrailingCommas = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
- By default, the serializer escapes all non-ASCII characters
- Currently non-ASCII characters are escaped, example: `你好 => \u4F60\u597D`
- This PR removes escaping for all Unicode characters

**Which issue(s) this PR fixes**: #1557

**Special notes for your reviewer**:
- Test added

**Does this PR introduce a user-facing change?**: No.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
