### PR TITLE
Update SSH.NET to 2023.0.0

### DIFF
--- a/build/versions.props
+++ b/build/versions.props
@@ -37,7 +37,7 @@
     <HealthCheckKubernetes>7.0.0</HealthCheckKubernetes>
     <HealthCheckMongoDB>7.0.0</HealthCheckMongoDB>
     <HealthCheckMySql>7.0.0</HealthCheckMySql>
-    <HealthCheckNetwork>7.0.0</HealthCheckNetwork>
+    <HealthCheckNetwork>7.1.0</HealthCheckNetwork>
     <HealthCheckNats>7.0.0</HealthCheckNats>
     <HealthCheckNpgSql>7.1.0</HealthCheckNpgSql>
     <HealthCheckOpenIdConnectServer>7.1.0</HealthCheckOpenIdConnectServer>

--- a/src/HealthChecks.Network/HealthChecks.Network.csproj
+++ b/src/HealthChecks.Network/HealthChecks.Network.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.9" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <Compile Include="../HealthCheckResultTask.cs" />


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files