### PR TITLE
Remove StringComparison.OrdinalIgnoreCase as EF Core translation

### DIFF
--- a/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
+++ b/src/HealthChecks.UI/Core/HostedService/HealthCheckReportCollector.cs
@@ -198,10 +198,12 @@ internal sealed class HealthCheckReportCollector : IHealthCheckReportCollector, 
 
     private async Task<bool> ShouldNotifyAsync(string healthCheckName)
     {
+#pragma warning disable RCS1155 // Use StringComparison when comparing strings.
         var lastNotifications = await _db.Failures
-           .Where(lf => string.Equals(lf.HealthCheckName, healthCheckName, StringComparison.OrdinalIgnoreCase))
+           .Where(lf => string.Equals(lf.HealthCheckName, healthCheckName))
            .OrderByDescending(lf => lf.LastNotified)
            .Take(2).ToListAsync();
+#pragma warning restore RCS1155 // Use StringComparison when comparing strings.
 
         if (lastNotifications?.Count == 2)
         {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

**What this PR does / why we need it**:
Fix EF Core translation to SQL code

**Which issue(s) this PR fixes**:
Remove StringComparison.OrdinalIgnoreCase as EF Core is not able to translate to SQL code string.Equals with StringComparison

**Special notes for your reviewer**:
It fails in at least two EF Core providers I've tested SQLServer and SQLite

**Does this PR introduce a user-facing change?**:
NO

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x ] Code compiles correctly

