### PR TITLE
Use DNS-based values for address rather than cluster IP

### DIFF
--- a/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
+++ b/src/HealthChecks.UI.K8s.Operator/Operator/KubernetesAddressFactory.cs
@@ -8,7 +8,7 @@ internal class KubernetesAddressFactory
     {
         var defaultPort = int.Parse(resource.Spec.PortNumber ?? Constants.DEFAULT_PORT);
         var port = GetServicePort(service)?.Port ?? defaultPort;
-        var address = service.Spec.ClusterIP;
+        var address = $"{service.Metadata.Name}.{service.Metadata.Namespace()}.svc.cluster.local";
 
         string healthScheme = resource.Spec.HealthChecksScheme;
 


### PR DESCRIPTION
**What this PR does / why we need it**: 

* Issue (I think): The k8s operator, when discovering a service, uses the ClusterIP of the service to publish it to the UI monitor. However, the ClusterIP may not be visible to other namespaces.
* Fix (I think): By moving from the ClusterIP to an address resolvable by DNS (e.g. `myservice.mynamespace.svc.cluster.local`), the UI will receive a resolvable address from the operator and will be able to retrieve healthcheck information.

**Which issue(s) this PR fixes**: Supports #2144. Not sure if it fixes it and it definitely warrants further discussion.

Please reference the issue this PR will close: #2144

**Special notes for your reviewer**: I'm new to this and want to make certain my theoretical understanding is correct first. I'm happy to build and deploy this locally in my environment though may need a small bit of guidance on how to get the container out there etc. (I have a container registry I can deploy to as necessary).

**Does this PR introduce a user-facing change?**: If for some reason users were relying on the operator to specifically use ClusterIP -- though that use case seems unlikely to me -- they would see this as a change, though likely not a breaking change, given the way I understand Kubernetes DNS to work. 

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests -- in progress verifying
- [ ] Unit tests passing -- in progress verifying
- [ ] End-to-end tests passing -- in progress verifying
- [ ] Extended the documentation -- will do
- [ ] Provided sample for the feature -- will do
