### PR TITLE
Ensure all HealthChecks libraries have a .NETCoreApp TFM.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <DefaultNetCoreApp>net6.0</DefaultNetCoreApp>
+    <DefaultLibraryTargetFrameworks>$(DefaultNetCoreApp);netstandard2.0</DefaultLibraryTargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/HealthChecks.ApplicationStatus/HealthChecks.ApplicationStatus.csproj
+++ b/src/HealthChecks.ApplicationStatus/HealthChecks.ApplicationStatus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);ApplicationStatus</PackageTags>
     <Description>HealthChecks.ApplicationStatus is the health check package for detection graceful shutdown.</Description>
     <VersionPrefix>$(HealthCheckApplicationStatus)</VersionPrefix>

--- a/src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
+++ b/src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);ArangoDb</PackageTags>
     <Description>HealthChecks.ArangoDb is the health check package for ArangoDb.</Description>
     <VersionPrefix>$(HealthCheckArangoDb)</VersionPrefix>

--- a/src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
+++ b/src/HealthChecks.Aws.S3/HealthChecks.Aws.S3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;S3;Simple Storage Service</PackageTags>
     <Description>HealthChecks.Aws.S3 is the health check package for S3 Buckets and files.</Description>
     <VersionPrefix>$(HealthCheckAWSS3)</VersionPrefix>

--- a/src/HealthChecks.Aws.SecretsManager/HealthChecks.Aws.SecretsManager.csproj
+++ b/src/HealthChecks.Aws.SecretsManager/HealthChecks.Aws.SecretsManager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;Secrets Manager;</PackageTags>
     <Description>HealthChecks.Aws.SecretsManager is the health check package for Secrets Manager.</Description>
     <VersionPrefix>$(HealthCheckAWSSecretsManager)</VersionPrefix>

--- a/src/HealthChecks.Aws.Sns/HealthChecks.Aws.Sns.csproj
+++ b/src/HealthChecks.Aws.Sns/HealthChecks.Aws.Sns.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;SNS;Amazon Simple Notification Service</PackageTags>
     <Description>HealthChecks.Aws.Sns is the health check package for Amazon Simple Notification Service.</Description>
     <VersionPrefix>$(HealthCheckAWSSns)</VersionPrefix>

--- a/src/HealthChecks.Aws.Sqs/HealthChecks.Aws.Sqs.csproj
+++ b/src/HealthChecks.Aws.Sqs/HealthChecks.Aws.Sqs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;SQS;Simple Queue Service</PackageTags>
     <Description>HealthChecks.Aws.Sqs is the health check package for SQS queues.</Description>
     <VersionPrefix>$(HealthCheckAWSSqs)</VersionPrefix>

--- a/src/HealthChecks.Aws.SystemsManager/HealthChecks.Aws.SystemsManager.csproj
+++ b/src/HealthChecks.Aws.SystemsManager/HealthChecks.Aws.SystemsManager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);AWS;Systems Manager;Parameter Store</PackageTags>
     <Description>HealthChecks.Aws.SystemsManager is the health check package for Systems Manager for Parameter Store.</Description>
     <VersionPrefix>$(HealthCheckAWSSystemsManager)</VersionPrefix>

--- a/src/HealthChecks.Azure.Data.Tables/HealthChecks.Azure.Data.Tables.csproj
+++ b/src/HealthChecks.Azure.Data.Tables/HealthChecks.Azure.Data.Tables.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;Tables</PackageTags>
     <Description>HealthChecks.Azure.Data.Tables is the health check package for Azure Tables.</Description>
     <VersionPrefix>$(HealthCheckAzureDataTables)</VersionPrefix>

--- a/src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
+++ b/src/HealthChecks.Azure.IoTHub/HealthChecks.Azure.IoTHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;IoT Hub</PackageTags>
     <Description>HealthChecks.Azure.IoTHub is the health check package for Azure IoT Hub.</Description>
     <VersionPrefix>$(HealthCheckIoTHub)</VersionPrefix>

