### PR TITLE
Webhooks list API newline handling (#2287)

### DIFF
--- a/src/HealthChecks.UI/Middleware/UIWebHooksApiMiddleware.cs
+++ b/src/HealthChecks.UI/Middleware/UIWebHooksApiMiddleware.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using HealthChecks.UI.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace HealthChecks.UI.Core;
@@ -12,8 +13,9 @@ public class UIWebHooksApiMiddleware
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<UIWebHooksApiMiddleware> _logger;
 
-    public UIWebHooksApiMiddleware(RequestDelegate next, IServiceScopeFactory serviceScopeFactory)
+    public UIWebHooksApiMiddleware(RequestDelegate next, IServiceScopeFactory serviceScopeFactory, ILogger<UIWebHooksApiMiddleware> logger)
     {
         _ = next;
         _jsonSerializerOptions = new JsonSerializerOptions
@@ -21,6 +23,7 @@ public class UIWebHooksApiMiddleware
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
         _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -28,12 +31,45 @@ public class UIWebHooksApiMiddleware
         using var scope = _serviceScopeFactory.CreateScope();
 
         var settings = scope.ServiceProvider.GetRequiredService<IOptions<Settings>>();
-        var sanitizedWebhooksResponse = settings.Value.Webhooks.Select(item => new
+        var sanitizedWebhooksResponse = settings.Value.Webhooks.Select(item =>
         {
-            item.Name,
-            Payload = string.IsNullOrEmpty(item.Payload) ? new JsonObject() : JsonNode.Parse(Regex.Unescape(item.Payload))
+            try
+            {
+                var payloadObject = string.IsNullOrEmpty(item.Payload) ? new JsonObject() : JsonNode.Parse(ReplaceEscapeSequences(item.Payload));
+                return new
+                {
+                    item.Name,
+                    Payload = payloadObject
+                };
+            }
+            catch (JsonException exception)
+            {
+                var errorMessage = $"UIWebHooksApiMiddleware threw an exception when trying to parse payload for webhook {item.Name}.";
+                _logger.LogError(exception, errorMessage);
+                throw new Exception(errorMessage, exception);
+            }
         });
 
         await context.Response.WriteAsJsonAsync(sanitizedWebhooksResponse, _jsonSerializerOptions).ConfigureAwait(false);
     }
+
+    public static string ReplaceEscapeSequences(string input)
+    {
+        // Regular expression to match newline and carriage return escape sequences outside of double quotes
+        var pattern = @"(?<!\"")\\([nr])((?=(?:[^""]*\""[^""]*"")*[^""]*$))";
+
+        return Regex.Replace(input, pattern, match =>
+        {
+            if (match.Groups[1].Value == "n")
+            {
+                return "\n";
+            }
+            else if (match.Groups[1].Value == "r")
+            {
+                return "\r";
+            }
+            return match.Value; // No change if the match doesn't represent a newline or carriage return
+        });
+    }
+
 }

