### PR TITLE
refactor: Update the health check UI sample to use SSL

### DIFF
--- a/samples/HealthChecks.Sample/Properties/launchSettings.json
+++ b/samples/HealthChecks.Sample/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:62618/",
-      "sslPort": 44318
+      "applicationUrl": "https://localhost:44318",
+      "useSsl": true
     }
   },
   "profiles": {
@@ -24,7 +24,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:2123/"
+      "applicationUrl": "https://localhost:44318",
+      "useSSL": true
     }
   }
 }

--- a/samples/HealthChecks.Sample/appsettings.json
+++ b/samples/HealthChecks.Sample/appsettings.json
@@ -1,16 +1,18 @@
 {
+  "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "ApplicationInsights": {
     "InstrumentationKey": "your-instrumentation-key"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  },
-  "AllowedHosts": "*",
   "Data": {
     "ConnectionStrings": {
       "Sample": "Server=.;Initial Catalog=master;Integrated Security=true"
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "HealthChecks": "Debug", /* TODO: Not recommended for production environments */
+      "Microsoft": "Warning"
     }
   }
 }

--- a/samples/HealthChecks.UI.Branding/Properties/launchSettings.json
+++ b/samples/HealthChecks.UI.Branding/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:62618/",
-      "sslPort": 44318
+      "applicationUrl": "https://localhost:44318",
+      "useSsl": true
     }
   },
   "profiles": {
@@ -24,7 +24,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44318",
+      "useSSL": true
     }
   }
 }

--- a/samples/HealthChecks.UI.Branding/Startup.cs
+++ b/samples/HealthChecks.UI.Branding/Startup.cs
@@ -25,12 +25,12 @@ public class Startup
                 setup.SetHeaderText("Branding Demo - Health Checks Status");
                 setup.AddHealthCheckEndpoint("endpoint1", "/health-random");
                 setup.AddHealthCheckEndpoint("endpoint2", "health-process");
-                //Webhook endpoint with custom notification hours, and custom failure and description messages
+                //Webhook endpoint with custom notification hours (8am - 5pm), and custom failure and description messages
 
-                setup.AddWebhookNotification("webhook1", uri: "https://healthchecks2.requestcatcher.com/",
-                        payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+                setup.AddWebhookNotification("webhook2", uri: "https://healthchecks2.requestcatcher.com/",
+                        payload: "{ \"message\": \"Webhook2 report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
                             restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}",
-                            shouldNotifyFunc: (livenessName, report) => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 23,
+                            shouldNotifyFunc: (livenessName, report) => DateTime.UtcNow.Hour >= 8 && DateTime.UtcNow.Hour <= 17,
                             customMessageFunc: (livenessName, report) =>
                            {
                                var failing = report.Entries.Where(e => e.Value.Status == UIHealthStatus.Unhealthy);
@@ -46,11 +46,10 @@ public class Startup
                 setup.AddWebhookNotification(
                     name: "webhook1",
                     uri: "https://healthchecks.requestcatcher.com/",
-                    payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+                    payload: "{  \"message\": \"Webhook1 report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
                     restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}");
             }).AddInMemoryStorage()
-              .Services
-            .AddControllers();
+            .Services.AddControllers();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/HealthChecks.UI.Branding/appsettings.json
+++ b/samples/HealthChecks.UI.Branding/appsettings.json
@@ -1,9 +1,6 @@
 {
   "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "HealthChecksUI": {
-    "KubernetesDiscoveryService": {
-      "Enabled": false
-    }
   },
   "Logging": {
     "LogLevel": {

--- a/samples/HealthChecks.UI.Branding/appsettings.json
+++ b/samples/HealthChecks.UI.Branding/appsettings.json
@@ -1,15 +1,15 @@
 {
+  "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "HealthChecksUI": {
     "KubernetesDiscoveryService": {
-      "Enabled":  false
+      "Enabled": false
     }
   },
   "Logging": {
     "LogLevel": {
       "Microsoft": "Warning",
-      "HealthChecks":  "Debug",
+      "HealthChecks": "Debug", /* TODO: Not recommended for production environments */
       "Default": "Information"
     }
-  },
-  "AllowedHosts": "*"
+  }
 }

--- a/samples/HealthChecks.UI.Oidc/Properties/launchSettings.json
+++ b/samples/HealthChecks.UI.Oidc/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:62618/",
-      "sslPort": 44318
+      "applicationUrl": "https://localhost:44318",
+      "useSsl": true
     }
   },
   "profiles": {
@@ -24,7 +24,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44318",
+      "useSSL": true
     }
   }
 }

