### PR TITLE
DocumentDb - Add option to check database and collection

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -17,7 +17,7 @@
     <HealthCheckConsul>7.0.0</HealthCheckConsul>
     <HealthCheckCosmosDb>7.0.0</HealthCheckCosmosDb>
     <HealthCheckDapr>7.0.0</HealthCheckDapr>
-    <HealthCheckDocumentDb>7.0.0</HealthCheckDocumentDb>
+    <HealthCheckDocumentDb>7.1.0</HealthCheckDocumentDb>
     <HealthCheckDynamoDb>7.0.0</HealthCheckDynamoDb>
     <HealthCheckElasticsearch>7.0.0</HealthCheckElasticsearch>
     <HealthCheckEventStoregRPC>7.0.0</HealthCheckEventStoregRPC>

--- a/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
@@ -30,6 +30,12 @@ public class DocumentDbHealthCheck : IHealthCheck
                     documentDbClient = _connections[_documentDbOptions.UriEndpoint];
                 }
             }
+
+            if (CanCheckCollectionInDatabase())
+            {
+                await documentDbClient.ReadDocumentCollectionAsync(GetCollectionUri()).ConfigureAwait(false);
+            }
+
             await documentDbClient.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             return HealthCheckResult.Healthy();
@@ -39,4 +45,16 @@ public class DocumentDbHealthCheck : IHealthCheck
             return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
         }
     }
+
+    private bool CanCheckCollectionInDatabase()
+    {
+        if (string.IsNullOrWhiteSpace(_documentDbOptions.DatabaseName) || string.IsNullOrWhiteSpace(_documentDbOptions.CollectionName))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private Uri GetCollectionUri() => UriFactory.CreateDocumentCollectionUri(_documentDbOptions.DatabaseName, _documentDbOptions.CollectionName);
 }

--- a/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
@@ -13,6 +13,8 @@ public class DocumentDbHealthCheck : IHealthCheck
     {
         _documentDbOptions.UriEndpoint = Guard.ThrowIfNull(documentDbOptions.UriEndpoint);
         _documentDbOptions.PrimaryKey = Guard.ThrowIfNull(documentDbOptions.PrimaryKey);
+        _documentDbOptions.DatabaseName = documentDbOptions.DatabaseName;
+        _documentDbOptions.CollectionName = documentDbOptions.CollectionName;
     }
 
     /// <inheritdoc />
@@ -35,8 +37,10 @@ public class DocumentDbHealthCheck : IHealthCheck
             {
                 await documentDbClient.ReadDocumentCollectionAsync(GetCollectionUri()).ConfigureAwait(false);
             }
-
-            await documentDbClient.OpenAsync(cancellationToken).ConfigureAwait(false);
+            else
+            {
+                await documentDbClient.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             return HealthCheckResult.Healthy();
         }

--- a/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
@@ -33,7 +33,7 @@ public class DocumentDbHealthCheck : IHealthCheck
                 }
             }
 
-            if (CanCheckCollectionInDatabase())
+            if (!string.IsNullOrWhiteSpace(_documentDbOptions.DatabaseName) && !string.IsNullOrWhiteSpace(_documentDbOptions.CollectionName))
             {
                 await documentDbClient.ReadDocumentCollectionAsync(GetCollectionUri()).ConfigureAwait(false);
             }

--- a/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
@@ -49,16 +49,4 @@ public class DocumentDbHealthCheck : IHealthCheck
             return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
         }
     }
-
-    private bool CanCheckCollectionInDatabase()
-    {
-        if (string.IsNullOrWhiteSpace(_documentDbOptions.DatabaseName) || string.IsNullOrWhiteSpace(_documentDbOptions.CollectionName))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private Uri GetCollectionUri() => UriFactory.CreateDocumentCollectionUri(_documentDbOptions.DatabaseName, _documentDbOptions.CollectionName);
 }

