### PR TITLE
Updating dependabot to weekly updates and grouping non-major nuget package changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,13 @@ updates:
 - package-ecosystem: "nuget"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+    groups:
+      dependencies:
+        update-types:
+        - "minor"
+        - "patch"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:  The goal is to reduce the maintenance overhead, this change sets the dependabot interval to weekly updates and groups all non-major nuget changes together into a single PR (as [Github have recently released the group option](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/))

**Which issue(s) this PR fixes**:  https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/2006  It doesn't fix this issue but it contributes to making versioning a little bit easier to manage.

**Special notes for your reviewer**:  None

**Does this PR introduce a user-facing change?**:  No