--- a/samples/HealthChecks.UI.Oidc/appsettings.json
+++ b/samples/HealthChecks.UI.Oidc/appsettings.json
@@ -1,9 +1,5 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  },
+  "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "HealthChecksUI": {
     "HealthChecks": [
       {
@@ -14,5 +10,12 @@
     "Webhooks": [],
     "EvaluationTimeinSeconds": 5,
     "MinimumSecondsBetweenFailureNotifications": 60
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "HealthChecks": "Debug", /* TODO: Not recommended for production environments */
+      "Microsoft": "Warning"
+    }
   }
 }

--- a/samples/HealthChecks.UI.Sample/HealthChecks.UI.Sample.csproj
+++ b/samples/HealthChecks.UI.Sample/HealthChecks.UI.Sample.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI.InMemory.Storage\HealthChecks.UI.InMemory.Storage.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI\HealthChecks.UI.csproj" />
   </ItemGroup>

--- a/samples/HealthChecks.UI.Sample/Properties/launchSettings.json
+++ b/samples/HealthChecks.UI.Sample/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:62618/",
-      "sslPort": 44318
+      "applicationUrl": "https://localhost:44318",
+      "useSsl": true
     }
   },
   "profiles": {
@@ -24,7 +24,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44318",
+      "useSSL": true
     }
   }
 }

--- a/samples/HealthChecks.UI.Sample/Startup.cs
+++ b/samples/HealthChecks.UI.Sample/Startup.cs
@@ -1,3 +1,6 @@
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+
 namespace HealthChecks.UI.Sample;
 
 public class Startup
@@ -6,9 +9,8 @@ public class Startup
     // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
     public void ConfigureServices(IServiceCollection services)
     {
-        services
-            .AddHealthChecksUI()
-            .AddInMemoryStorage();
+        services.AddHealthChecks();
+        services.AddHealthChecksUI().AddInMemoryStorage();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -16,6 +18,14 @@ public class Startup
     {
         app
             .UseRouting()
-            .UseEndpoints(config => config.MapHealthChecksUI());
+            .UseEndpoints(config =>
+            {
+                config.MapHealthChecksUI();
+                config.MapHealthChecks("/healthchecks", new HealthCheckOptions
+                {
+                    Predicate = _ => true,
+                    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                });
+            });
     }
 }

--- a/samples/HealthChecks.UI.Sample/appsettings.json
+++ b/samples/HealthChecks.UI.Sample/appsettings.json
@@ -1,10 +1,5 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  },
-  "AllowedHosts": "localhost", /* TODO: Add your production URL here separated by semi colon.*/
+  "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "HealthChecksUI": {
     "HealthChecks": [
       {
@@ -24,5 +19,12 @@
     "HeaderText": "The health of my app services",
     "EvaluationTimeinSeconds": 10,
     "MinimumSecondsBetweenFailureNotifications": 60
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "HealthChecks": "Debug", /* TODO: Not recommended for production environments */
+      "Microsoft": "Warning"
+    }
   }
 }

--- a/samples/HealthChecks.UI.Sample/appsettings.json
+++ b/samples/HealthChecks.UI.Sample/appsettings.json
@@ -8,12 +8,12 @@
         "RequireHttps": true
       }
     ],
