### PR TITLE
Update to currently supported Target Frameworks.

### DIFF
--- a/.github/workflows/healthchecks_arangodb_ci.yml
+++ b/.github/workflows/healthchecks_arangodb_ci.yml
@@ -42,9 +42,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.ArangoDb/HealthChecks.ArangoDb.csproj &&

--- a/.github/workflows/healthchecks_consul_ci.yml
+++ b/.github/workflows/healthchecks_consul_ci.yml
@@ -42,9 +42,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Consul/HealthChecks.Consul.csproj &&

--- a/.github/workflows/healthchecks_elasticsearch_ci.yml
+++ b/.github/workflows/healthchecks_elasticsearch_ci.yml
@@ -42,9 +42,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - run:
           ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
       - name: Restore

--- a/.github/workflows/healthchecks_eventstore_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_ci.yml
@@ -45,9 +45,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.EventStore/HealthChecks.EventStore.csproj &&

--- a/.github/workflows/healthchecks_eventstore_grpc_ci.yml
+++ b/.github/workflows/healthchecks_eventstore_grpc_ci.yml
@@ -44,9 +44,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj &&

--- a/.github/workflows/healthchecks_gremlin_ci.yml
+++ b/.github/workflows/healthchecks_gremlin_ci.yml
@@ -44,9 +44,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Gremlin/HealthChecks.Gremlin.csproj &&

--- a/.github/workflows/healthchecks_ibmmq_ci.yml
+++ b/.github/workflows/healthchecks_ibmmq_ci.yml
@@ -47,9 +47,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.IbmMQ/HealthChecks.IbmMQ.csproj &&

--- a/.github/workflows/healthchecks_influxdb_ci.yml
+++ b/.github/workflows/healthchecks_influxdb_ci.yml
@@ -36,9 +36,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.InfluxDB/HealthChecks.InfluxDB.csproj &&

--- a/.github/workflows/healthchecks_kafka_ci.yml
+++ b/.github/workflows/healthchecks_kafka_ci.yml
@@ -57,9 +57,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Kafka/HealthChecks.Kafka.csproj &&

--- a/.github/workflows/healthchecks_milvus_ci.yml
+++ b/.github/workflows/healthchecks_milvus_ci.yml
@@ -40,9 +40,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Milvus/HealthChecks.Milvus.csproj &&          

--- a/.github/workflows/healthchecks_mongodb_ci.yml
+++ b/.github/workflows/healthchecks_mongodb_ci.yml
@@ -41,9 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.MongoDb/HealthChecks.MongoDb.csproj &&

--- a/.github/workflows/healthchecks_mysql_ci.yml
+++ b/.github/workflows/healthchecks_mysql_ci.yml
@@ -43,9 +43,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.MySql/HealthChecks.MySql.csproj &&

--- a/.github/workflows/healthchecks_nats_ci.yml
+++ b/.github/workflows/healthchecks_nats_ci.yml
@@ -43,9 +43,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Nats/HealthChecks.Nats.csproj &&

--- a/.github/workflows/healthchecks_network_ci.yml
+++ b/.github/workflows/healthchecks_network_ci.yml
@@ -68,9 +68,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Network/HealthChecks.Network.csproj &&

--- a/.github/workflows/healthchecks_npgsql_ci.yml
+++ b/.github/workflows/healthchecks_npgsql_ci.yml
@@ -44,9 +44,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj &&

--- a/.github/workflows/healthchecks_openidconnectserver_ci.yml
+++ b/.github/workflows/healthchecks_openidconnectserver_ci.yml
@@ -41,9 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.OpenIdConnectServer/HealthChecks.OpenIdConnectServer.csproj &&

--- a/.github/workflows/healthchecks_oracle_ci.yml
+++ b/.github/workflows/healthchecks_oracle_ci.yml
@@ -43,9 +43,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Oracle/HealthChecks.Oracle.csproj &&

--- a/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
+++ b/.github/workflows/healthchecks_publisher_cloudwatch_ci.yml
@@ -38,9 +38,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Publisher.CloudWatch/HealthChecks.Publisher.CloudWatch.csproj &&

--- a/.github/workflows/healthchecks_qdrant_ci.yml
+++ b/.github/workflows/healthchecks_qdrant_ci.yml
@@ -43,9 +43,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Qdrant/HealthChecks.Qdrant.csproj &&          

--- a/.github/workflows/healthchecks_rabbitmq_ci.yml
+++ b/.github/workflows/healthchecks_rabbitmq_ci.yml
@@ -41,9 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Rabbitmq/HealthChecks.Rabbitmq.csproj &&

--- a/.github/workflows/healthchecks_ravendb_ci.yml
+++ b/.github/workflows/healthchecks_ravendb_ci.yml
@@ -43,9 +43,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.RavenDB/HealthChecks.RavenDB.csproj &&

--- a/.github/workflows/healthchecks_redis_ci.yml
+++ b/.github/workflows/healthchecks_redis_ci.yml
@@ -41,9 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Redis/HealthChecks.Redis.csproj &&

