### PR TITLE
[Nats] Add overload for NatsOptions with IServiceProvider

### DIFF
--- a/src/HealthChecks.Nats/DependencyInjection/NatsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Nats/DependencyInjection/NatsHealthCheckBuilderExtensions.cs
@@ -48,4 +48,44 @@ public static class NatsHealthCheckBuilderExtensions
             tags,
             timeout));
     }
+
+    /// <summary>
+    /// Add a health check for Nats.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="setup">The factory to configure the Nats setup.</param>
+    /// <param name="name">
+    /// The health check name.
+    /// Optional.
+    /// If <see langword="null"/> the type name 'nats' will be used for the name.
+    /// </param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails.
+    /// Optional.
+    /// If <see langword="null"/> then the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+    /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+    public static IHealthChecksBuilder AddNats(
+        this IHealthChecksBuilder builder,
+        Action<IServiceProvider, NatsOptions>? setup,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name ?? NAME,
+            sp =>
+            {
+                var options = new NatsOptions();
+                setup?.Invoke(sp, options);
+
+                return new NatsHealthCheck(options);
+            },
+            failureStatus,
+            tags,
+            timeout));
+    }
 }

--- a/src/HealthChecks.Nats/DependencyInjection/NatsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Nats/DependencyInjection/NatsHealthCheckBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class NatsHealthCheckBuilderExtensions
     /// If <see langword="null"/> then the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
     /// </param>
     /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
-    /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
     /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
     public static IHealthChecksBuilder AddNats(
         this IHealthChecksBuilder builder,

--- a/test/HealthChecks.Nats.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Nats.Tests/DependencyInjection/RegistrationTests.cs
@@ -33,7 +33,7 @@ public class nats_registration_should
             .AddHealthChecks()
             .AddNats((sp, setup) => setup.Url = sp.GetRequiredService<IDependency>().ConnectionString);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
 
         var registration = options.Value.Registrations.First();

--- a/test/HealthChecks.Nats.Tests/HealthChecks.Nats.approved.txt
+++ b/test/HealthChecks.Nats.Tests/HealthChecks.Nats.approved.txt
@@ -20,5 +20,6 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class NatsHealthCheckBuilderExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNats(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<HealthChecks.Nats.NatsOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNats(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<System.IServiceProvider, HealthChecks.Nats.NatsOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:

This PR adds a new overload for Nats Health Check supporting NatsOptions creation with IServiceProvider.

**Which issue(s) this PR fixes**:

#1827

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x]  End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