--- a/src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
+++ b/src/HealthChecks.Azure.KeyVault.Secrets/HealthChecks.Azure.KeyVault.Secrets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure Key Vault;Secrets</PackageTags>
     <Description>HealthChecks.Azure.KeyVault.Secrets is the health check package for Azure Key Vault secrets</Description>
     <VersionPrefix>$(HealthCheckKeyVaultSecrets)</VersionPrefix>

--- a/src/HealthChecks.Azure.Messaging.EventHubs/HealthChecks.Azure.Messaging.EventHubs.csproj
+++ b/src/HealthChecks.Azure.Messaging.EventHubs/HealthChecks.Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;EventHub</PackageTags>
     <Description>HealthChecks.Azure.Messaging.EventHubs is the health check package for Azure Event Hubs.</Description>
     <VersionPrefix>$(HealthCheckAzureMessagingEventsHubs)</VersionPrefix>

--- a/src/HealthChecks.Azure.Storage.Blobs/HealthChecks.Azure.Storage.Blobs.csproj
+++ b/src/HealthChecks.Azure.Storage.Blobs/HealthChecks.Azure.Storage.Blobs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;AzureStorage</PackageTags>
     <Description>HealthChecks.Azure.Storage.Blobs is the health check package for Blobs.</Description>
     <VersionPrefix>$(HealthCheckAzureStorageBlobs)</VersionPrefix>

--- a/src/HealthChecks.Azure.Storage.Files.Shares/HealthChecks.Azure.Storage.Files.Shares.csproj
+++ b/src/HealthChecks.Azure.Storage.Files.Shares/HealthChecks.Azure.Storage.Files.Shares.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;AzureStorage</PackageTags>
     <Description>HealthChecks.Azure.Storage.Files.Shares is the health check package for Azure File Shares.</Description>
     <VersionPrefix>$(HealthCheckAzureStorageFilesShares)</VersionPrefix>

--- a/src/HealthChecks.Azure.Storage.Queues/HealthChecks.Azure.Storage.Queues.csproj
+++ b/src/HealthChecks.Azure.Storage.Queues/HealthChecks.Azure.Storage.Queues.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;AzureStorage</PackageTags>
     <Description>HealthChecks.Azure.Storage.Queues is the health check package for Azure Storage Queues.</Description>
     <VersionPrefix>$(HealthCheckAzureStorageQueues)</VersionPrefix>

--- a/src/HealthChecks.AzureApplicationInsights/HealthChecks.AzureApplicationInsights.csproj
+++ b/src/HealthChecks.AzureApplicationInsights/HealthChecks.AzureApplicationInsights.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>HealthCheck;Azure;ApplicationInsights</PackageTags>
     <Description>HealthChecks.AzureApplicationInsights is the health check package for Azure Application Insights.</Description>
     <VersionPrefix>$(HealthCheckAzureApplicationInsights)</VersionPrefix>

--- a/src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
+++ b/src/HealthChecks.AzureDigitalTwin/HealthChecks.AzureDigitalTwin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;DigitalTwin</PackageTags>
     <Description>HealthChecks.AzureDigitalTwin is the health check package for Azure DigitalTwin.</Description>
     <VersionPrefix>$(HealthCheckAzureDigitalTwin)</VersionPrefix>

--- a/src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
+++ b/src/HealthChecks.AzureKeyVault/HealthChecks.AzureKeyVault.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure Key Vault;Secrets</PackageTags>
     <Description>HealthChecks.AzureKeyVault is the health check package for Azure Key Vault secrets</Description>
     <VersionPrefix>$(HealthCheckKeyVault)</VersionPrefix>

--- a/src/HealthChecks.AzureSearch/HealthChecks.AzureSearch.csproj
+++ b/src/HealthChecks.AzureSearch/HealthChecks.AzureSearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;Search</PackageTags>
     <Description>HealthChecks.AzureSearch is the health check package for Azure Search.</Description>
     <VersionPrefix>$(HealthCheckAzureSearch)</VersionPrefix>