--- a/.github/workflows/healthchecks_solr_ci.yml
+++ b/.github/workflows/healthchecks_solr_ci.yml
@@ -55,9 +55,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.Solr/HealthChecks.Solr.csproj &&

--- a/.github/workflows/healthchecks_sqlserver_ci.yml
+++ b/.github/workflows/healthchecks_sqlserver_ci.yml
@@ -44,9 +44,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.SqlServer/HealthChecks.SqlServer.csproj &&

--- a/.github/workflows/healthchecks_ui_cd.yml
+++ b/.github/workflows/healthchecks_ui_cd.yml
@@ -17,9 +17,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore UI
         run: dotnet restore ./src/HealthChecks.UI/HealthChecks.UI.csproj
       - name: Restore UI.Client

--- a/.github/workflows/healthchecks_ui_cd_preview.yml
+++ b/.github/workflows/healthchecks_ui_cd_preview.yml
@@ -18,9 +18,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore UI
         run: dotnet restore ./src/HealthChecks.UI/HealthChecks.UI.csproj
       - name: Restore UI.Client

--- a/.github/workflows/healthchecks_ui_ci.yml
+++ b/.github/workflows/healthchecks_ui_ci.yml
@@ -63,9 +63,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ./src/HealthChecks.UI/HealthChecks.UI.csproj &&

--- a/.github/workflows/reusable_cd_preview_workflow.yml
+++ b/.github/workflows/reusable_cd_preview_workflow.yml
@@ -25,9 +25,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: dotnet restore ${{inputs.PROJECT_PATH}}
       - name: Build

--- a/.github/workflows/reusable_cd_workflow.yml
+++ b/.github/workflows/reusable_cd_workflow.yml
@@ -22,9 +22,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: dotnet restore ${{inputs.PROJECT_PATH}}
       - name: Build

--- a/.github/workflows/reusable_ci_workflow.yml
+++ b/.github/workflows/reusable_ci_workflow.yml
@@ -22,9 +22,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
       - name: Restore
         run: |
           dotnet restore ${{inputs.PROJECT_PATH}} &&

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);1591;IDISP013;AD0001;</NoWarn> <!--TODO: temporary solution, remove AD0001 after https://github.com/dotnet/aspnetcore/issues/50836 fixed-->
+    <NoWarn>$(NoWarn);1591;IDISP013;</NoWarn>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,9 +43,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.10" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
     <PackageVersion Include="Microsoft.Azure.Devices" Version="1.40.0" />
     <PackageVersion Include="Microsoft.Azure.DocumentDB.Core" Version="2.20.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultNetCoreApp>net6.0</DefaultNetCoreApp>
+    <DefaultNetCoreApp>net8.0</DefaultNetCoreApp>
     <DefaultLibraryTargetFrameworks>$(DefaultNetCoreApp);netstandard2.0</DefaultLibraryTargetFrameworks>
   </PropertyGroup>
   

--- a/src/HealthChecks.Dapr/HealthChecks.Dapr.csproj
+++ b/src/HealthChecks.Dapr/HealthChecks.Dapr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);Dapr</PackageTags>
     <Description>HealthChecks.Dapr is the health check package for Dapr.</Description>
     <VersionPrefix>$(HealthCheckDapr)</VersionPrefix>

--- a/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
+++ b/src/HealthChecks.EventStore.gRPC/HealthChecks.EventStore.gRPC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);EventStore;gRPC</PackageTags>
     <Description>HealthChecks.EventStore.gRPC is the health check package for EventStore, using the gRPC client.</Description>
     <VersionPrefix>$(HealthCheckEventStoregRPC)</VersionPrefix>

--- a/src/HealthChecks.Kubernetes/HealthChecks.Kubernetes.csproj
+++ b/src/HealthChecks.Kubernetes/HealthChecks.Kubernetes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);Kubernetes;k8s;Cluster</PackageTags>
     <Description>HealthChecks.HealthChecks is the health check package for Kubernetes clusters.</Description>
     <VersionPrefix>$(HealthCheckKubernetes)</VersionPrefix>

--- a/src/HealthChecks.Network/HealthChecks.Network.csproj
+++ b/src/HealthChecks.Network/HealthChecks.Network.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Network;Sftp;Ftp;Tcp;DNS</PackageTags>
     <Description>HealthChecks.Network is the health check package for network services.</Description>
     <VersionPrefix>$(HealthCheckNetwork)</VersionPrefix>

--- a/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
+++ b/src/HealthChecks.NpgSql/HealthChecks.NpgSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Beat;Postgress</PackageTags>
     <Description>HealthChecks.NpgSql is a health check for Postgress Sql.</Description>
     <VersionPrefix>$(HealthCheckNpgSql)</VersionPrefix>

--- a/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
+++ b/src/HealthChecks.Prometheus.Metrics/HealthChecks.Prometheus.Metrics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);Prometheus;Prometheus Exporter;Metrics</PackageTags>
     <Description>HealthChecks.Publisher.Prometheus is a health check prometheus metrics exporter.</Description>
     <VersionPrefix>$(HealthCheckPrometheusMetrics)</VersionPrefix>

