### PR TITLE
Add file health check similar to folder health check

### DIFF
--- a/src/HealthChecks.System/DependencyInjection/SystemHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.System/DependencyInjection/SystemHealthCheckBuilderExtensions.cs
@@ -282,7 +282,7 @@ public static class SystemHealthCheckBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="setup">Delegate for configuring the health check. Optional.</param>
-    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'files' will be used for the name.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'file' will be used for the name.</param>
     /// <param name="failureStatus">
     /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
     /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
@@ -306,7 +306,7 @@ public static class SystemHealthCheckBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="setup">The action method to configure the health check parameters.</param>
-    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'files' will be used for the name.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'file' will be used for the name.</param>
     /// <param name="failureStatus">
     /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
     /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.

--- a/src/HealthChecks.System/FileHealthCheck.cs
+++ b/src/HealthChecks.System/FileHealthCheck.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecks.System;
+
+public class FileHealthCheck : IHealthCheck
+{
+    private readonly FileHealthCheckOptions _fileOptions;
+
+    public FileHealthCheck(FileHealthCheckOptions fileOptions)
+    {
+        _fileOptions = fileOptions;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            List<string> errorList = new();
+            foreach (string folder in _fileOptions.Files)
+            {
+                if (!string.IsNullOrEmpty(folder))
+                {
+                    if (!File.Exists(folder))
+                    {
+                        errorList.Add($"File {folder} does not exist.");
+                        if (!_fileOptions.CheckAllFiles)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return Task.FromResult(errorList.GetHealthState(context));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new HealthCheckResult(context.Registration.FailureStatus, exception: ex));
+        }
+    }
+}

--- a/src/HealthChecks.System/FileHealthCheck.cs
+++ b/src/HealthChecks.System/FileHealthCheck.cs
@@ -16,13 +16,13 @@ public class FileHealthCheck : IHealthCheck
         try
         {
             List<string> errorList = new();
-            foreach (string folder in _fileOptions.Files)
+            foreach (string file in _fileOptions.Files)
             {
-                if (!string.IsNullOrEmpty(folder))
+                if (!string.IsNullOrEmpty(file))
                 {
-                    if (!File.Exists(folder))
+                    if (!File.Exists(file))
                     {
-                        errorList.Add($"File {folder} does not exist.");
+                        errorList.Add($"File {file} does not exist.");
                         if (!_fileOptions.CheckAllFiles)
                         {
                             break;

--- a/src/HealthChecks.System/FileHealthCheckOptions.cs
+++ b/src/HealthChecks.System/FileHealthCheckOptions.cs
@@ -1,0 +1,19 @@
+namespace HealthChecks.System;
+
+public class FileHealthCheckOptions
+{
+    internal List<string> Files { get; } = new();
+    public bool CheckAllFiles { get; set; }
+
+    public FileHealthCheckOptions AddFile(string file)
+    {
+        Files.Add(file);
+        return this;
+    }
+
+    public FileHealthCheckOptions WithCheckAllFiles()
+    {
+        CheckAllFiles = true;
+        return this;
+    }
+}

--- a/src/HealthChecks.System/FileHealthCheckOptions.cs
+++ b/src/HealthChecks.System/FileHealthCheckOptions.cs
@@ -2,7 +2,7 @@ namespace HealthChecks.System;
 
 public class FileHealthCheckOptions
 {
-    internal List<string> Files { get; } = new();
+    public List<string> Files { get; } = new();
     public bool CheckAllFiles { get; set; }
 
     public FileHealthCheckOptions AddFile(string file)

--- a/test/HealthChecks.System.Tests/Functional/FileHealthCheckTests.cs
+++ b/test/HealthChecks.System.Tests/Functional/FileHealthCheckTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+
+namespace HealthChecks.System.Tests.Functional;
+
+public class file_healthcheck_should
+{
+    [Fact]
+    public async Task be_healthy_if_file_is_available()
+    {
+        var webHostBuilder = new WebHostBuilder()
+           .ConfigureServices(services =>
+           {
+               services.AddHealthChecks()
+                   .AddFile(setup => setup.AddFile(Path.Combine(Directory.GetCurrentDirectory(), "HealthChecks.System.Tests.dll")), tags: new string[] { "file" });
+           })
+           .Configure(app =>
+           {
+               app.UseHealthChecks("/health", new HealthCheckOptions
+               {
+                   Predicate = r => r.Tags.Contains("file")
+               });
+           });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task be_healthy_if_no_file_provided()
+    {
+        var webHostBuilder = new WebHostBuilder()
+           .ConfigureServices(services =>
+           {
+               services.AddHealthChecks()
+                   .AddFile(setup =>
+                   {
+                   }, tags: new string[] { "file" });
+           })
+           .Configure(app =>
+           {
+               app.UseHealthChecks("/health", new HealthCheckOptions
+               {
+                   Predicate = r => r.Tags.Contains("file")
+               });
+           });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task be_unhealthy_if_file_is_not_available()
+    {
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddFile(setup => setup.AddFile($"{Directory.GetCurrentDirectory()}/non-existing-file"), tags: new string[] { "file" });
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("file")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+}

--- a/test/HealthChecks.System.Tests/HealthChecks.System.approved.txt
+++ b/test/HealthChecks.System.Tests/HealthChecks.System.approved.txt
@@ -14,6 +14,18 @@ namespace HealthChecks.System
         public HealthChecks.System.DiskStorageOptions WithCheckAllDrives() { }
         public delegate string ErrorDescription(string driveName, long minimumFreeMegabytes, long? actualFreeMegabytes);
     }
+    public class FileHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
+    {
+        public FileHealthCheck(HealthChecks.System.FileHealthCheckOptions fileOptions) { }
+        public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public class FileHealthCheckOptions
+    {
+        public FileHealthCheckOptions() { }
+        public bool CheckAllFiles { get; set; }
+        public HealthChecks.System.FileHealthCheckOptions AddFile(string file) { }
+        public HealthChecks.System.FileHealthCheckOptions WithCheckAllFiles() { }
+    }
     public class FolderHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
         public FolderHealthCheck(HealthChecks.System.FolderHealthCheckOptions folderOptions) { }
@@ -54,6 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class SystemHealthCheckBuilderExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddDiskStorageHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<HealthChecks.System.DiskStorageOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddFile(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<HealthChecks.System.FileHealthCheckOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddFile(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<System.IServiceProvider, HealthChecks.System.FileHealthCheckOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddFolder(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<HealthChecks.System.FolderHealthCheckOptions>? setup, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddPrivateMemoryHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, long maximumMemoryBytes, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddProcessAllocatedMemoryHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, int maximumMegabytesAllocated, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }

--- a/test/HealthChecks.System.Tests/HealthChecks.System.approved.txt
+++ b/test/HealthChecks.System.Tests/HealthChecks.System.approved.txt
@@ -23,6 +23,7 @@ namespace HealthChecks.System
     {
         public FileHealthCheckOptions() { }
         public bool CheckAllFiles { get; set; }
+        public System.Collections.Generic.List<string> Files { get; }
         public HealthChecks.System.FileHealthCheckOptions AddFile(string file) { }
         public HealthChecks.System.FileHealthCheckOptions WithCheckAllFiles() { }
     }


### PR DESCRIPTION
This health check allows to check fo existing files similar to FolderHealthCheck

    services.AddHealthChecks()
        .AddFile(setup => setup.AddFile("FileUnderTest")), tags: new string[] { "file" });