--- a/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
+++ b/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;ServiceBus</PackageTags>
     <Description>HealthChecks.AzureServiceBus is the health check package for Azure Service Bus Queues and Topics.</Description>
     <VersionPrefix>$(HealthCheckAzureServiceBus)</VersionPrefix>

--- a/src/HealthChecks.Consul/HealthChecks.Consul.csproj
+++ b/src/HealthChecks.Consul/HealthChecks.Consul.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Consul</PackageTags>
     <Description>HealthChecks.Consul is the health check package for Consul Server.</Description>
     <VersionPrefix>$(HealthCheckConsul)</VersionPrefix>

--- a/src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
+++ b/src/HealthChecks.CosmosDb/HealthChecks.CosmosDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;CosmosDb</PackageTags>
     <Description>HealthChecks.CosmosDb is the health check package for Azure CosmosDb.</Description>
     <VersionPrefix>$(HealthCheckCosmosDb)</VersionPrefix>

--- a/src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
+++ b/src/HealthChecks.DocumentDb/HealthChecks.DocumentDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Azure;DocumentDb</PackageTags>
     <Description>HealthChecks.DocumentDb is the health check package for Azure DocumentDb.</Description>
     <VersionPrefix>$(HealthCheckDocumentDb)</VersionPrefix>

--- a/src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
+++ b/src/HealthChecks.DynamoDb/HealthChecks.DynamoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);DynamoDb;AWS</PackageTags>
     <Description>HealthChecks.DynamoDb is the health check package for AWS DynamoDb.</Description>
     <VersionPrefix>$(HealthCheckDynamoDb)</VersionPrefix>

--- a/src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
+++ b/src/HealthChecks.Elasticsearch/HealthChecks.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Elasticsearch</PackageTags>
     <Description>HealthChecks.Elasticsearch is the health check package for Elasticsearch.</Description>
     <VersionPrefix>$(HealthCheckElasticsearch)</VersionPrefix>

--- a/src/HealthChecks.EventStore/HealthChecks.EventStore.csproj
+++ b/src/HealthChecks.EventStore/HealthChecks.EventStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);EventStore</PackageTags>
     <Description>HealthChecks.EventStore is the health check package for EventStore, using the TCP Client.</Description>
     <VersionPrefix>$(HealthCheckEventStore)</VersionPrefix>

--- a/src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
+++ b/src/HealthChecks.Gcp.CloudFirestore/HealthChecks.Gcp.CloudFirestore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--since v3.0.0 Google.Cloud.Firestore supports netstandard2.1 instead of netstandard2.0-->
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreApp);netstandard2.1</TargetFrameworks>
     <PackageTags>$(PackageTags);CloudFirestore</PackageTags>
     <Description>HealthChecks.Gcp.CloudFirestore is the health check package for the Firebase Cloud Firebase realtime database.</Description>
     <VersionPrefix>$(HealthCheckCloudFirestore)</VersionPrefix>

--- a/src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
+++ b/src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Gremlin;TinkerPop;GraphDB</PackageTags>
     <Description>HealthChecks.Gremlin is the health check package for Gremlin.</Description>
     <VersionPrefix>$(HealthCheckGremlin)</VersionPrefix>

--- a/src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
+++ b/src/HealthChecks.Hangfire/HealthChecks.Hangfire.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Hangfire</PackageTags>
     <Description>HealthChecks.Hangfire is the health check package for Hangfire.</Description>
     <VersionPrefix>$(HealthCheckHangfire)</VersionPrefix>

--- a/src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
+++ b/src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);IbmMQ</PackageTags>
     <Description>HealthChecks.IbmMQ is the health check package for IbmMQ.</Description>
     <VersionPrefix>$(HealthCheckIbmMQ)</VersionPrefix>

