### PR TITLE
Sign HealthChecks.MongoDb

### DIFF
--- a/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
+++ b/src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj
@@ -5,7 +5,6 @@
     <PackageTags>$(PackageTags);MongoDb</PackageTags>
     <Description>HealthChecks.MongoDb is the health check package for MongoDb.</Description>
     <VersionPrefix>$(HealthCheckMongoDB)</VersionPrefix>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We can sign this assembly now because MongoDB.Driver is now signed as of v2.28.