### PR TITLE
use lts EventStoreDB docker image as latest fails to start

### DIFF
--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore
+        image: eventstore/eventstore:release-v5
         ports:
           - "2113:2113"
           - "1113:1113"

--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore:release-v5
+        image: eventstore/eventstore:23.10
         ports:
           - "2113:2113"
           - "1113:1113"

--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore:23.10
+        image: eventstore/eventstore:lts
         ports:
           - "2113:2113"
           - "1113:1113"

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore
+        image: eventstore/eventstore:release-v5
         ports:
           - "1113:1113"
           - "2113:2113"

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore:23.10
+        image: eventstore/eventstore:lts
         ports:
           - "1113:1113"
           - "2113:2113"

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       eventstore:
-        image: eventstore/eventstore:release-v5
+        image: eventstore/eventstore:23.10
         ports:
           - "1113:1113"
           - "2113:2113"


### PR DESCRIPTION
```log
   [    1, 1,23:13:32.973,FTL] The option "EnableExternalTcp" is not a known option.
   [    1, 1,23:13:32.974,FTL] Found unknown options. To continue anyway, set AllowUnknownOptions to true.
   [    1, 1,23:13:32.974,INF] Use the --help option in the command line to see the full list of EventStoreDB configuration options.
  Error: Failed to initialize container eventstore/eventstore
Error: One or more containers failed to start.
```

For more details please see https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/actions/runs/8514935948/job/23321532350?pr=2185