### PR TITLE
Npgsql: don't create more than one DataSource

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -39,7 +39,7 @@
     <HealthCheckMySql>7.0.0</HealthCheckMySql>
     <HealthCheckNetwork>7.0.0</HealthCheckNetwork>
     <HealthCheckNats>7.0.0</HealthCheckNats>
-    <HealthCheckNpgSql>7.0.0</HealthCheckNpgSql>
+    <HealthCheckNpgSql>7.1.0</HealthCheckNpgSql>
     <HealthCheckOpenIdConnectServer>7.1.0</HealthCheckOpenIdConnectServer>
     <HealthCheckOracle>7.0.0</HealthCheckOracle>
     <HealthCheckPrometheusMetrics>7.0.0</HealthCheckPrometheusMetrics>

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -106,7 +106,7 @@ public static class NpgSqlHealthCheckBuilderExtensions
             name ?? NAME,
             sp =>
             {
-                // The Data Source needs to be created only once,
+                // The Data Source needs to be fromFactory only once,
                 // as each instance has it's own connection pool.
                 // See https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993 for more details.
 
@@ -115,19 +115,33 @@ public static class NpgSqlHealthCheckBuilderExtensions
                 if (existingDataSource is null)
                 {
                     // Create a new Data Source
-                    NpgsqlDataSource created = dbDataSourceFactory(sp);
-                    // Perform an atomic exchange, but only if the value is still null.
-                    existingDataSource = Interlocked.CompareExchange(ref dataSource, created, null);
-                    if (existingDataSource is not null)
+                    NpgsqlDataSource fromFactory = dbDataSourceFactory(sp);
+                    // Try to resolve the Data Source from DI.
+                    NpgsqlDataSource? fromDI = sp.GetService<NpgsqlDataSource>();
+
+                    if (fromDI is not null && fromDI.ConnectionString.Equals(fromFactory.ConnectionString))
                     {
-                        // Some other thread has created the data source in the meantime,
-                        // we dispose our own copy, and use the existing instance.
-                        created.Dispose();
-                        options.DataSource = existingDataSource;
+                        // If they are using the same ConnectionString, we can reuse the instance from DI.
+                        // So there is only ONE NpgsqlDataSource per the whole app and ONE connection pool.
+                        fromFactory.Dispose();
+                        Interlocked.Exchange(ref dataSource, fromDI);
+                        options.DataSource = fromDI;
                     }
                     else
                     {
-                        options.DataSource = created;
+                        // Perform an atomic exchange, but only if the value is still null.
+                        existingDataSource = Interlocked.CompareExchange(ref dataSource, fromFactory, null);
+                        if (existingDataSource is not null)
+                        {
+                            // Some other thread has created the data source in the meantime,
+                            // we dispose our own copy, and use the existing instance.
+                            fromFactory.Dispose();
+                            options.DataSource = existingDataSource;
+                        }
+                        else
+                        {
+                            options.DataSource = fromFactory;
+                        }
                     }
                 }
 

--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -106,7 +106,7 @@ public static class NpgSqlHealthCheckBuilderExtensions
             name ?? NAME,
             sp =>
             {
-                // The Data Source needs to be fromFactory only once,
+                // The Data Source needs to be created only once,
                 // as each instance has it's own connection pool.
                 // See https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993 for more details.
 
@@ -123,7 +123,12 @@ public static class NpgSqlHealthCheckBuilderExtensions
                     {
                         // If they are using the same ConnectionString, we can reuse the instance from DI.
                         // So there is only ONE NpgsqlDataSource per the whole app and ONE connection pool.
-                        fromFactory.Dispose();
+
+                        if (!ReferenceEquals(fromDI, fromFactory))
+                        {
+                            // Dispose it, as long as it's not the same instance.
+                            fromFactory.Dispose();
+                        }
                         Interlocked.Exchange(ref dataSource, fromDI);
                         options.DataSource = fromDI;
                     }

--- a/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
+++ b/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <PackageTags>$(PackageTags);Beat;Postgress</PackageTags>
     <Description>HealthChecks.NpgSql is a health check for Postgress Sql.</Description>
     <VersionPrefix>$(HealthCheckNpgSql)</VersionPrefix>

--- a/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
+++ b/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.9" />
   </ItemGroup>
 

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,6 +1,6 @@
+using System.Reflection;
 using HealthChecks.NpgSql;
 using Npgsql;
-using System.Reflection;
 
 namespace HealthChecks.Npgsql.Tests.DependencyInjection;
 

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,4 +1,6 @@
 using HealthChecks.NpgSql;
+using Npgsql;
+using System.Reflection;
 
 namespace HealthChecks.Npgsql.Tests.DependencyInjection;
 
@@ -84,6 +86,46 @@ public class npgsql_registration_should
         for (int i = 0; i < 10; i++)
         {
             _ = registration.Factory(serviceProvider);
+        }
+
+        factoryCalls.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void factory_reuses_pre_registered_datasource_when_possible(bool sameConnectionString)
+    {
+        const string connectionString = "Server=localhost";
+        ServiceCollection services = new();
+
+        services.AddSingleton<NpgsqlDataSource>(serviceProvider =>
+        {
+            var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+            return dataSourceBuilder.Build();
+        });
+
+        int factoryCalls = 0;
+        services.AddHealthChecks()
+            .AddNpgSql(_ =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                return sameConnectionString ? connectionString : $"{connectionString}2";
+            }, name: "my-npg-1");
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.Single();
+
+        for (int i = 0; i < 10; i++)
+        {
+            var healthCheck = (NpgSqlHealthCheck)registration.Factory(serviceProvider);
+            var fieldInfo = typeof(NpgSqlHealthCheck).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
+            var npgSqlHealthCheckOptions = (NpgSqlHealthCheckOptions)fieldInfo!.GetValue(healthCheck)!;
+
+            Assert.Equal(sameConnectionString, ReferenceEquals(serviceProvider.GetRequiredService<NpgsqlDataSource>(), npgSqlHealthCheckOptions.DataSource));
         }
 
         factoryCalls.ShouldBe(1);


### PR DESCRIPTION
3 out of 4 DI extension methods are now ensuring that the `DataSource` is created only once (in a thread-safe way), and when it's possible they reuse the instance registered in the DI.

It's not an ideal fix, because the current design still allows the users to have more than one `NpgsqlDataSource` per their app. Example:

```cs
void Configure(IHostApplicationBuilder builder)
{
    builder.Services.AddNpgsqlDataSource("connectionString"); // registers a singleton factory for NpgsqlDataSource using Npgsql.DependencyInjection package, is used by the app
    builder.AddHealthChecks().AddNpgSql(new NpgSqlHealthCheckOptions()
    {
        ConnectionString = "connectionString" // registers a factory used only by the health check
    });
}
```

@unaizorrilla it's the fix I propose for 7.0.

For 8.0 we need to introduce a breaking change similar to what I did for the Azure clients in https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/2040

Contributes to #1993.