### PR TITLE
RedisHealthCheck bug fixes

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -45,7 +45,7 @@
     <HealthCheckPublisherSeq>7.0.0</HealthCheckPublisherSeq>
     <HealthCheckRabbitMQ>7.0.0</HealthCheckRabbitMQ>
     <HealthCheckRavenDB>7.0.0</HealthCheckRavenDB>
-    <HealthCheckRedis>7.0.0</HealthCheckRedis>
+    <HealthCheckRedis>7.0.1</HealthCheckRedis>
     <HealthCheckSendGrid>7.0.0</HealthCheckSendGrid>
     <HealthCheckSignalR>7.0.0</HealthCheckSignalR>
     <HealthCheckSolr>7.0.0</HealthCheckSolr>

--- a/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Redis/DependencyInjection/RedisHealthCheckBuilderExtensions.cs
@@ -115,7 +115,7 @@ public static class RedisHealthCheckBuilderExtensions
 
         return builder.Add(new HealthCheckRegistration(
            name ?? NAME,
-           sp => new RedisHealthCheck(connectionMultiplexerFactory(sp)),
+           sp => new RedisHealthCheck(() => connectionMultiplexerFactory(sp)),
            failureStatus,
            tags,
            timeout));

--- a/src/HealthChecks.Redis/RedisHealthCheck.cs
+++ b/src/HealthChecks.Redis/RedisHealthCheck.cs
@@ -9,7 +9,7 @@ namespace HealthChecks.Redis;
 /// </summary>
 public class RedisHealthCheck : IHealthCheck
 {
-    private static readonly ConcurrentDictionary<string, ConnectionMultiplexer> _connections = new();
+    private static readonly ConcurrentDictionary<string, IConnectionMultiplexer> _connections = new();
     private readonly string? _redisConnectionString;
     private readonly IConnectionMultiplexer? _connectionMultiplexer;
 
@@ -28,7 +28,7 @@ public class RedisHealthCheck : IHealthCheck
     {
         try
         {
-            var connection = (ConnectionMultiplexer)_connectionMultiplexer!;
+            IConnectionMultiplexer? connection = _connectionMultiplexer;
 
             if (_redisConnectionString is not null && !_connections.TryGetValue(_redisConnectionString, out connection))
             {
@@ -50,7 +50,7 @@ public class RedisHealthCheck : IHealthCheck
                 }
             }
 
-            foreach (var endPoint in connection.GetEndPoints(configuredOnly: true))
+            foreach (var endPoint in connection!.GetEndPoints(configuredOnly: true))
             {
                 var server = connection.GetServer(endPoint);
 

--- a/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Redis.Tests/DependencyInjection/RegistrationTests.cs
@@ -106,6 +106,7 @@ public class redis_registration_should
 
         registration.Name.ShouldBe("redis");
         check.ShouldBeOfType<RedisHealthCheck>();
-        factoryCalled.ShouldBeTrue();
+        // the factory is called when it's used for the first time, as it can throw
+        factoryCalled.ShouldBeFalse();
     }
 }

--- a/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
+++ b/test/HealthChecks.Redis.Tests/Functional/RedisHealthCheckTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using StackExchange.Redis;
+using StackExchange.Redis.Maintenance;
+using StackExchange.Redis.Profiling;
 
 namespace HealthChecks.Redis.Tests.Functional;
 
@@ -163,5 +165,83 @@ public class redis_healthcheck_should
 
         response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).ShouldContain("Healthcheck timed out");
