### PR TITLE
Update example code for HealthChecks.CosmosDb

### DIFF
--- a/src/HealthChecks.CosmosDb/README.md
+++ b/src/HealthChecks.CosmosDb/README.md
@@ -38,7 +38,7 @@ void Configure(IHealthChecksBuilder builder)
             ApplicationRegion = Regions.EastUS2,
         }));
     builder.AddHealthChecks().AddAzureCosmosDB(
-        optionsFactory: sp => new CosmosDbHealthCheckOptions()
+        optionsFactory: sp => new AzureCosmosDbHealthCheckOptions()
         {
             DatabaseId = "demo"
         });


### PR DESCRIPTION
**What this PR does / why we need it**:

Wrong options class in the code example. 

On line 24 in this file it mentions `AzureCosmosDbHealthCheckOptions` correctly for optionsFactory. But in the example code it uses the old CosmosDbHealthCheckOptions

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [x] Provided sample for the feature
