### PR TITLE
use GH reusable workflows to reduce .yml duplication

### DIFF
--- a/.github/workflows/healthchecks_azurekeyvault_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd.yml
@@ -8,22 +8,8 @@ on:
 
 jobs:
   build:
-    env:
+    uses: ./.github/workflows/reusable_workflow.yml
+    with:
       BUILD_CONFIG: Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: dotnet restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-      - name: Build
-        run: dotnet build --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj -c $BUILD_CONFIG
-      - name: Pack
-        run: dotnet pack --no-build ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj -c $BUILD_CONFIG -o ./artifacts
-      - name: Publish
-        run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.AzureKeyVault.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      PROJECT_PATH: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.AzureKeyVault

--- a/.github/workflows/healthchecks_azurekeyvault_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/reusable_workflow.yml
+    uses: ./.github/workflows/reusable_cd_workflow.yml
     with:
       BUILD_CONFIG: Release
       PROJECT_PATH: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj

--- a/.github/workflows/healthchecks_azurekeyvault_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/reusable_cd_workflow.yml
+    secrets: inherit
     with:
       BUILD_CONFIG: Release
       PROJECT_PATH: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj

--- a/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/reusable_cd_preview_workflow.yml
+    secrets: inherit
     with:
       BUILD_CONFIG: Release
       VERSION_SUFFIX_PREFIX: rc2

--- a/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_cd_preview.yml
@@ -8,23 +8,9 @@ on:
 
 jobs:
   build:
-    env:
+    uses: ./.github/workflows/reusable_cd_preview_workflow.yml
+    with:
       BUILD_CONFIG: Release
