### PR TITLE
Update CallerArgumentExpressionAttribute.cs

### DIFF
--- a/src/CallerArgumentExpressionAttribute.cs
+++ b/src/CallerArgumentExpressionAttribute.cs
@@ -34,13 +34,13 @@ namespace System.Diagnostics.CodeAnalysis
 
 #endif
 
-internal class Guard
+internal static class Guard
 {
     /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
     /// <param name="argument">The reference type argument to validate as non-null.</param>
     /// <param name="throwOnEmptyString">Only applicable to strings.</param>
     /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-    public static T ThrowIfNull<T>([NotNull] T? argument, bool throwOnEmptyString = false, [CallerArgumentExpression("argument")] string? paramName = null)
+    public static T ThrowIfNull<T>([NotNull] T? argument, bool throwOnEmptyString = false, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         where T : class
     {
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
- use `nameof` for `CallerArgumentExpressionAttribute`
- let `Guard` class to be `static` since no instance members


**What this PR does / why we need it**: Improve code quality and maintainability

**Does this PR introduce a user-facing change?**: No


Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
