### PR TITLE
Remove unnecessary precondition checks

### DIFF
--- a/src/HealthChecks.MySql/MySqlHealthCheck.cs
+++ b/src/HealthChecks.MySql/MySqlHealthCheck.cs
@@ -13,10 +13,6 @@ public class MySqlHealthCheck : IHealthCheck
     public MySqlHealthCheck(MySqlHealthCheckOptions options)
     {
         Guard.ThrowIfNull(options);
-        if (options.DataSource is null && options.ConnectionString is null)
-            throw new InvalidOperationException("One of options.DataSource or options.ConnectionString must be specified.");
-        if (options.DataSource is not null && options.ConnectionString is not null)
-            throw new InvalidOperationException("Only one of options.DataSource or options.ConnectionString must be specified.");
         _options = options;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Code clean up from https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/2096#discussion_r1422019193.

The public constructors prevent the object from being in this state.

**Does this PR introduce a user-facing change?**:

No.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [N/A] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [N/A] Extended the documentation
- [N/A] Provided sample for the feature
