### PR TITLE
HealthChecks.UI.Image/Dockerfile: build and run on aspnet & sdk v8

### DIFF
--- a/build/docker-images/HealthChecks.UI.Image/Dockerfile
+++ b/build/docker-images/HealthChecks.UI.Image/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS sdk-with-node
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS sdk-with-node
 
 ENV NODE_VERSION 18.16.0
 ENV NODE_DOWNLOAD_SHA fc83046a93d2189d919005a348db3b2372b598a145d84eb9781a3a4b0f032e95


### PR DESCRIPTION
The UI Docker won't build currently.

First, [this PR](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/2194) needs to be merged since dotnet reports a vulnerability warning as error in the Azure.Identity nuget.

Then, this PR updates the runtime and sdk docker images from .NET 6 to .NET 8, because the v6 sdk won't build the project that have been upgraded to .NET 8 already.

I built the docker with these changes and it seems mostly fine safe for a few missing icons but that may be due to everything being served from localhost. Happy to contribute further.