### PR TITLE
Improve Datadog health check

### DIFF
--- a/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
@@ -24,15 +24,34 @@ public static class DatadogHealthCheckBuilderExtensions
         string datadogAgentName = "127.0.0.1",
         string[]? defaultTags = default)
     {
+        builder.AddDatadogPublisher(serviceCheckName, new StatsdConfig() { StatsdServerName = datadogAgentName }, defaultTags);
+        return builder;
+    }
+
+    /// <summary>
+    /// Add a health check publisher for Datadog.
+    /// </summary>
+    /// <remarks>
+    /// For each <see cref="HealthReport"/> published a custom service check indicating the health check status (OK - Healthy, WARNING - Degraded, CRITICAL - Unhealthy)
+    /// and a metric indicating the total time the health check took to execute in milliseconds is sent to Datadog.
+    /// </remarks>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to datadog. Example: "myservice.healthchecks".</param>
+    /// <param name="statsdConfig">The whole Datadog StatsdConfig</param>
+    /// <param name="defaultTags">Specifies a collection of tags to send with the custom check and metric.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddDatadogPublisher(
+        this IHealthChecksBuilder builder,
+        string serviceCheckName,
+        StatsdConfig statsdConfig,
+        string[]? defaultTags = default)
+    {
         builder.Services
             .AddSingleton<IHealthCheckPublisher>(sp =>
             {
                 var dogStatsdService = new DogStatsdService();
 
-                dogStatsdService.Configure(new StatsdConfig
-                {
-                    StatsdServerName = datadogAgentName
-                });
+                dogStatsdService.Configure(statsdConfig);
 
                 return new DatadogPublisher(dogStatsdService, serviceCheckName, defaultTags);
             });

--- a/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.Datadog/DependencyInjection/DatadogHealthCheckBuilderExtensions.cs
@@ -14,17 +14,27 @@ public static class DatadogHealthCheckBuilderExtensions
     /// and a metric indicating the total time the health check took to execute in milliseconds is sent to Datadog.
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-    /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to datadog. Example: "myservice.healthchecks".</param>
-    /// <param name="datadogAgentName">Specified Datadog agent server name. Defaults to localhost address 127.0.0.1.</param>
+    /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to Datadog. Example: "myservice.healthchecks".</param>
+    /// <param name="serviceFactory">
+    /// An optional factory to obtain <see cref="DogStatsdService"/> used by the health check.
+    /// When not provided, <see cref="DogStatsdService" /> is simply resolved from <see cref="IServiceProvider"/>.
+    /// </param>
     /// <param name="defaultTags">Specifies a collection of tags to send with the custom check and metric.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddDatadogPublisher(
         this IHealthChecksBuilder builder,
         string serviceCheckName,
-        string datadogAgentName = "127.0.0.1",
+        Func<IServiceProvider, DogStatsdService>? serviceFactory = default,
         string[]? defaultTags = default)
     {
-        builder.AddDatadogPublisher(serviceCheckName, new StatsdConfig() { StatsdServerName = datadogAgentName }, defaultTags);
+        builder.Services
+            .AddSingleton<IHealthCheckPublisher>(sp =>
+            {
+                DogStatsdService service = serviceFactory?.Invoke(sp) ?? sp.GetRequiredService<DogStatsdService>();
+
+                return new DatadogPublisher(service, serviceCheckName, defaultTags);
+            });
+
         return builder;
     }
 
@@ -36,14 +46,14 @@ public static class DatadogHealthCheckBuilderExtensions
     /// and a metric indicating the total time the health check took to execute in milliseconds is sent to Datadog.
     /// </remarks>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
-    /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to datadog. Example: "myservice.healthchecks".</param>
-    /// <param name="statsdConfig">The whole Datadog StatsdConfig</param>
+    /// <param name="serviceCheckName">Specifies the name of the custom check and metric that will be published to Datadog. Example: "myservice.healthchecks".</param>
+    /// <param name="statsdConfigFactory">The factory method to resolve <see cref="StatsdConfig"/>.</param>
     /// <param name="defaultTags">Specifies a collection of tags to send with the custom check and metric.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddDatadogPublisher(
         this IHealthChecksBuilder builder,
         string serviceCheckName,
-        StatsdConfig statsdConfig,
+        Func<IServiceProvider, StatsdConfig> statsdConfigFactory,
         string[]? defaultTags = default)
     {
         builder.Services
@@ -51,7 +61,7 @@ public static class DatadogHealthCheckBuilderExtensions
             {
                 var dogStatsdService = new DogStatsdService();
 
-                dogStatsdService.Configure(statsdConfig);
+                dogStatsdService.Configure(statsdConfigFactory.Invoke(sp));
 
                 return new DatadogPublisher(dogStatsdService, serviceCheckName, defaultTags);
             });