--- a/src/HealthChecks.InfluxDB/HealthChecks.InfluxDB.csproj
+++ b/src/HealthChecks.InfluxDB/HealthChecks.InfluxDB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>HealthCheck;Health;InfluxDB</PackageTags>
     <Description>HealthChecks.InfluxDB is the health check package for InfluxDB.</Description>
     <VersionPrefix>$(HealthCheckInfluxDB)</VersionPrefix>

--- a/src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
+++ b/src/HealthChecks.Kafka/HealthChecks.Kafka.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Kafka;Confluent</PackageTags>
     <Description>HealthChecks.Kafka is the health check package for Kafka.</Description>
     <VersionPrefix>$(HealthCheckKafka)</VersionPrefix>

--- a/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
+++ b/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);MongoDb</PackageTags>
     <Description>HealthChecks.MongoDb is the health check package for MongoDb.</Description>
     <VersionPrefix>$(HealthCheckMongoDB)</VersionPrefix>

--- a/src/HealthChecks.MySql/HealthChecks.MySql.csproj
+++ b/src/HealthChecks.MySql/HealthChecks.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);MySQL</PackageTags>
     <Description>HealthChecks.MySql is the health check package for MySQL.</Description>
     <VersionPrefix>$(HealthCheckMySql)</VersionPrefix>

--- a/src/HealthChecks.Nats/HealthChecks.Nats.csproj
+++ b/src/HealthChecks.Nats/HealthChecks.Nats.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Nats</PackageTags>
     <Description>HealthChecks.Nats is the health check package for Nats.</Description>
     <VersionPrefix>$(HealthCheckNats)</VersionPrefix>

--- a/src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
+++ b/src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);IdentityServer;IdSvr;OpenId;OpenIdConnect</PackageTags>
     <Description>HealthChecks.OpenIdConnectServer is the health check package for OpenIdConnect servers</Description>
     <VersionPrefix>$(HealthCheckOpenIdConnectServer)</VersionPrefix>

--- a/src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
+++ b/src/HealthChecks.Oracle/HealthChecks.Oracle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks);netstandard2.1</TargetFrameworks>
     <PackageTags>$(PackageTags);Oracle</PackageTags>
     <Description>HealthChecks.Oracle is the health check package for Oracle Database.</Description>
     <VersionPrefix>$(HealthCheckOracle)</VersionPrefix>

--- a/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
+++ b/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Application Insights</PackageTags>
     <Description>HealthChecks.Publisher.ApplicationInsights is the health check publisher for Application Insights.</Description>
     <VersionPrefix>$(HealthCheckPublisherAppplicationInsights)</VersionPrefix>

--- a/src/HealthChecks.Publisher.CloudWatch/HealthChecks.Publisher.CloudWatch.csproj
+++ b/src/HealthChecks.Publisher.CloudWatch/HealthChecks.Publisher.CloudWatch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;AWS;CloudWatch</PackageTags>
     <Description>HealthChecks.Publisher.CloudWatch is the health check publisher for AWS CloudWatch.</Description>
     <VersionPrefix>$(HealthCheckPublisherCloudWatch)</VersionPrefix>

--- a/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
+++ b/src/HealthChecks.Publisher.Datadog/HealthChecks.Publisher.Datadog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Datadog</PackageTags>
     <Description>HealthChecks.Publisher.Datadog is the health check publisher for Datadog.</Description>
     <VersionPrefix>$(HealthCheckPublisherDatadog)</VersionPrefix>

--- a/src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
+++ b/src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);RabbitMQ</PackageTags>
     <Description>HealthChecks.RabbitMQ is the health check package for RabbitMQ.</Description>
     <VersionPrefix>$(HealthCheckRabbitMQ)</VersionPrefix>

--- a/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
+++ b/src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);RavenDB</PackageTags>
     <Description>HealthChecks.RavenDB is the health check package for RavenDB.</Description>
     <VersionPrefix>$(HealthCheckRavenDB)</VersionPrefix>