+    }
+
+    [Fact]
+    public async Task not_every_IConnectionMultiplexer_is_ConnectionMultiplexer()
+    {
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IConnectionMultiplexer>(new NotConnectionMultiplexer());
+                services.AddHealthChecks().AddRedis(sp => sp.GetRequiredService<IConnectionMultiplexer>());
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = _ => true
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync().ConfigureAwait(false);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private sealed class NotConnectionMultiplexer : IConnectionMultiplexer
+    {
+        // it returns an empty array of endpoints, so nothing should get checked and OK should be returned by the health check
+        public EndPoint[] GetEndPoints(bool configuredOnly = false) => Array.Empty<EndPoint>();
+
+#pragma warning disable CS0067
+        public override string ToString() => "stop complaining about Nullability";
+        public string ClientName => throw new NotImplementedException();
+        public string Configuration => throw new NotImplementedException();
+        public int TimeoutMilliseconds => throw new NotImplementedException();
+        public long OperationCount => throw new NotImplementedException();
+        public bool PreserveAsyncOrder { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool IsConnected => throw new NotImplementedException();
+        public bool IsConnecting => throw new NotImplementedException();
+        public bool IncludeDetailInExceptions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public int StormLogThreshold { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public event EventHandler<RedisErrorEventArgs>? ErrorMessage;
+        public event EventHandler<ConnectionFailedEventArgs>? ConnectionFailed;
+        public event EventHandler<InternalErrorEventArgs>? InternalError;
+        public event EventHandler<ConnectionFailedEventArgs>? ConnectionRestored;
+        public event EventHandler<EndPointEventArgs>? ConfigurationChanged;
+        public event EventHandler<EndPointEventArgs>? ConfigurationChangedBroadcast;
+        public event EventHandler<ServerMaintenanceEvent>? ServerMaintenanceEvent;
+        public event EventHandler<HashSlotMovedEventArgs>? HashSlotMoved;
+        public void Close(bool allowCommandsToComplete = true) => throw new NotImplementedException();
+        public Task CloseAsync(bool allowCommandsToComplete = true) => throw new NotImplementedException();
+        public bool Configure(TextWriter? log = null) => throw new NotImplementedException();
+        public Task<bool> ConfigureAsync(TextWriter? log = null) => throw new NotImplementedException();
+        public void Dispose() => throw new NotImplementedException();
+        public ValueTask DisposeAsync() => throw new NotImplementedException();
+        public void ExportConfiguration(Stream destination, ExportOptions options = (ExportOptions)(-1)) => throw new NotImplementedException();
+        public ServerCounters GetCounters() => throw new NotImplementedException();
+        public IDatabase GetDatabase(int db = -1, object? asyncState = null) => throw new NotImplementedException();
+        public int GetHashSlot(RedisKey key) => throw new NotImplementedException();
+        public IServer GetServer(string host, int port, object? asyncState = null) => throw new NotImplementedException();
+        public IServer GetServer(string hostAndPort, object? asyncState = null) => throw new NotImplementedException();
+        public IServer GetServer(IPAddress host, int port) => throw new NotImplementedException();
+        public IServer GetServer(EndPoint endpoint, object? asyncState = null) => throw new NotImplementedException();
+        public IServer[] GetServers() => throw new NotImplementedException();
+        public string GetStatus() => throw new NotImplementedException();
+        public void GetStatus(TextWriter log) => throw new NotImplementedException();
+        public string? GetStormLog() => throw new NotImplementedException();
+        public ISubscriber GetSubscriber(object? asyncState = null) => throw new NotImplementedException();
+        public int HashSlot(RedisKey key) => throw new NotImplementedException();
+        public long PublishReconfigure(CommandFlags flags = CommandFlags.None) => throw new NotImplementedException();
+        public Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None) => throw new NotImplementedException();
+        public void RegisterProfiler(Func<ProfilingSession?> profilingSessionProvider) => throw new NotImplementedException();
+        public void ResetStormLog() => throw new NotImplementedException();
+        public void Wait(Task task) => throw new NotImplementedException();
+        public T Wait<T>(Task<T> task) => throw new NotImplementedException();
+        public void WaitAll(params Task[] tasks) => throw new NotImplementedException();
+#pragma warning restore CS0067
     }
 }


### PR DESCRIPTION
While using `RedisHealthCheck` and reading it's code I've found two bugs.

## not every IConnectionMultiplexer is ConnectionMultiplexer

The ctor accepts an `IConnectionMultiplexer` interface:

https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/c000704e1e256c932539fcd5d4c8df781e8ec1a7/src/HealthChecks.Redis/RedisHealthCheck.cs#L21

but later a cast to concrete type was being performed, which could have resulted in an exception in a scenario where the user would provide an instance of type that implements the `IConnectionMultiplexer` interface, but does not derive from `ConnectionMultiplexer` type

https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/c000704e1e256c932539fcd5d4c8df781e8ec1a7/src/HealthChecks.Redis/RedisHealthCheck.cs#L31

## ConnectionMultiplexer.Connect should not be called during HealthCheckRegistration creation

A call to `ConnectionMultiplexer.Connect` throws when it is not possible to connect to the redis server(s). The call should not be invoked when `HealthCheckRegistration` is created, but when `RedisHealthCheck` needs the `IConnectionMultiplexer` for the first time, so exceptions can be handled gracefully.

I've added a test that runs into the problem:

```csharp
// This factory will throw when called for the first time.
// The health check should take care of that and report Unhealthy status rather than throw an exception.
services.AddSingleton<IConnectionMultiplexer>(
    _ => ConnectionMultiplexer.Connect("nonexistinghost:6379,allowAdmin=true"));
services.AddHealthChecks()
    .AddRedis(serviceProvider => serviceProvider.GetRequiredService<IConnectionMultiplexer>());
```

<details>

```log
  Failed HealthChecks.Redis.Tests.Functional.redis_healthcheck_should.be_unhealthy_when_connection_multiplexer_factory_throws_on_connect [8 s]
  Error Message:
   StackExchange.Redis.RedisConnectionException : It was not possible to connect to the redis server(s). Error connecting right now. To allow this multiplexer to continue retrying until it's able to connect, use abortConnect=false in your connection string or AbortOnConnectFail=false; in your code.
  Stack Trace:
     at StackExchange.Redis.ConnectionMultiplexer.ConnectImpl(ConfigurationOptions configuration, TextWriter log, Nullable`1 serverType, EndPointCollection endpoints) in /_/src/StackExchange.Redis/ConnectionMultiplexer.cs:line 708
   at StackExchange.Redis.ConnectionMultiplexer.Connect(ConfigurationOptions configuration, TextWriter log) in /_/src/StackExchange.Redis/ConnectionMultiplexer.cs:line 673
   at StackExchange.Redis.ConnectionMultiplexer.Connect(String configuration, TextWriter log) in /_/src/StackExchange.Redis/ConnectionMultiplexer.cs:line 651
   at HealthChecks.Redis.Tests.Functional.redis_healthcheck_should.<>c.<be_unhealthy_when_connection_multiplexer_factory_throws_on_connect>b__4_2(IServiceProvider _) in D:\projects\forks\healthChecks\test\HealthChecks.Redis.Tests\Functional\RedisHealthCheckTests.cs:line 126
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(Type serviceType)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType, ServiceProviderEngineScope serviceProviderEngineScope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
   at HealthChecks.Redis.Tests.Functional.redis_healthcheck_should.<>c.<be_unhealthy_when_connection_multiplexer_factory_throws_on_connect>b__4_3(IServiceProvider serviceProvider) in D:\projects\forks\healthChecks\test\HealthChecks.Redis.Tests\Functional\RedisHealthCheckTests.cs:line 128
   at Microsoft.Extensions.DependencyInjection.RedisHealthCheckBuilderExtensions.<>c__DisplayClass4_0.<AddRedis>b__0(IServiceProvider sp) in D:\projects\forks\healthChecks\src\HealthChecks.Redis\DependencyInjection\RedisHealthCheckBuilderExtensions.cs:line 118
   at Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService.RunCheckAsync(HealthCheckRegistration registration, CancellationToken cancellationToken)
   at Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService.RunCheckAsync(HealthCheckRegistration registration, CancellationToken cancellationToken)
   at Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService.CheckHealthAsync(Func`2 predicate, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckMiddleware.InvokeAsync(HttpContext httpContext)
   at Microsoft.AspNetCore.TestHost.HttpContextBuilder.<>c__DisplayClass23_0.<<SendAsync>g__RunRequestAsync|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.TestHost.ClientHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at HealthChecks.Redis.Tests.Functional.redis_healthcheck_should.be_unhealthy_when_connection_multiplexer_factory_throws_on_connect() in D:\projects\forks\healthChecks\test\HealthChecks.Redis.Tests\Functional\RedisHealthCheckTests.cs:line 140
```

</details>



cc @sungam3r