--- a/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbHealthCheck.cs
@@ -35,7 +35,7 @@ public class DocumentDbHealthCheck : IHealthCheck
 
             if (!string.IsNullOrWhiteSpace(_documentDbOptions.DatabaseName) && !string.IsNullOrWhiteSpace(_documentDbOptions.CollectionName))
             {
-                await documentDbClient.ReadDocumentCollectionAsync(GetCollectionUri()).ConfigureAwait(false);
+                await documentDbClient.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(_documentDbOptions.DatabaseName, _documentDbOptions.CollectionName)).ConfigureAwait(false);
             }
             else
             {

--- a/src/HealthChecks.DocumentDb/DocumentDbOptions.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbOptions.cs
@@ -9,7 +9,7 @@ public class DocumentDbOptions
 
     public string PrimaryKey { get; set; } = null!;
 
-    public string DatabaseName { get; set; } = null!;
+    public string? DatabaseName { get; set; }
 
-    public string CollectionName { get; set; } = null!;
+    public string? CollectionName { get; set; }
 }

--- a/src/HealthChecks.DocumentDb/DocumentDbOptions.cs
+++ b/src/HealthChecks.DocumentDb/DocumentDbOptions.cs
@@ -8,4 +8,8 @@ public class DocumentDbOptions
     public string UriEndpoint { get; set; } = null!;
 
     public string PrimaryKey { get; set; } = null!;
+
+    public string DatabaseName { get; set; } = null!;
+
+    public string CollectionName { get; set; } = null!;
 }

--- a/test/HealthChecks.DocumentDb.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.DocumentDb.Tests/DependencyInjection/RegistrationTests.cs
@@ -18,6 +18,7 @@ public class documentdb_registration_should
         registration.Name.ShouldBe("documentdb");
         check.ShouldBeOfType<DocumentDbHealthCheck>();
     }
+
     [Fact]
     public void add_named_health_check_when_properly_configured()
     {
@@ -32,6 +33,29 @@ public class documentdb_registration_should
         var check = registration.Factory(serviceProvider);
 
         registration.Name.ShouldBe("my-documentdb-group");
+        check.ShouldBeOfType<DocumentDbHealthCheck>();
+    }
+
+    [Fact]
+    public void add_health_check_when_properly_configured_with_database_name_and_collection_name()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddDocumentDb(_ =>
+            {
+                _.PrimaryKey = "key";
+                _.UriEndpoint = "endpoint";
+                _.DatabaseName = "database";
+                _.CollectionName = "collection";
+            });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.ShouldBe("documentdb");
         check.ShouldBeOfType<DocumentDbHealthCheck>();
     }
 }

--- a/test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.approved.txt
+++ b/test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.approved.txt
@@ -8,6 +8,8 @@ namespace HealthChecks.DocumentDb
     public class DocumentDbOptions
     {
         public DocumentDbOptions() { }
+        public string CollectionName { get; set; }
+        public string DatabaseName { get; set; }
         public string PrimaryKey { get; set; }
         public string UriEndpoint { get; set; }
     }

--- a/test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.approved.txt
+++ b/test/HealthChecks.DocumentDb.Tests/HealthChecks.DocumentDb.approved.txt
@@ -8,8 +8,8 @@ namespace HealthChecks.DocumentDb
     public class DocumentDbOptions
     {
         public DocumentDbOptions() { }
-        public string CollectionName { get; set; }
-        public string DatabaseName { get; set; }
+        public string? CollectionName { get; set; }
+        public string? DatabaseName { get; set; }
         public string PrimaryKey { get; set; }
         public string UriEndpoint { get; set; }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
- Extends DocumentDb Health Check with option to check against provided database and collection
- When both provided then Health Check calls `ReadDocumentCollectionAsync(...)`

**Which issue(s) this PR fixes**: 
closes #333

**Special notes for your reviewer**:
- Registration test added

**Does this PR introduce a user-facing change?**: No.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