--- a/src/HealthChecks.Redis/HealthChecks.Redis.csproj
+++ b/src/HealthChecks.Redis/HealthChecks.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Redis</PackageTags>
     <Description>HealthChecks.Redis is the health check package for Redis.</Description>
     <VersionPrefix>$(HealthCheckRedis)</VersionPrefix>

--- a/src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
+++ b/src/HealthChecks.SendGrid/HealthChecks.SendGrid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);SendGrid</PackageTags>
     <Description>HealthChecks.SendGrid is the health check package for SendGrid.</Description>
     <VersionPrefix>$(HealthCheckSendGrid)</VersionPrefix>

--- a/src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
+++ b/src/HealthChecks.SignalR/HealthChecks.SignalR.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);SignalR</PackageTags>
     <Description>HealthChecks.SignalR is the health check package for SignalR.</Description>
     <VersionPrefix>$(HealthCheckSignalR)</VersionPrefix>

--- a/src/HealthChecks.Solr/HealthChecks.Solr.csproj
+++ b/src/HealthChecks.Solr/HealthChecks.Solr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);solr</PackageTags>
     <Description>HealthChecks.solr is the health check package for solr.</Description>
     <VersionPrefix>$(HealthCheckSolr)</VersionPrefix>

--- a/src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
+++ b/src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Sql Server</PackageTags>
     <Description>HealthChecks.SqlServer is the health check package for SqlServer.</Description>
     <VersionPrefix>$(HealthCheckSqlServer)</VersionPrefix>

--- a/src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
+++ b/src/HealthChecks.Sqlite/HealthChecks.Sqlite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Sqlite</PackageTags>
     <Description>HealthChecks.Sqlite is the health check package for Sqlite.</Description>
     <VersionPrefix>$(HealthCheckSqlite)</VersionPrefix>

--- a/src/HealthChecks.Sqlite/SqliteHealthCheck.cs
+++ b/src/HealthChecks.Sqlite/SqliteHealthCheck.cs
@@ -29,7 +29,7 @@ public class SqliteHealthCheck : IHealthCheck
 
             using var command = connection.CreateCommand();
             command.CommandText = _options.CommandText;
-            object result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            object? result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
             return _options.HealthCheckResultBuilder == null
                 ? HealthCheckResult.Healthy()

--- a/src/HealthChecks.System/DependencyInjection/SystemHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.System/DependencyInjection/SystemHealthCheckBuilderExtensions.cs
@@ -218,6 +218,9 @@ public static class SystemHealthCheckBuilderExtensions
     /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
     /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
+#if NET6_0_OR_GREATER
+    [global::System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     public static IHealthChecksBuilder AddWindowsServiceHealthCheck(
         this IHealthChecksBuilder builder,
         string serviceName,

--- a/src/HealthChecks.System/HealthChecks.System.csproj
+++ b/src/HealthChecks.System/HealthChecks.System.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Beat;System;Ping;Disk Storage</PackageTags>
     <Description>HealthChecks.System is the system health check package.</Description>
     <VersionPrefix>$(HealthCheckSystem)</VersionPrefix>

--- a/src/HealthChecks.System/WindowsServiceHealthCheck.cs
+++ b/src/HealthChecks.System/WindowsServiceHealthCheck.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.System;
 
+#if NET6_0_OR_GREATER
+[global::System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
 public class WindowsServiceHealthCheck : IHealthCheck
 {
     private readonly string _serviceName;


### PR DESCRIPTION
This ensures that when libraries and apps who depend on the HealthChecks libraries get the correct transitive dependences for .NETCoreApp TFMs (for example Microsoft.Bcl.AsyncInterfaces).

This follows the following [guidance](https://learn.microsoft.com/dotnet/standard/library-guidance/cross-platform-targeting):

✔️ CONSIDER multi-targeting even if your source code is the same for all targets, when your project has any library or package dependencies.

Fix #2180
Fix #2084
Fix #2163

cc @damianedwards