-      VERSION_SUFFIX: rc2.${{ github.run_number }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: dotnet restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-      - name: Build
-        run: dotnet build --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj -c $BUILD_CONFIG
-      - name: Pack
-        run: dotnet pack --no-build ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG -o ./artifacts
-      - name: Publish
-        run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.AzureKeyVault.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      VERSION_SUFFIX_PREFIX: rc2
+      PROJECT_PATH: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.AzureKeyVault

--- a/.github/workflows/healthchecks_azurekeyvault_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_ci.yml
@@ -9,6 +9,7 @@ on:
      - test/HealthChecks.AzureKeyVault.Tests/**
      - test/_SHARED/**
      - .github/workflows/healthchecks_azurekeyvault_ci.yml
+     - .github/workflows/reusable_ci_workflow.yml
      - Directory.Build.props
      - Directory.Build.targets
    tags-ignore:
@@ -22,6 +23,7 @@ on:
       - test/HealthChecks.AzureKeyVault.Tests/**
       - test/_SHARED/**
       - .github/workflows/healthchecks_azurekeyvault_ci.yml
+     - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
 
@@ -29,6 +31,6 @@ jobs:
   build:
     uses: ./.github/workflows/reusable_ci_workflow.yml
     with:
-      projectPath: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-      testProjectPath: ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
-      flags: AzureKeyVault
+      PROJECT_PATH: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+      TEST_PROJECT_PATH: ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
+      CODECOV_FLAGS: AzureKeyVault

--- a/.github/workflows/healthchecks_azurekeyvault_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_ci.yml
@@ -23,7 +23,7 @@ on:
       - test/HealthChecks.AzureKeyVault.Tests/**
       - test/_SHARED/**
       - .github/workflows/healthchecks_azurekeyvault_ci.yml
-     - .github/workflows/reusable_ci_workflow.yml
+      - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
 

--- a/.github/workflows/healthchecks_azurekeyvault_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_ci.yml
@@ -27,39 +27,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: |
-          dotnet restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj &&
-          dotnet restore ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
-      - name: Check formatting
-        run: |
-          dotnet format --no-restore --verify-no-changes --severity warn ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj || (echo "Run 'dotnet format' to fix issues" && exit 1) &&
-          dotnet format --no-restore --verify-no-changes --severity warn ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj || (echo "Run 'dotnet format' to fix issues" && exit 1)
-      - name: Build
-        run: |
-          dotnet build --no-restore ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
-          dotnet build --no-restore ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
-      - name: Test
-        run: >
-          dotnet test
-          ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
-          --no-restore
-          --no-build
-          --collect "XPlat Code Coverage"
-          --results-directory .coverage
-          --
-          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v3
-        with:
-          flags: AzureKeyVault
-          directory: .coverage
+    uses: ./.github/workflows/reusable_ci_workflow.yml
+    with:
+      projectPath: ./src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+      testProjectPath: ./test/HealthChecks.AzureKeyVault.Tests/HealthChecks.AzureKeyVault.Tests.csproj
+      flags: AzureKeyVault

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
@@ -5,10 +5,10 @@ on:
     tags:
       - release-azurekeyvault-secrets-*
       - release-all-*
-      
+
 jobs:
   build:
-    uses: ./.github/workflows/reusable_workflow.yml
+    uses: ./.github/workflows/reusable_cd_workflow.yml
     with:
       BUILD_CONFIG: Release
       PROJECT_PATH: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
@@ -5,25 +5,11 @@ on:
     tags:
       - release-azurekeyvault-secrets-*
       - release-all-*
-
+      
 jobs:
   build:
-    env:
+    uses: ./.github/workflows/reusable_workflow.yml
+    with:
       BUILD_CONFIG: Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: dotnet restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
-      - name: Build
-        run: dotnet build --no-restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj -c $BUILD_CONFIG
-      - name: Pack
-        run: dotnet pack --no-build ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj -c $BUILD_CONFIG -o ./artifacts
-      - name: Publish
-        run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.Azure.KeyVault.Secrets.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      PROJECT_PATH: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.Azure.KeyVault.Secrets

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_cd.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/reusable_cd_workflow.yml
+    secrets: inherit
     with:
       BUILD_CONFIG: Release
       PROJECT_PATH: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_cd_preview.yml
@@ -8,23 +8,9 @@ on:
 
 jobs:
   build:
-    env:
+    uses: ./.github/workflows/reusable_cd_preview_workflow.yml
+    with:
       BUILD_CONFIG: Release
-      VERSION_SUFFIX: rc1.${{ github.run_number }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: dotnet restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
-      - name: Build
-        run: dotnet build --no-restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj -c $BUILD_CONFIG
-      - name: Pack
-        run: dotnet pack --no-build ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj --version-suffix $VERSION_SUFFIX -c $BUILD_CONFIG -o ./artifacts
-      - name: Publish
-        run: dotnet nuget push ./artifacts/AspNetCore.HealthChecks.Azure.KeyVault.Secrets.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      VERSION_SUFFIX_PREFIX: rc1
+      PROJECT_PATH: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.Azure.KeyVault.Secrets

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_cd_preview.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_cd_preview.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/reusable_cd_preview_workflow.yml
+    secrets: inherit
     with:
       BUILD_CONFIG: Release
       VERSION_SUFFIX_PREFIX: rc1

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
@@ -9,6 +9,7 @@ on:
      - test/HealthChecks.Azure.KeyVault.Secrets.Tests/**
      - test/_SHARED/**
      - .github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
+     - .github/workflows/reusable_ci_workflow.yml
      - Directory.Build.props
      - Directory.Build.targets
    tags-ignore:
@@ -22,44 +23,15 @@ on:
       - test/HealthChecks.Azure.KeyVault.Secrets.Tests/**
       - test/_SHARED/**
       - .github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
+      - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-      - name: Restore
-        run: |
-          dotnet restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj &&
-          dotnet restore ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
-      - name: Check formatting
-        run: |
-          dotnet format --no-restore --verify-no-changes --severity warn ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj || (echo "Run 'dotnet format' to fix issues" && exit 1) &&
-          dotnet format --no-restore --verify-no-changes --severity warn ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj || (echo "Run 'dotnet format' to fix issues" && exit 1)
-      - name: Build
-        run: |
-          dotnet build --no-restore ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
-          dotnet build --no-restore ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
-      - name: Test
-        run: >
-          dotnet test
-          ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
-          --no-restore
-          --no-build
-          --collect "XPlat Code Coverage"
-          --results-directory .coverage
-          --
-          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v3
-        with:
-          flags: AzureKeyVault
-          directory: .coverage
+    uses: ./.github/workflows/reusable_ci_workflow.yml
+    with:
+      projectPath: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
+      testProjectPath: ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
+      flags: AzureKeyVault
+

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     uses: ./.github/workflows/reusable_ci_workflow.yml
     with:
-      projectPath: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
-      testProjectPath: ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
-      flags: AzureKeyVault
+      PROJECT_PATH: ./src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
+      TEST_PROJECT_PATH: ./test/HealthChecks.Azure.KeyVault.Secrets.Tests/HealthChecks.Azure.KeyVault.Secrets.Tests.csproj
+      CODECOV_FLAGS: AzureKeyVault
 

--- a/.github/workflows/reusable_cd_preview_workflow.yml
+++ b/.github/workflows/reusable_cd_preview_workflow.yml
@@ -1,0 +1,37 @@
+name: Reusable Preview CD Workflow
+
+on:
+  workflow_call:
+    inputs:
+      BUILD_CONFIG:
+        required: true
+        type: string
+      VERSION_SUFFIX_PREFIX:
+        required: true
+        type: string
+      PROJECT_PATH:
+        required: true
+        type: string
+      PACKAGE_NAME:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+      - name: Restore
+        run: dotnet restore ${{inputs.PROJECT_PATH}}
+      - name: Build
+        run: dotnet build --no-restore ${{inputs.PROJECT_PATH}} -c ${{inputs.BUILD_CONFIG}}
+      - name: Pack
+        run: dotnet pack --no-build ${{inputs.PROJECT_PATH}} --version-suffix ${{inputs.VERSION_SUFFIX_PREFIX}}.${{ github.run_number }} -c ${{inputs.BUILD_CONFIG}} -o ./artifacts
+      - name: Publish
+        run: dotnet nuget push ./artifacts/${{inputs.PACKAGE_NAME}}.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/reusable_cd_workflow.yml
+++ b/.github/workflows/reusable_cd_workflow.yml
@@ -1,0 +1,34 @@
+name: Reusable CD Workflow
+
+on:
+  workflow_call:
+    inputs:
+      BUILD_CONFIG:
+        required: true
+        type: string
+      PROJECT_PATH:
+        required: true
+        type: string
+      PACKAGE_NAME:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+      - name: Restore
+        run: dotnet restore ${{inputs.PROJECT_PATH}}
+      - name: Build
+        run: dotnet build --no-restore ${{inputs.PROJECT_PATH}} -c ${{inputs.BUILD_CONFIG}}
+      - name: Pack
+        run: dotnet pack --no-build ${{inputs.PROJECT_PATH}} -c ${{inputs.BUILD_CONFIG}} -o ./artifacts
+      - name: Publish
+        run: dotnet nuget push ./artifacts/${{inputs.PACKAGE_NAME}}.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/reusable_ci_workflow.yml
+++ b/.github/workflows/reusable_ci_workflow.yml
@@ -3,13 +3,13 @@ name: Reusable CI workflow
 on:
   workflow_call:
     inputs:
-      projectPath:
+      PROJECT_PATH:
         required: true
         type: string
-      testProjectPath:
+      TEST_PROJECT_PATH:
         required: true
         type: string
-      flags:
+      CODECOV_FLAGS:
         required: true
         type: string
 
@@ -26,20 +26,20 @@ jobs:
             7.0.x
       - name: Restore
         run: |
-          dotnet restore ${{inputs.projectPath}} &&
-          dotnet restore ${{inputs.testProjectPath}}
+          dotnet restore ${{inputs.PROJECT_PATH}} &&
+          dotnet restore ${{inputs.TEST_PROJECT_PATH}}
       - name: Check formatting
         run: |
-          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.projectPath}} || (echo "Run 'dotnet format' to fix issues" && exit 1) &&
-          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.testProjectPath}} || (echo "Run 'dotnet format' to fix issues" && exit 1)
+          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.PROJECT_PATH}} || (echo "Run 'dotnet format' to fix issues" && exit 1) &&
+          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.TEST_PROJECT_PATH}} || (echo "Run 'dotnet format' to fix issues" && exit 1)
       - name: Build
         run: |
-          dotnet build --no-restore ${{inputs.projectPath}}
-          dotnet build --no-restore ${{inputs.testProjectPath}}
+          dotnet build --no-restore ${{inputs.PROJECT_PATH}}
+          dotnet build --no-restore ${{inputs.TEST_PROJECT_PATH}}
       - name: Test
         run: >
           dotnet test
-          ${{inputs.testProjectPath}}
+          ${{inputs.TEST_PROJECT_PATH}}
           --no-restore
           --no-build
           --collect "XPlat Code Coverage"
@@ -49,5 +49,5 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@v3
         with:
-          flags: ${{inputs.flags}}
+          flags: ${{inputs.CODECOV_FLAGS}}
           directory: .coverage

--- a/.github/workflows/reusable_ci_workflow.yml
+++ b/.github/workflows/reusable_ci_workflow.yml
@@ -1,0 +1,53 @@
+name: Reusable CI workflow
+
+on:
+  workflow_call:
+    inputs:
+      projectPath:
+        required: true
+        type: string
+      testProjectPath:
+        required: true
+        type: string
+      flags:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+      - name: Restore
+        run: |
+          dotnet restore ${{inputs.projectPath}} &&
+          dotnet restore ${{inputs.testProjectPath}}
+      - name: Check formatting
+        run: |
+          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.projectPath}} || (echo "Run 'dotnet format' to fix issues" && exit 1) &&
+          dotnet format --no-restore --verify-no-changes --severity warn ${{inputs.testProjectPath}} || (echo "Run 'dotnet format' to fix issues" && exit 1)
+      - name: Build
+        run: |
+          dotnet build --no-restore ${{inputs.projectPath}}
+          dotnet build --no-restore ${{inputs.testProjectPath}}
+      - name: Test
+        run: >
+          dotnet test
+          ${{inputs.testProjectPath}}
+          --no-restore
+          --no-build
+          --collect "XPlat Code Coverage"
+          --results-directory .coverage
+          --
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: ${{inputs.flags}}
+          directory: .coverage

--- a/src/HealthChecks.Azure.KeyVault.Secrets/AzureKeyVaultSecretsHealthCheck.cs
+++ b/src/HealthChecks.Azure.KeyVault.Secrets/AzureKeyVaultSecretsHealthCheck.cs
@@ -31,7 +31,7 @@ public sealed class AzureKeyVaultSecretsHealthCheck : IHealthCheck
     public AzureKeyVaultSecretsHealthCheck(SecretClient secretClient, AzureKeyVaultSecretOptions options)
     {
         _secretClient = Guard.ThrowIfNull(secretClient);
-        _options = options;
+        _options = Guard.ThrowIfNull(options);
     }
 
     /// <inheritdoc />

--- a/src/HealthChecks.Azure.KeyVault.Secrets/AzureKeyVaultSecretsHealthCheck.cs
+++ b/src/HealthChecks.Azure.KeyVault.Secrets/AzureKeyVaultSecretsHealthCheck.cs
@@ -31,7 +31,7 @@ public sealed class AzureKeyVaultSecretsHealthCheck : IHealthCheck
     public AzureKeyVaultSecretsHealthCheck(SecretClient secretClient, AzureKeyVaultSecretOptions options)
     {
         _secretClient = Guard.ThrowIfNull(secretClient);
-        _options = Guard.ThrowIfNull(options);
+        _options = options;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
I am about to introduce more new packages and I wonder whether it would be possible to reduce the .yml duplication by using workflows.

I wrote it based on https://dev.to/n3wt0n/avoid-duplication-github-actions-reusable-workflows-3ae8