--- a/src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
+++ b/src/HealthChecks.Publisher.Prometheus/HealthChecks.Publisher.Prometheus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);Publisher;Prometheus;Prometheus Gateway</PackageTags>
     <Description>[Deprecated! Use pull model with AspNetCore.HealthChecks.Prometheus.Metrics package instead] HealthChecks.Publisher.PrometheusGateway is the health check publisher for Prometheus Gateway.</Description>
     <VersionPrefix>$(HealthCheckPublisherPrometheus)</VersionPrefix>

--- a/src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
+++ b/src/HealthChecks.Publisher.Seq/HealthChecks.Publisher.Seq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Publisher;Seq</PackageTags>
     <Description>HealthChecks.Publisher.Seq is the health check publisher for Seq.</Description>
     <VersionPrefix>$(HealthCheckPublisherSeq)</VersionPrefix>

--- a/src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj
+++ b/src/HealthChecks.UI.Client/HealthChecks.UI.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);UI;Client</PackageTags>
     <Description>HealthChecks.UI.Client contains some mandatory abstractions to work with HealthChecks.UI.</Description>
     <VersionPrefix>$(HealthCheckUIClient)</VersionPrefix>

--- a/src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj
+++ b/src/HealthChecks.UI.Core/HealthChecks.UI.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <PackageTags>$(PackageTags);Core</PackageTags>
     <Description>HealthChecks.UI.Core package containing builder and model definitions</Description>
     <VersionPrefix>$(HealthCheckUICore)</VersionPrefix>

--- a/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
+++ b/src/HealthChecks.UI.K8s.Operator/HealthChecks.UI.K8s.Operator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreApp)</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
     <VersionPrefix>$(HealthChecksUIK8sOperator)</VersionPrefix>

--- a/src/HealthChecks.Uris/HealthChecks.Uris.csproj
+++ b/src/HealthChecks.Uris/HealthChecks.Uris.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultLibraryTargetFrameworks)</TargetFrameworks>
     <PackageTags>$(PackageTags);Uri;Url;Uris;Urls</PackageTags>
     <Description>HealthChecks.Uris is a simple health check package for Uri groups.</Description>
     <VersionPrefix>$(HealthCheckUri)</VersionPrefix>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);IDE1006;RCS1090</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0053;IDE0060</WarningsNotAsErrors>
   </PropertyGroup>

--- a/test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj
+++ b/test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TestTfmsInParallel>false</TestTfmsInParallel>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.Elasticsearch\HealthChecks.Elasticsearch.csproj" />
     <PackageReference Include="Ductus.FluentDocker" />

--- a/test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj
+++ b/test/HealthChecks.Elasticsearch.Tests/HealthChecks.Elasticsearch.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- The functional tests can't be run in parallel because they conflict with each other when creating docker containers. -->
     <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 

--- a/test/HealthChecks.Elasticsearch.Tests/Resources/docker-compose.yml
+++ b/test/HealthChecks.Elasticsearch.Tests/Resources/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.2"
-
 services:
   setup:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3

--- a/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.Tests.csproj
+++ b/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.Tests.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
   </ItemGroup>

--- a/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.Tests.csproj
+++ b/test/HealthChecks.UI.Client.Tests/HealthChecks.UI.Client.Tests.csproj
@@ -1,7 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/test/HealthChecks.UI.Data.Tests/HealthChecks.UI.Data.Tests.csproj
+++ b/test/HealthChecks.UI.Data.Tests/HealthChecks.UI.Data.Tests.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <ProjectReference Include="..\..\src\HealthChecks.UI.Data\HealthChecks.UI.Data.csproj" />

--- a/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
+++ b/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\build\docker-images\HealthChecks.UI.Image\HealthChecks.UI.Image.csproj" />
-    <ProjectReference Include="..\..\src\HealthChecks.UI.Client\HealthChecks.UI.Client.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI.InMemory.Storage\HealthChecks.UI.InMemory.Storage.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI.MySql.Storage\HealthChecks.UI.MySql.Storage.csproj" />
     <ProjectReference Include="..\..\src\HealthChecks.UI.PostgreSQL.Storage\HealthChecks.UI.PostgreSQL.Storage.csproj" />

--- a/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
+++ b/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="Functional\Configuration\appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/test/HealthChecks.Uris.Tests/HealthChecks.Uris.Tests.csproj
+++ b/test/HealthChecks.Uris.Tests/HealthChecks.Uris.Tests.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="RichardSzalay.MockHttp" />
     <ProjectReference Include="..\..\src\HealthChecks.Uris\HealthChecks.Uris.csproj" />


### PR DESCRIPTION
**What this PR does / why we need it**:

This drops support for end-of-life TFMs: anything before `net8.0` keeping `netstandard2.0` in any library that supported it before.

Tests are run on net8 and net9.

**Does this PR introduce a user-facing change?**:

Yes, it drops support for end-of-life TFMs in preparation for releasing the next major version.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