--- a/test/HealthChecks.UI.Tests/Functional/WebhookApiEndpointTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/WebhookApiEndpointTests.cs
@@ -1,0 +1,196 @@
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace HealthChecks.UI.Tests;
+
+public class ui_webhooks_api
+{
+    [Fact]
+    public async Task should_generate_successful_response_for_webhooks_path()
+    {
+        // Arrange
+        string webhookName = "testWebhook";
+        string webhookUri = "http://webhook/sample";
+        string webhookPayload = "{\"key\":\"value\"}";
+        string webhookRestorePayload = "{\"key\":\"restoreValue\"}";
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddRouting()
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup
+                            .AddWebhookNotification(
+                                name: webhookName,
+                                uri: webhookUri,
+                                payload: webhookPayload,
+                                restorePayload: webhookRestorePayload);
+                    })
+                    .AddInMemoryStorage(databaseName: "WebhooksResponseTest");
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapHealthChecksUI(); // Registers the HealthChecks UI middleware
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        // Act
+        var response = await server.CreateRequest(new Configuration.Options().WebhookPath).GetAsync();
+
+        // Assert
+        response.EnsureSuccessStatusCode(); // Verify 200 OK response
+        response.Content.Headers.ContentType?.ToString().ShouldBe("application/json; charset=utf-8");
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var responseJson = JsonSerializer.Deserialize<List<WebHookApiItem>>(responseBody, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        responseJson.ShouldNotBeNull();
+        responseJson.Count.ShouldBe(1);
+
+        var webhookResponse = responseJson.First();
+        webhookResponse.Name.ShouldBe(webhookName);
+
+        // Verify dynamic payload as serialized JSON object
+        var payloadJson = JsonSerializer.Serialize(webhookResponse.Payload);
+        payloadJson.ShouldBe(webhookPayload);
+    }
+
+    [Fact]
+    public async Task should_generate_successful_response_for_webhooks_path_with_newline_in_payload()
+    {
+        // Arrange
+        string webhookName = "testWebhook";
+        string webhookUri = "http://webhook/sample";
+        string webhookPayload = "{\"key\":\"line 1\\nline 2\"}";
+        string webhookRestorePayload = "{\"key\":\"restoreValue\"}";
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddRouting()
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup
+                            .AddWebhookNotification(
+                                name: webhookName,
+                                uri: webhookUri,
+                                payload: webhookPayload,
+                                restorePayload: webhookRestorePayload);
+                    })
+                    .AddInMemoryStorage(databaseName: "WebhooksResponseTest");
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapHealthChecksUI(); // Registers the HealthChecks UI middleware
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        // Act
+        var response = await server.CreateRequest(new Configuration.Options().WebhookPath).GetAsync();
+
+        // Assert
+        response.EnsureSuccessStatusCode(); // Verify 200 OK response
+        response.Content.Headers.ContentType?.ToString().ShouldBe("application/json; charset=utf-8");
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var responseJson = JsonSerializer.Deserialize<List<WebHookApiItem>>(responseBody, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        responseJson.ShouldNotBeNull();
+        responseJson.Count.ShouldBe(1);
+
+        var webhookResponse = responseJson.First();
+        webhookResponse.Name.ShouldBe(webhookName);
+
+        // Verify dynamic payload as serialized JSON object
+        var payloadJson = JsonSerializer.Serialize(webhookResponse.Payload);
+        payloadJson.ShouldBe(webhookPayload);
+    }
+
+    [Fact]
+    public async Task should_generate_successful_response_for_webhooks_path_with_teams_example()
+    {
+        // Arrange
+        string webhookName = "Teams";
+        string webhookUri = "https://outlook.office.com/webhook/...";
+        string webhookPayload = "{\\r\\n  \"@context\": \"http://schema.org/extensions\",\\r\\n  \"@type\": \"MessageCard\",\\r\\n  \"themeColor\": \"0072C6\",\\r\\n  \"title\": \"[[LIVENESS]] has failed!\",\\r\\n  \"text\": \"[[FAILURE]] Click **Learn More** to go to BeatPulseUI Portal\",\\r\\n  \"potentialAction\": [\\r\\n    {\\r\\n      \"@type\": \"OpenUri\",\\r\\n      \"name\": \"Lear More\",\\r\\n      \"targets\": [\\r\\n        { \"os\": \"default\", \"uri\": \"http://localhost:52665/beatpulse-ui\" }\\r\\n      ]\\r\\n    }\\r\\n  ]\\r\\n}";
+        string webhookRestorePayload = "{\"text\":\"The HealthCheck [[LIVENESS]] is recovered. All is up and running\",\"channel\":\"#general\",\"link_names\": 1,\"username\":\"monkey-bot\",\"icon_emoji\":\":monkey_face\" }";
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddRouting()
+                    .AddHealthChecksUI(setup =>
+                    {
+                        setup
+                            .AddWebhookNotification(
+                                name: webhookName,
+                                uri: webhookUri,
+                                payload: webhookPayload,
+                                restorePayload: webhookRestorePayload);
+                    })
+                    .AddInMemoryStorage(databaseName: "WebhooksResponseTest");
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapHealthChecksUI(); // Registers the HealthChecks UI middleware
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        // Act
+        var response = await server.CreateRequest(new Configuration.Options().WebhookPath).GetAsync();
+
+        // Assert
+        response.EnsureSuccessStatusCode(); // Verify 200 OK response
+        response.Content.Headers.ContentType?.ToString().ShouldBe("application/json; charset=utf-8");
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var responseJson = JsonSerializer.Deserialize<List<WebHookApiItem>>(responseBody, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        responseJson.ShouldNotBeNull();
+        responseJson.Count.ShouldBe(1);
+
+        var webhookResponse = responseJson.First();
+        webhookResponse.Name.ShouldBe(webhookName);
+
+        // Unescape newlines, which are all outside of JSON values
+        var expectedPayload = JsonSerializer.Serialize(JsonNode.Parse(Regex.Unescape(webhookPayload)));
+        var payloadJson = JsonSerializer.Serialize(webhookResponse.Payload);
+        payloadJson.ShouldBe(expectedPayload);
+    }
+
+    private class WebHookApiItem
+    {
+        public string? Name { get; set; }
+        public JsonNode? Payload { get; set; }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Escaped new lines are allowed in the quoted JSON strings in payload for webhooks, but fail to render in the HealthChecks UI interface. An exception is thrown when Regex.Unescape() is called and then JsonNode.Parse() on the results, and literal newlines are included in JSON strings of the payload.

* Allow for escaped newlines inside double quoted blocks in payload when pulling the list of webhooks from the webhooks API
* Unit tests for newlines inside and outside quoted JSON strings in payload

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #2287 

**Special notes for your reviewer**:

First time contributing to a open source github project, this submission may be rough.  I do not know how to run end-to-end tests.

**Does this PR introduce a user-facing change?**:

Yes

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [?] End-to-end tests passing
