### PR TITLE
Update healthchecksui.css (background color on logo element)

### DIFF
--- a/src/HealthChecks.UI/assets/healthchecksui.css
+++ b/src/HealthChecks.UI/assets/healthchecksui.css
@@ -155,7 +155,6 @@ h4 {
 }
 
 .hc-aside__logo {
-  background-color: var(--primaryColor);
   background-image: var(--logoImageUrl);
   background-position: center;
   background-size: cover;


### PR DESCRIPTION
Background color shouldn't be used for logo image because it conflicts with images that use transparency for example SVGs (which are the standard format for logos on the web nowadays)