### PR TITLE
#2178 Added a new method CreateResponseWriter to UIResponseWriter

### DIFF
--- a/src/HealthChecks.UI.Client/UIResponseWriter.cs
+++ b/src/HealthChecks.UI.Client/UIResponseWriter.cs
@@ -15,40 +15,34 @@ public static class UIResponseWriter
     private static readonly byte[] _emptyResponse = new byte[] { (byte)'{', (byte)'}' };
     private static readonly Lazy<JsonSerializerOptions> _options = new(CreateJsonOptions);
 
-#pragma warning disable IDE1006 // Naming Styles
-    public static async Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report) // TODO: rename public API
-#pragma warning restore IDE1006 // Naming Styles
+    private static async Task WriteHealthCheckUIResponseAsync(HttpContext httpContext, HealthReport report, Lazy<JsonSerializerOptions> jsonOptions, Func<Exception, string>? exceptionFormatter = null)
     {
         if (report != null)
         {
             httpContext.Response.ContentType = DEFAULT_CONTENT_TYPE;
 
-            var uiReport = UIHealthReport.CreateFrom(report);
+            var uiReport = UIHealthReport.CreateFrom(report, exceptionFormatter);
 
-            await JsonSerializer.SerializeAsync(httpContext.Response.Body, uiReport, _options.Value).ConfigureAwait(false);
+            await JsonSerializer.SerializeAsync(httpContext.Response.Body, uiReport, jsonOptions.Value).ConfigureAwait(false);
         }
         else
         {
             await httpContext.Response.BodyWriter.WriteAsync(_emptyResponse).ConfigureAwait(false);
         }
     }
-
-#pragma warning disable IDE1006 // Naming Styles
-    public static async Task WriteHealthCheckUIResponseNoExceptionDetails(HttpContext httpContext, HealthReport report)
-#pragma warning restore IDE1006 // Naming Styles
+    public static Task WriteHealthCheckUIResponse(HttpContext httpContext, HealthReport report) // TODO: rename public API
     {
-        if (report != null)
-        {
-            httpContext.Response.ContentType = DEFAULT_CONTENT_TYPE;
+        return WriteHealthCheckUIResponseAsync(httpContext, report, _options);
+    }
 
-            var uiReport = UIHealthReport.CreateFrom(report, _ => "Exception Occurred.");
+    public static Task WriteHealthCheckUIResponseNoExceptionDetails(HttpContext httpContext, HealthReport report)
+    {
+        return WriteHealthCheckUIResponseAsync(httpContext, report, _options, _ => "Exception Occurred.");
+    }
 
-            await JsonSerializer.SerializeAsync(httpContext.Response.Body, uiReport, _options.Value).ConfigureAwait(false);
-        }
-        else
-        {
-            await httpContext.Response.BodyWriter.WriteAsync(_emptyResponse).ConfigureAwait(false);
-        }
+    public static Func<HttpContext, HealthReport, Task> CreateResponseWriter(Lazy<JsonSerializerOptions> jsonOptions, Func<Exception, string>? exceptionFormatter = null)
+    {
+        return (HttpContext httpContext, HealthReport report) => WriteHealthCheckUIResponseAsync(httpContext, report, jsonOptions, exceptionFormatter);
     }
 
     private static JsonSerializerOptions CreateJsonOptions()

--- a/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.approved.txt
+++ b/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.approved.txt
@@ -1,7 +1,8 @@
-﻿namespace HealthChecks.UI.Client
+namespace HealthChecks.UI.Client
 {
     public static class UIResponseWriter
     {
+        public static System.Func<Microsoft.AspNetCore.Http.HttpContext, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport, System.Threading.Tasks.Task> CreateResponseWriter(System.Lazy<System.Text.Json.JsonSerializerOptions> jsonOptions, System.Func<System.Exception, string>? exceptionFormatter = null) { }
         public static System.Threading.Tasks.Task WriteHealthCheckUIResponse(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport report) { }
         public static System.Threading.Tasks.Task WriteHealthCheckUIResponseNoExceptionDetails(Microsoft.AspNetCore.Http.HttpContext httpContext, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport report) { }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it possible for other projects to reuse UIResponseWriter even if they have other needs with regards to serialization options.

**Which issue(s) this PR fixes**:
#2178 

**Special notes for your reviewer**:
Do I need to document the functionality? A sample use case can be seen in the unit test.

All the tests from UI.Client and UI.Core run fine, which is what I would expect to be affected by the changes.

Many tests from other projects do not run successfully on my local setup, but that is also true before applying my changes. I assume I am missing some dependency, configuration or similar. It seems like there is a CI workflow to run tests in GitHub, but it is waiting for approval before it will run.

**Does this PR introduce a user-facing change?**:
The proposed change should only affect library users, not end-users.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