-    "webhooks": [
+    "Webhooks": [
       {
-        "name": "slack",
-        "uri": "https://hooks.slack.com/services/t0ghra4cr/bb551l6sw/lwyrvra2nes4pqg7pbpym",
-        "payload": "{\"text\":\"the healthcheck [[liveness]] is failing with the error message: [[failure]]. [[descriptions]]. <http://yourappstatus|click here> to get more details.\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}",
-        "restoredpayload": "{\"text\":\"the healthcheck [[liveness]] is recovered. all is up and running\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}"
+        "Name": "Slack",
+        "Uri": "https://hooks.slack.com/services/T0GHRA4CR/BB551L6SW/LWYRVRA2NEs4pQG7pbPym",
+        "Payload": "{\"text\":\"The HealthCheck [[LIVENESS]] is failing with the error message: [[FAILURE]]. [[DESCRIPTIONS]]. <http://yourappstatus|Click here> to get more details.\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}",
+        "RestoredPayload": "{\"text\":\"The HealthCheck [[LIVENESS]] is recovered. All is up and running\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}"
       }
     ],
     "HeaderText": "The health of my app services",

--- a/samples/HealthChecks.UI.Sample/appsettings.json
+++ b/samples/HealthChecks.UI.Sample/appsettings.json
@@ -1,19 +1,27 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "localhost", /* TODO: Add your production URL here separated by semi colon.*/
   "HealthChecksUI": {
     "HealthChecks": [
       {
         "Name": "HTTP-Api-Basic",
-        "Uri": "http://localhost:2122/healthz"
+        "Uri": "https://localhost:44318/healthchecks",
+        "RequireHttps": true
       }
     ],
-    "Webhooks": [
+    "webhooks": [
       {
-        "Name": "Slack",
-        "Uri": "https://hooks.slack.com/services/T0GHRA4CR/BB551L6SW/LWYRVRA2NEs4pQG7pbPym",
-        "Payload": "{\"text\":\"The HealthCheck [[LIVENESS]] is failing with the error message: [[FAILURE]]. [[DESCRIPTIONS]]. <http://yourappstatus|Click here> to get more details.\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}",
-        "RestoredPayload": "{\"text\":\"The HealthCheck [[LIVENESS]] is recovered. All is up and running\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}"
+        "name": "slack",
+        "uri": "https://hooks.slack.com/services/t0ghra4cr/bb551l6sw/lwyrvra2nes4pqg7pbpym",
+        "payload": "{\"text\":\"the healthcheck [[liveness]] is failing with the error message: [[failure]]. [[descriptions]]. <http://yourappstatus|click here> to get more details.\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}",
+        "restoredpayload": "{\"text\":\"the healthcheck [[liveness]] is recovered. all is up and running\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face:\"}"
       }
     ],
+    "HeaderText": "The health of my app services",
     "EvaluationTimeinSeconds": 10,
     "MinimumSecondsBetweenFailureNotifications": 60
   }

--- a/samples/HealthChecks.UI.StorageProviders/Properties/launchSettings.json
+++ b/samples/HealthChecks.UI.StorageProviders/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:62618/",
-      "sslPort": 44318
+      "applicationUrl": "https://localhost:44318",
+      "useSsl": true
     }
   },
   "profiles": {
@@ -24,7 +24,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44318",
+      "useSSL": true
     }
   }
 }

--- a/samples/HealthChecks.UI.StorageProviders/appsettings.json
+++ b/samples/HealthChecks.UI.StorageProviders/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "AllowedHosts": "localhost", /* TODO: CICD should replace this with your environment(dev,test,prod) URLs.*/
   "HealthChecksUI": {
     "HealthChecks": [
       {
@@ -13,9 +14,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
-      "HealthChecks":  "Debug"
+      "HealthChecks": "Debug", /* TODO: Not recommended for production environments */
+      "Microsoft": "Warning"
     }
-  },
-  "AllowedHosts": "*"
+  }
 }


### PR DESCRIPTION
* Encourage health check samples to be secure by design
* Add [.net SSL](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0#configure-https) configurations for sample UI.
* Include the health check JSON endpoint in the sample UI to ensure we have no errors displayed
* Include [AllowedHosts](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/host-filtering?view=aspnetcore-8.0) in the example.
* Contributes to #2245 

**Special notes for your reviewer**:

- Uncovered while enforcing SSL by default on IIS servers in production environments
- Found it difficult to quickly resolve the configuration across multiple build profiles
- Migration from net 6 to 8 uncovered changes to the ports used in [v7](https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/https-binding-kestrel) used by asp.net.
- Uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) prefix in commit comments.
- 1861 unit tests run locally with a few hiccups. I'm assuming you need to use the .\build\docker-compose.yml to run them all locally, successfully.
- Tries to improve the code to meet [OWASP security recommendations for .net](https://cheatsheetseries.owasp.org/cheatsheets/DotNet_Security_Cheat_Sheet.html). See "A10 Server-Side Request Forgery (SSRF)" recommendations.

You should set AllowedHosts with host filtering middleware when you want to restrict your ASP.NET Core app to specific hostnames. By defining the AllowedHosts key in your configuration (e.g., appsettings.json), you can ensure that your app only responds to requests from those specific hosts. Requests from other hosts will result in a default bad request (400) response. Keep in mind that this is different from CORS, which controls external origins that can access your app’s resources. If you need to manage cross-origin requests, use CORS; if you want to limit your app to specific hosts, use AllowedHosts.

**Does this PR introduce a user-facing change?**:
Indirectly, it encourages the use of https in the web browser when running Health Checks

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [X] Provided sample for the feature
