### PR TITLE
trigger the CI when file with version numbers gets updated

### DIFF
--- a/.github/workflows/healthchecks_applicationstatus_ci.yml
+++ b/.github/workflows/healthchecks_applicationstatus_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_arangodb_ci.yml
+++ b/.github/workflows/healthchecks_arangodb_ci.yml
@@ -24,6 +24,7 @@ on:
       - .github/workflows/healthchecks_arangodb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_aws_s3_ci.yml
+++ b/.github/workflows/healthchecks_aws_s3_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_aws_secretsmanager_ci.yml
+++ b/.github/workflows/healthchecks_aws_secretsmanager_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_aws_sns_ci.yml
+++ b/.github/workflows/healthchecks_aws_sns_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_aws_sqs_ci.yml
+++ b/.github/workflows/healthchecks_aws_sqs_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_aws_systemsmanager_ci.yml
+++ b/.github/workflows/healthchecks_aws_systemsmanager_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azure_digitaltwin_ci.yml
+++ b/.github/workflows/healthchecks_azure_digitaltwin_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azure_iothub_ci.yml
+++ b/.github/workflows/healthchecks_azure_iothub_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azureapplicationinsights_ci.yml
+++ b/.github/workflows/healthchecks_azureapplicationinsights_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azurekeyvault_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
+++ b/.github/workflows/healthchecks_azurekeyvault_secrets_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azuresearch_ci.yml
+++ b/.github/workflows/healthchecks_azuresearch_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_azureservicebus_ci.yml
+++ b/.github/workflows/healthchecks_azureservicebus_ci.yml
@@ -26,6 +26,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_consul_ci.yml
+++ b/.github/workflows/healthchecks_consul_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_consul_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_consul_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_cosmosdb_ci.yml
+++ b/.github/workflows/healthchecks_cosmosdb_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_cosmosdb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_cosmosdb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_dapr_ci.yml
+++ b/.github/workflows/healthchecks_dapr_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_dynamodb_ci.yml
+++ b/.github/workflows/healthchecks_dynamodb_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_elasticsearch_ci.yml
+++ b/.github/workflows/healthchecks_elasticsearch_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_elasticsearch_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_elasticsearch_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -10,6 +10,7 @@ on:
       - .github/workflows/healthchecks_eventstore_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -23,6 +24,7 @@ on:
       - .github/workflows/healthchecks_eventstore_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_eventstore_grpc_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_eventstore_grpc_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_gcp_cloudfirestore_ci.yml
+++ b/.github/workflows/healthchecks_gcp_cloudfirestore_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_gremlin_ci.yml
+++ b/.github/workflows/healthchecks_gremlin_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_gremlin_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_gremlin_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_hangfire_ci.yml
+++ b/.github/workflows/healthchecks_hangfire_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_ibmmq_ci.yml
+++ b/.github/workflows/healthchecks_ibmmq_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_ibmmq_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_ibmmq_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_influxdb_ci.yml
+++ b/.github/workflows/healthchecks_influxdb_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_influxdb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_influxdb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_kafka_ci.yml
+++ b/.github/workflows/healthchecks_kafka_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_kafka_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_kafka_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_kubernetes_ci.yml
+++ b/.github/workflows/healthchecks_kubernetes_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_milvus_ci.yml
+++ b/.github/workflows/healthchecks_milvus_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_milvus_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_milvus_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_mongodb_ci.yml
+++ b/.github/workflows/healthchecks_mongodb_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_mongodb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_mongodb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_mysql_ci.yml
+++ b/.github/workflows/healthchecks_mysql_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_mysql_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_mysql_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_nats_ci.yml
+++ b/.github/workflows/healthchecks_nats_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_nats_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_nats_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_network_ci.yml
+++ b/.github/workflows/healthchecks_network_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_network_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_network_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_npgsql_ci.yml
+++ b/.github/workflows/healthchecks_npgsql_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_npgsql_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_npgsql_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_openidconnectserver_ci.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_idsvr_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_idsvr_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_oracle_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_oracle_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_prometheus_metrics_ci.yml
+++ b/.github/workflows/healthchecks_prometheus_metrics_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_publisher_applicationinsights_ci.yml
+++ b/.github/workflows/healthchecks_publisher_applicationinsights_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
+++ b/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_publisher_cloudwatch_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_publisher_cloudwatch_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_publisher_datadog_ci.yml
+++ b/.github/workflows/healthchecks_publisher_datadog_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_publisher_prometheus_ci.yml
+++ b/.github/workflows/healthchecks_publisher_prometheus_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_publisher_seq_ci.yml
+++ b/.github/workflows/healthchecks_publisher_seq_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_qdrant_ci.yml
+++ b/.github/workflows/healthchecks_qdrant_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_qdrant_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_qdrant_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_rabbitmq_ci.yml
+++ b/.github/workflows/healthchecks_rabbitmq_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_rabbitmq_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_rabbitmq_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_ravendb_ci.yml
+++ b/.github/workflows/healthchecks_ravendb_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_ravendb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_ravendb_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_redis_ci.yml
+++ b/.github/workflows/healthchecks_redis_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_redis_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_redis_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_sendgrid_ci.yml
+++ b/.github/workflows/healthchecks_sendgrid_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_signalr_ci.yml
+++ b/.github/workflows/healthchecks_signalr_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_solr_ci.yml
+++ b/.github/workflows/healthchecks_solr_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_solr_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_solr_ci.
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_sqlite_ci.yml
+++ b/.github/workflows/healthchecks_sqlite_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_sqlserver_ci.yml
+++ b/.github/workflows/healthchecks_sqlserver_ci.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/healthchecks_sqlserver_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -24,6 +25,7 @@ on:
       - .github/workflows/healthchecks_sqlserver_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_system_ci.yml
+++ b/.github/workflows/healthchecks_system_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:

--- a/.github/workflows/healthchecks_ui_ci.yml
+++ b/.github/workflows/healthchecks_ui_ci.yml
@@ -13,6 +13,7 @@ on:
       - .github/workflows/healthchecks_ui_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
       - build/docker-images/HealthChecks.UI.Image/**
     tags-ignore:
       - release-*
@@ -29,6 +30,7 @@ on:
       - .github/workflows/healthchecks_ui_ci.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
       - build/docker-images/HealthChecks.UI.Image/**
 
 jobs:

--- a/.github/workflows/healthchecks_uris_ci.yml
+++ b/.github/workflows/healthchecks_uris_ci.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
     tags-ignore:
       - release-*
       - preview-*
@@ -26,6 +27,7 @@ on:
       - .github/workflows/reusable_ci_workflow.yml
       - Directory.Build.props
       - Directory.Build.targets
+      - Directory.Packages.props
 
 jobs:
   build:


### PR DESCRIPTION
Follow up to https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/2278 cc @Alirexaa 

FWIW I am going to merge it as soon as the CI gets green as the change was "automated" with following app:

```cs
namespace EasyReplace
{
    internal class Program
    {
        static void Main(string[] args)
        {
            string text = @"
      - Directory.Build.props
      - Directory.Build.targets
";

            string cpm = @"
      - Directory.Build.props
      - Directory.Build.targets
      - Directory.Packages.props
";

            foreach (string filePath in Directory.EnumerateFiles(@"D:\projects\forks\healthChecks\.github\workflows\"))
            {
                File.WriteAllText(filePath, File.ReadAllText(filePath).Replace(text, cpm));
            }
        }
    }
}
````