### PR TITLE
2261 Add basic authentication support to Solr health check

### DIFF
--- a/src/HealthChecks.Solr/DependencyInjection/SolrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Solr/DependencyInjection/SolrHealthCheckBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class SolrHealthCheckBuilderExtensions
         TimeSpan? timeout = default)
     {
         var options = new SolrOptions();
-        options.UseServer(solrUri, solrCore, timeout: null);
+        options.UseServer(solrUri, solrCore, username: null, password: null, timeout: null);
 
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,

--- a/src/HealthChecks.Solr/SolrHealthCheck.cs
+++ b/src/HealthChecks.Solr/SolrHealthCheck.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using HttpWebAdapters;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using SolrNet.Impl;
 
@@ -28,6 +29,11 @@ public class SolrHealthCheck : IHealthCheck
                 {
                     Timeout = (int)_options.Timeout.TotalMilliseconds
                 };
+
+                if (!string.IsNullOrWhiteSpace(_options.Username) && !string.IsNullOrWhiteSpace(_options.Password))
+                {
+                    solrConnection.HttpWebRequestFactory = new BasicAuthHttpWebRequestFactory(_options.Username, _options.Password);
+                }
 
                 if (!_connections.TryAdd(url, solrConnection))
                 {

--- a/src/HealthChecks.Solr/SolrOptions.cs
+++ b/src/HealthChecks.Solr/SolrOptions.cs
@@ -6,12 +6,18 @@ public class SolrOptions
 
     public string Core { get; private set; } = null!;
 
+    public string? Username { get; private set; }
+
+    public string? Password { get; private set; }
+
     public TimeSpan Timeout { get; private set; }
 
-    public SolrOptions UseServer(string uri, string core, TimeSpan? timeout)
+    public SolrOptions UseServer(string uri, string core, string? username, string? password, TimeSpan? timeout)
     {
         Uri = Guard.ThrowIfNull(uri);
         Core = Guard.ThrowIfNull(core);
+        Username = username;
+        Password = password;
         Timeout = timeout ?? TimeSpan.FromMilliseconds(1000);
 
         return this;

--- a/test/HealthChecks.Solr.Tests/Functional/SolrHealthCheckTests.cs
+++ b/test/HealthChecks.Solr.Tests/Functional/SolrHealthCheckTests.cs
@@ -29,6 +29,29 @@ public class solr_healthcheck_should
     }
 
     [Fact]
+    public async Task be_healthy_if_solr_with_credentials_is_available()
+    {
+        var webHostBuilder = new WebHostBuilder()
+           .ConfigureServices(services =>
+           {
+               services.AddHealthChecks()
+                .AddSolr(options => options.UseServer("http://localhost:8983/solr", "solrcore", "solr", "SolrRocks", null), tags: new string[] { "solr" });
+           })
+           .Configure(app =>
+           {
+               app.UseHealthChecks("/health", new HealthCheckOptions
+               {
+                   Predicate = r => r.Tags.Contains("solr"),
+                   ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+               });
+           });
+
+        using var server = new TestServer(webHostBuilder);
+        using var response = await server.CreateRequest("/health").GetAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task be_unhealthy_if_solr_ping_is_disabled()
     {
         var webHostBuilder = new WebHostBuilder()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Adds basic authentication support to the Solr health check.

**Which issue(s) this PR fixes**:
Most enterprise environments configure Solr to use SSL and some sort of authentication.  This PR adds basic authentication support to the Solr health check.

Please reference the issue this PR will close: #_[issue number]_
#2261 

**Special notes for your reviewer**:
Some of the existing Solr unit tests required a higher timeout from the default of 1 second in order to succeed.  However I did not commit those temporary changes since it's likely it's my local testing environment.  Also the new unit test I wrote requires Solr to be configured to use basic authentication.

**Does this PR introduce a user-facing change?**:
No.  All changes are opt-in/optional.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