--- a/src/HealthChecks.Publisher.Datadog/README.md
+++ b/src/HealthChecks.Publisher.Datadog/README.md
@@ -1,0 +1,39 @@
+## Datadog Health Check
+
+This health check verifies the ability to communicate with [Datadog](https://www.datadoghq.com/). It uses the provided [DogStatsdService](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=dotnet#dogstatsd-client) to record a run status for the specified named service check.
+
+### Defaults
+
+By default, the `DogStatsdService` instance is resolved from service provider. You need to specify the name of the custom check that will be published to Datadog.
+
+```csharp
+void Configure(IHealthChecksBuilder builder)
+{
+    builder.Services.AddSingleton(sp =>
+    {
+        StatsdConfig config = new() { StatsdServerName = "127.0.0.1" };
+        DogStatsdService service = new();
+        service.Configure(config);
+        return service;
+    });
+    builder.AddDatadogPublisher(serviceCheckName: "myservice.healthchecks");
+}
+```
+
+### Customization
+
+You can use the overload that requires a `StatsdConfig` factory method. In such case, the health check is going to create a dedicated instance of `DogStatsdService` that will be used only by the health check itself.
+
+
+```csharp
+void Customization(IHealthChecksBuilder builder)
+{
+    builder.AddDatadogPublisher(
+        serviceCheckName: "myservice.healthchecks",
+        sp => new StatsdConfig()
+        {
+            StatsdServerName = "127.0.0.1",
+            StatsdPort = 123,
+        });
+}
+```

--- a/test/HealthChecks.Publisher.Datadog.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Publisher.Datadog.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,3 +1,5 @@
+using StatsdClient;
+
 namespace HealthChecks.Publisher.Datadog.Tests.DependencyInjection;
 
 public class datadog_publisher_registration_should
@@ -6,13 +8,50 @@ public class datadog_publisher_registration_should
     public void add_healthcheck_when_properly_configured()
     {
         var services = new ServiceCollection()
+            .AddSingleton(sp =>
+            {
+                StatsdConfig config = new() { StatsdServerName = "127.0.0.1" };
+                DogStatsdService service = new();
+                service.Configure(config);
+                return service;
+            })
             .AddHealthChecks()
-            .AddDatadogPublisher(serviceCheckName: "serviceCheckName", datadogAgentName: "127.0.0.1")
+            .AddDatadogPublisher(serviceCheckName: "serviceCheckName")
             .Services;
 
         using var serviceProvider = services.BuildServiceProvider();
         var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
 
         publisher.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CodeFromReadmeCompiles()
+    {
+        Defaults(new ServiceCollection().AddHealthChecks());
+        Customization(new ServiceCollection().AddHealthChecks());
+
+        void Defaults(IHealthChecksBuilder builder)
+        {
+            builder.Services.AddSingleton(sp =>
+            {
+                StatsdConfig config = new() { StatsdServerName = "127.0.0.1" };
+                DogStatsdService service = new();
+                service.Configure(config);
+                return service;
+            });
+            builder.AddDatadogPublisher(serviceCheckName: "myservice.healthchecks");
+        }
+
+        void Customization(IHealthChecksBuilder builder)
+        {
+            builder.AddDatadogPublisher(
+                serviceCheckName: "myservice.healthchecks",
+                sp => new StatsdConfig()
+                {
+                    StatsdServerName = "127.0.0.1",
+                    StatsdPort = 123,
+                });
+        }
     }
 }

--- a/test/HealthChecks.Publisher.Datadog.Tests/HealthChecks.Publisher.Datadog.approved.txt
+++ b/test/HealthChecks.Publisher.Datadog.Tests/HealthChecks.Publisher.Datadog.approved.txt
@@ -2,6 +2,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class DatadogHealthCheckBuilderExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddDatadogPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string serviceCheckName, string datadogAgentName = "127.0.0.1", string[]? defaultTags = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddDatadogPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string serviceCheckName, System.Func<System.IServiceProvider, StatsdClient.StatsdConfig> statsdConfigFactory, string[]? defaultTags = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddDatadogPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string serviceCheckName, System.Func<System.IServiceProvider, StatsdClient.DogStatsdService>? serviceFactory = null, string[]? defaultTags = null) { }
     }
 }


### PR DESCRIPTION
1. Ensure we resolve a singleton instance rather than create a dedicated one by default (https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/2289#issuecomment-2511930940)
2. Add Readme
3. Update tests so they pass

I've removed the overload that takes a string, so it's a breaking change. It will be released as part of the 9.0 release (major version update).

cc @kevingosse