### PR TITLE
Send a MySQL ping packet by default

### DIFF
--- a/src/HealthChecks.MySql/DependencyInjection/MySqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.MySql/DependencyInjection/MySqlHealthCheckBuilderExtensions.cs
@@ -10,14 +10,13 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class MySqlHealthCheckBuilderExtensions
 {
     private const string NAME = "mysql";
-    internal const string HEALTH_QUERY = "SELECT 1;";
 
     /// <summary>
     /// Add a health check for MySQL databases.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionString">The MySQL connection string to be used.</param>
-    /// <param name="healthQuery">The query to be executed.</param>
+    /// <param name="healthQuery">The optional query to be executed. If this is <c>null</c>, a MySQL "ping" packet will be sent to the server instead of a query.</param>
     /// <param name="configure">An optional action to allow additional MySQL specific configuration.</param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'mysql' will be used for the name.</param>
     /// <param name="failureStatus">
@@ -30,7 +29,7 @@ public static class MySqlHealthCheckBuilderExtensions
     public static IHealthChecksBuilder AddMySql(
         this IHealthChecksBuilder builder,
         string connectionString,
-        string healthQuery = HEALTH_QUERY,
+        string? healthQuery = null,
         Action<MySqlConnection>? configure = null,
         string? name = default,
         HealthStatus? failureStatus = default,
@@ -45,7 +44,7 @@ public static class MySqlHealthCheckBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
     /// <param name="connectionStringFactory">A factory to build the MySQL connection string to use.</param>
-    /// <param name="healthQuery">The query to be executed.</param>
+    /// <param name="healthQuery">The optional query to be executed. If this is <c>null</c>, a MySQL "ping" packet will be sent to the server instead of a query.</param>
     /// <param name="configure">An optional action to allow additional MySQL specific configuration.</param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'mysql' will be used for the name.</param>
     /// <param name="failureStatus">
@@ -58,7 +57,7 @@ public static class MySqlHealthCheckBuilderExtensions
     public static IHealthChecksBuilder AddMySql(
         this IHealthChecksBuilder builder,
         Func<IServiceProvider, string> connectionStringFactory,
-        string healthQuery = HEALTH_QUERY,
+        string? healthQuery = null,
         Action<MySqlConnection>? configure = null,
         string? name = default,
         HealthStatus? failureStatus = default,

--- a/src/HealthChecks.MySql/MySqlHealthCheckOptions.cs
+++ b/src/HealthChecks.MySql/MySqlHealthCheckOptions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using MySqlConnector;
 
@@ -17,7 +16,7 @@ public class MySqlHealthCheckOptions
     /// <summary>
     /// The query to be executed.
     /// </summary>
-    public string CommandText { get; set; } = MySqlHealthCheckBuilderExtensions.HEALTH_QUERY;
+    public string? CommandText { get; set; }
 
     /// <summary>
     /// An optional action executed before the connection is opened in the health check.


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous default behavior for the MySQL health check was to execute `SELECT 1;`. This is fairly heavyweight; it would be more efficient to send a MySQL "ping" packet, which is a binary test of server health. `MySqlHealthCheckOptions.CommandText` now defaults to `null`, meaning "ping the server". Users can opt in to setting a command that will be executed on the server, but the default is now a more efficient ping.

**Which issue(s) this PR fixes**:
Fixes #2031

Please reference the issue this PR will close: #2031

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes; it makes `MySqlHealthCheckOptions.CommandText` nullable and changes its default value; it also makes the `healthQuery` parameter to `AddMySql` nullable and changes its default value to `null`.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
