### PR TITLE
Improve Npgsql health check design

### DIFF
--- a/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.NpgSql/DependencyInjection/NpgSqlHealthCheckBuilderExtensions.cs
@@ -149,7 +149,7 @@ public static class NpgSqlHealthCheckBuilderExtensions
     /// Add a health check for Postgres databases.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-    /// <param name="options">Options for health check. It's mandatory to provide <see cref="NpgSqlHealthCheckOptions.ConnectionString"/>.</param>
+    /// <param name="options">Options for health check.</param>
     /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
     /// <param name="failureStatus">
     /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -9,20 +9,34 @@ namespace HealthChecks.NpgSql;
 /// </summary>
 public class NpgSqlHealthCheckOptions
 {
+    internal NpgSqlHealthCheckOptions()
+    {
+        // this ctor is internal on purpose:
+        // those who want to use DataSource need to use the extension methods
+        // that take care of creating the right thing 
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="NpgSqlHealthCheckOptions"/>.
+    /// </summary>
+    /// <param name="connectionString">The PostgreSQL connection string to be used.</param>
+    public NpgSqlHealthCheckOptions(string connectionString)
+    {
+        ConnectionString = Guard.ThrowIfNull(connectionString, throwOnEmptyString: true);
+    }
+
     /// <summary>
     /// The Postgres connection string to be used.
     /// Use <see cref="DataSource"/> property for advanced configuration.
     /// </summary>
-    public string? ConnectionString
-    {
-        get => DataSource?.ConnectionString;
-        set => DataSource = value is not null ? NpgsqlDataSource.Create(value) : null;
-    }
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// The Postgres data source to be used.
     /// </summary>
-    public NpgsqlDataSource? DataSource { get; set; }
+    internal NpgsqlDataSource? DataSource { get; set; }
+
+    internal bool TriedToResolveFromDI { get; set; }
 
     /// <summary>
     /// The query to be executed.

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -65,8 +65,6 @@ public class NpgSqlHealthCheckOptions
     /// </remarks>
     public NpgsqlDataSource? DataSource { get; internal set; }
 
-    internal bool TriedToResolveFromDI;
-
     /// <summary>
     /// The query to be executed.
     /// </summary>

--- a/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
+++ b/src/HealthChecks.NpgSql/NpgSqlHealthCheckOptions.cs
@@ -11,32 +11,61 @@ public class NpgSqlHealthCheckOptions
 {
     internal NpgSqlHealthCheckOptions()
     {
-        // this ctor is internal on purpose:
-        // those who want to use DataSource need to use the extension methods
-        // that take care of creating the right thing 
+        // This ctor is internal on purpose: those who want to use NpgSqlHealthCheckOptions
+        // need to specify either ConnectionString or DataSource when creating it.
+        // Making the ConnectionString and DataSource setters internal
+        // allows us to ensure that the customers don't try to mix both concepts.
+        // By encapsulating all of that, we ensure that all instances of this type are valid.
     }
 
     /// <summary>
     /// Creates an instance of <see cref="NpgSqlHealthCheckOptions"/>.
     /// </summary>
     /// <param name="connectionString">The PostgreSQL connection string to be used.</param>
+    /// <remarks>
+    /// <see cref="NpgsqlDataSource"/> supports additional configuration beyond the connection string,
+    /// such as logging, advanced authentication options, type mapping management, and more.
+    /// To further configure a data source, use <see cref=" NpgsqlDataSourceBuilder"/> and
+    /// the <see cref="NpgSqlHealthCheckOptions(NpgsqlDataSource)"/> constructor.
+    /// </remarks>
     public NpgSqlHealthCheckOptions(string connectionString)
     {
         ConnectionString = Guard.ThrowIfNull(connectionString, throwOnEmptyString: true);
     }
 
     /// <summary>
-    /// The Postgres connection string to be used.
-    /// Use <see cref="DataSource"/> property for advanced configuration.
+    /// Creates an instance of <see cref="NpgSqlHealthCheckOptions"/>.
     /// </summary>
-    public string? ConnectionString { get; set; }
+    /// <param name="dataSource">The Postgres <see cref="NpgsqlDataSource" /> to be used.</param>
+    /// <remarks>
+    /// Depending on how the <see cref="NpgsqlDataSource" /> was configured, the connections it hands out may be pooled.
+    /// That is why it should be the exact same <see cref="NpgsqlDataSource" /> that is used by other parts of your app.
+    /// </remarks>
+    public NpgSqlHealthCheckOptions(NpgsqlDataSource dataSource)
+    {
+        DataSource = Guard.ThrowIfNull(dataSource);
+    }
 
     /// <summary>
-    /// The Postgres data source to be used.
+    /// The Postgres connection string to be used.
     /// </summary>
-    internal NpgsqlDataSource? DataSource { get; set; }
+    /// <remarks>
+    /// <see cref="NpgsqlDataSource"/> supports additional configuration beyond the connection string,
+    /// such as logging, advanced authentication options, type mapping management, and more.
+    /// To further configure a data source, use <see cref=" NpgsqlDataSourceBuilder"/> and the <see cref="NpgSqlHealthCheckOptions(NpgsqlDataSource)"/> constructor.
+    /// </remarks>
+    public string? ConnectionString { get; internal set; }
 
-    internal bool TriedToResolveFromDI { get; set; }
+    /// <summary>
+    /// The Postgres <see cref="NpgsqlDataSource" /> to be used.
+    /// </summary>
+    /// <remarks>
+    /// Depending on how the <see cref="NpgsqlDataSource" /> was configured, the connections it hands out may be pooled.
+    /// That is why it should be the exact same <see cref="NpgsqlDataSource" /> that is used by other parts of your app.
+    /// </remarks>
+    public NpgsqlDataSource? DataSource { get; internal set; }
+
+    internal bool TriedToResolveFromDI;
 
     /// <summary>
     /// The query to be executed.

--- a/src/HealthChecks.NpgSql/README.md
+++ b/src/HealthChecks.NpgSql/README.md
@@ -1,0 +1,47 @@
+## PostgreSQL Health Check
+
+This health check verifies the ability to communicate with [PostgreSQL](https://www.postgresql.org/). It uses the [Npgsql](https://www.npgsql.org/) library.
+
+## NpgsqlDataSource
+
+Starting with Npgsql 7.0 (and .NET 7), the starting point for any database operation is [NpgsqlDataSource](https://www.npgsql.org/doc/api/Npgsql.NpgsqlDataSource.html). The data source represents your PostgreSQL database, and can hand out connections to it, or support direct execution of SQL against it. The data source encapsulates the various Npgsql configuration needed to connect to PostgreSQL, as well as the **connection pooling which makes Npgsql efficient**.
+
+Npgsql's **data source supports additional configuration beyond the connection string**, such as logging, advanced authentication options, type mapping management, and more.
+
+## Recommended approach
+
+To take advantage of the performance `NpgsqlDataSource` has to offer, it should be used as a **singleton**. Otherwise, the app might end up with having multiple data source instances, all of which would have their own connection pools. This can lead to resources exhaustion and major performance issues (Example: [#1993](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993)).
+
+We encourage you to use [Npgsql.DependencyInjection](https://www.nuget.org/packages/Npgsql.DependencyInjection) package for registering a singleton factory for `NpgsqlDataSource`.  It allows easy configuration of your Npgsql connections and registers the appropriate services in your DI container.
+
+To make the shift to `NpgsqlDataSource` as easy as possible,  the `Npgsql.DependencyInjection` package registers not just a factory for the data source, but also factory for `NpgsqlConnection`  (and even `DbConnection`). So, your app does not need to suddenly start using `NpgsqlDataSource` everywhere.
+
+```csharp
+void Configure(IServiceCollection services)
+{
+    services.AddNpgsqlDataSource("Host=pg_server;Username=test;Password=test;Database=test");
+    services.AddHealthChecks().AddNpgSql();
+}
+```
+
+By default, the `NpgsqlDataSource` instance is resolved from service provider. If you need to access more than one PostgreSQL database, you can use keyed DI services to achieve that:
+
+```csharp
+void Configure(IServiceCollection services)
+{
+    services.AddNpgsqlDataSource("Host=pg_server;Username=test;Password=test;Database=first", serviceKey: "first");
+    services.AddHealthChecks().AddNpgSql(sp => sp.GetRequiredKeyedService<NpgsqlDataSource>("first"));
+
+    services.AddNpgsqlDataSource("Host=pg_server;Username=test;Password=test;Database=second", serviceKey: "second");
+    services.AddHealthChecks().AddNpgSql(sp => sp.GetRequiredKeyedService<NpgsqlDataSource>("second"));
+}
+```
+
+
+## Connection String
+
+Raw connection string is of course still supported:
+
+```csharp
+services.AddHealthChecks().AddNpgSql("Host=pg_server;Username=test;Password=test;Database=test");
+```

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -122,8 +122,8 @@ public class npgsql_registration_should
         for (int i = 0; i < 10; i++)
         {
             var healthCheck = (NpgSqlHealthCheck)registration.Factory(serviceProvider);
-            var optionsField = typeof(NpgSqlHealthCheck).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
-            var npgSqlHealthCheckOptions = (NpgSqlHealthCheckOptions)optionsField!.GetValue(healthCheck)!;
+            var fieldInfo = typeof(NpgSqlHealthCheck).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
+            var npgSqlHealthCheckOptions = (NpgSqlHealthCheckOptions)fieldInfo!.GetValue(healthCheck)!;
 
             Assert.Equal(sameConnectionString, ReferenceEquals(serviceProvider.GetRequiredService<NpgsqlDataSource>(), npgSqlHealthCheckOptions.DataSource));
         }

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -130,4 +130,19 @@ public class npgsql_registration_should
 
         factoryCalls.ShouldBe(1);
     }
+
+    [Fact]
+    public void recommended_scenario_compiles_and_works_as_expected()
+    {
+        ServiceCollection services = new();
+        services.AddNpgsqlDataSource("Host=pg_server;Username=test;Password=test;Database=test");
+        services.AddHealthChecks().AddNpgSql();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+        var registration = options.Value.Registrations.Single();
+        var healthCheck = registration.Factory(serviceProvider);
+
+        healthCheck.ShouldBeOfType<NpgSqlHealthCheck>();
+    }
 }

--- a/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Npgsql.Tests/DependencyInjection/RegistrationTests.cs
@@ -125,10 +125,7 @@ public class npgsql_registration_should
             var optionsField = typeof(NpgSqlHealthCheck).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
             var npgSqlHealthCheckOptions = (NpgSqlHealthCheckOptions)optionsField!.GetValue(healthCheck)!;
 
-            var dataSourceProperty = typeof(NpgSqlHealthCheckOptions).GetProperty("DataSource", BindingFlags.Instance | BindingFlags.NonPublic);
-            var dataSource = (NpgsqlDataSource)dataSourceProperty!.GetValue(npgSqlHealthCheckOptions)!;
-
-            Assert.Equal(sameConnectionString, ReferenceEquals(serviceProvider.GetRequiredService<NpgsqlDataSource>(), dataSource));
+            Assert.Equal(sameConnectionString, ReferenceEquals(serviceProvider.GetRequiredService<NpgsqlDataSource>(), npgSqlHealthCheckOptions.DataSource));
         }
 
         factoryCalls.ShouldBe(1);

--- a/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
+++ b/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
@@ -7,11 +7,10 @@ namespace HealthChecks.NpgSql
     }
     public class NpgSqlHealthCheckOptions
     {
-        public NpgSqlHealthCheckOptions() { }
+        public NpgSqlHealthCheckOptions(string connectionString) { }
         public string CommandText { get; set; }
         public System.Action<Npgsql.NpgsqlConnection>? Configure { get; set; }
         public string? ConnectionString { get; set; }
-        public Npgsql.NpgsqlDataSource? DataSource { get; set; }
         public System.Func<object?, Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult>? HealthCheckResultBuilder { get; set; }
     }
 }
@@ -20,8 +19,8 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class NpgSqlHealthCheckBuilderExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, HealthChecks.NpgSql.NpgSqlHealthCheckOptions options, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
-        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, Npgsql.NpgsqlDataSource> dbDataSourceFactory, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, string> connectionStringFactory, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, Npgsql.NpgsqlDataSource>? dbDataSourceFactory = null, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddNpgSql(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string connectionString, string healthQuery = "SELECT 1;", System.Action<Npgsql.NpgsqlConnection>? configure = null, string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }

--- a/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
+++ b/test/HealthChecks.Npgsql.Tests/HealthChecks.NpgSql.approved.txt
@@ -7,10 +7,12 @@ namespace HealthChecks.NpgSql
     }
     public class NpgSqlHealthCheckOptions
     {
+        public NpgSqlHealthCheckOptions(Npgsql.NpgsqlDataSource dataSource) { }
         public NpgSqlHealthCheckOptions(string connectionString) { }
         public string CommandText { get; set; }
         public System.Action<Npgsql.NpgsqlConnection>? Configure { get; set; }
-        public string? ConnectionString { get; set; }
+        public string? ConnectionString { get; }
+        public Npgsql.NpgsqlDataSource? DataSource { get; }
         public System.Func<object?, Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult>? HealthCheckResultBuilder { get; set; }
     }
 }

--- a/test/HealthChecks.Npgsql.Tests/HealthChecks.Npgsql.Tests.csproj
+++ b/test/HealthChecks.Npgsql.Tests/HealthChecks.Npgsql.Tests.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Npgsql.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.NpgSql\HealthChecks.NpgSql.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR implements #2113 for Npgsql:

- offer two public `NpgSqlHealthCheckOptions` ctors: one that requires `ConnectionString` and another that requires `DataSource`. This allows us to ensure that every instance of this type is valid.
- make `ConnectionString` and `DataSource` properties readonly. This allows us to ensure that the customers are not providing both.
- add README.md and explain what we recommend and why