### PR TITLE
#2373 Add option to use trackAvailability() instead of trackEvents() in applicationInsightsPublisher

### DIFF
--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -136,7 +136,7 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
         }
     }
 
-    private TelemetryClient GetOrCreateTelemetryClient()
+    internal virtual TelemetryClient GetOrCreateTelemetryClient()
     {
         if (_client == null)
         {

--- a/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/ApplicationInsightsPublisher.cs
@@ -19,17 +19,20 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
     private readonly string? _connectionString;
     private readonly bool _saveDetailedReport;
     private readonly bool _excludeHealthyReports;
+    private readonly bool _trackAsAvailability;
 
     public ApplicationInsightsPublisher(
         IOptions<TelemetryConfiguration>? telemetryConfiguration,
         string? connectionString = default,
         bool saveDetailedReport = false,
-        bool excludeHealthyReports = false)
+        bool excludeHealthyReports = false,
+        bool trackAsAvailability = false)
     {
         _telemetryConfiguration = telemetryConfiguration?.Value;
         _connectionString = connectionString;
         _saveDetailedReport = saveDetailedReport;
         _excludeHealthyReports = excludeHealthyReports;
+        _trackAsAvailability = trackAsAvailability;
     }
 
     public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
@@ -57,18 +60,34 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
     {
         foreach (var reportEntry in report.Entries.Where(entry => !_excludeHealthyReports || entry.Value.Status != HealthStatus.Healthy))
         {
-            client.TrackEvent($"{EVENT_NAME}:{reportEntry.Key}",
-                properties: new Dictionary<string, string?>()
-                {
-                    { nameof(Environment.MachineName), Environment.MachineName },
-                    { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name },
-                    { HEALTHCHECK_NAME, reportEntry.Key }
-                },
-                metrics: new Dictionary<string, double>()
-                {
-                    { METRIC_STATUS_NAME, reportEntry.Value.Status == HealthStatus.Healthy ? 1 : 0 },
-                    { METRIC_DURATION_NAME, reportEntry.Value.Duration.TotalMilliseconds }
-                });
+            if( _trackAsAvailability )
+            {
+                client.TrackAvailability( $"{EVENT_NAME}:{reportEntry.Key}",
+                    DateTimeOffset.UtcNow,
+                    reportEntry.Value.Duration,
+                    Environment.MachineName,
+                    reportEntry.Value.Status == HealthStatus.Healthy,
+                    reportEntry.Value.Exception?.Message,
+                    properties: new Dictionary<string, string?>()
+                    {
+                        { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name },
+                        { HEALTHCHECK_NAME, reportEntry.Key }
+                    });
+            }
+            else
+            {
+                client.TrackEvent($"{EVENT_NAME}:{reportEntry.Key}",
+                    properties: new Dictionary<string, string?>()
+                    {
+                        { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name },
+                        { HEALTHCHECK_NAME, reportEntry.Key }
+                    },
+                    metrics: new Dictionary<string, double>()
+                    {
+                        { METRIC_STATUS_NAME, reportEntry.Value.Status == HealthStatus.Healthy ? 1 : 0 },
+                        { METRIC_DURATION_NAME, reportEntry.Value.Duration.TotalMilliseconds }
+                    });
+            }
         }
 
         foreach (var reportEntry in report.Entries.Where(entry => entry.Value.Exception != null))
@@ -87,19 +106,34 @@ internal class ApplicationInsightsPublisher : IHealthCheckPublisher
                 });
         }
     }
-    private static void SaveGeneralizedReport(HealthReport report, TelemetryClient client)
+    private void SaveGeneralizedReport(HealthReport report, TelemetryClient client)
     {
-        client.TrackEvent(EVENT_NAME,
-            properties: new Dictionary<string, string?>
-            {
-                { nameof(Environment.MachineName), Environment.MachineName },
-                { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name }
-            },
-            metrics: new Dictionary<string, double>
-            {
-                { METRIC_STATUS_NAME, report.Status == HealthStatus.Healthy ? 1 : 0 },
-                { METRIC_DURATION_NAME, report.TotalDuration.TotalMilliseconds }
-            });
+        if( _trackAsAvailability )
+        {
+            client.TrackAvailability( EVENT_NAME,
+                DateTimeOffset.UtcNow,
+                report.TotalDuration,
+                Environment.MachineName,
+                report.Status == HealthStatus.Healthy,
+                properties: new Dictionary<string, string?>
+                {
+                    { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name }
+                });
+        }
+        else
+        {
+            client.TrackEvent(EVENT_NAME,
+                properties: new Dictionary<string, string?>
+                {
+                    { nameof(Environment.MachineName), Environment.MachineName },
+                    { nameof(Assembly), Assembly.GetEntryAssembly()?.GetName().Name }
+                },
+                metrics: new Dictionary<string, double>
+                {
+                    { METRIC_STATUS_NAME, report.Status == HealthStatus.Healthy ? 1 : 0 },
+                    { METRIC_DURATION_NAME, report.TotalDuration.TotalMilliseconds }
+                });
+        }
     }
 
     private TelemetryClient GetOrCreateTelemetryClient()

--- a/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.ApplicationInsights/DependencyInjection/ApplicationInsightsHealthCheckBuilderExtensions.cs
@@ -18,18 +18,20 @@ public static class ApplicationInsightsHealthCheckBuilderExtensions
     /// <param name="connectionString">Specified Application Insights connection string. Optional. If <c>null</c> <see cref="TelemetryConfiguration"/> is resolved from DI container.</param>
     /// <param name="saveDetailedReport">Specifies if save an Application Insights event for each HealthCheck or just save one event with the global status for all the HealthChecks. Optional.</param>
     /// <param name="excludeHealthyReports">Specifies if save an Application Insights event only for reports indicating an unhealthy status.</param>
+    /// <param name="trackAsAvailability">Specifies if healthCheck result should be tracked as availability event. If false, healthCheck result will be tracked as custom event.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddApplicationInsightsPublisher(
         this IHealthChecksBuilder builder,
         string? connectionString = default,
         bool saveDetailedReport = false,
-        bool excludeHealthyReports = false)
+        bool excludeHealthyReports = false,
+        bool trackAsAvailability = false)
     {
         builder.Services
            .AddSingleton<IHealthCheckPublisher>(sp =>
            {
                var telemetryConfigurationOptions = sp.GetService<IOptions<TelemetryConfiguration>>();
-               return new ApplicationInsightsPublisher(telemetryConfigurationOptions, connectionString, saveDetailedReport, excludeHealthyReports);
+               return new ApplicationInsightsPublisher(telemetryConfigurationOptions, connectionString, saveDetailedReport, excludeHealthyReports, trackAsAvailability);
            });
 
         return builder;

--- a/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
+++ b/src/HealthChecks.Publisher.ApplicationInsights/HealthChecks.Publisher.ApplicationInsights.csproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Microsoft.ApplicationInsights" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/Functional/ApplicationInsightsPublisherTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using NSubstitute;
 
@@ -16,5 +19,116 @@ public class application_insights_publisher_should
 
         publish.ShouldThrow<ArgumentException>()
             .Message.ShouldBe("A connection string or TelemetryConfiguration must be set!");
+    }
+
+    [Fact]
+    public async Task send_availabilityTelemetry_when_trackAsAvailability_is_true_and_detailedReport_is_false()
+    {
+        var telemetryChannel = Substitute.For<ITelemetryChannel>();
+        var telemetryConfiguration = new TelemetryConfiguration
+        {
+            TelemetryChannel = telemetryChannel,
+            DisableTelemetry = false
+        };
+        var telemetryClient = new TelemetryClient(telemetryConfiguration);
+        var options = Substitute.For<IOptions<TelemetryConfiguration>>();
+        var publisher = Substitute.ForPartsOf<ApplicationInsightsPublisher>(options, "ConnectionString", false, false, true);
+        publisher.When(svc => svc.GetOrCreateTelemetryClient()).DoNotCallBase();
+        publisher.GetOrCreateTelemetryClient().Returns(telemetryClient);
+        var report = new HealthReport(new Dictionary<string, HealthReportEntry>(), TimeSpan.FromSeconds(5));
+
+        await publisher.PublishAsync(report, CancellationToken.None);
+
+        telemetryChannel
+            .Received()
+            .Send( Arg.Is<ITelemetry>(i => i is AvailabilityTelemetry &&
+                                           (i as AvailabilityTelemetry)!.Duration == report.TotalDuration &&
+                                           (i as AvailabilityTelemetry)!.RunLocation == Environment.MachineName &&
+                                           (i as AvailabilityTelemetry)!.Success &&
+                                           (i as AvailabilityTelemetry)!.Properties.Count == 1
+                                           ));
+    }
+
+    [Fact]
+    public async Task send_eventTelemetry_when_trackAsAvailability_and_detailedReport_is_false()
+    {
+        var telemetryChannel = Substitute.For<ITelemetryChannel>();
+        var telemetryConfiguration = new TelemetryConfiguration
+        {
+            TelemetryChannel = telemetryChannel,
+            DisableTelemetry = false
+        };
+        var telemetryClient = new TelemetryClient(telemetryConfiguration);
+        var options = Substitute.For<IOptions<TelemetryConfiguration>>();
+        var publisher = Substitute.ForPartsOf<ApplicationInsightsPublisher>(options, "ConnectionString", false, false, false);
+        publisher.When(svc => svc.GetOrCreateTelemetryClient()).DoNotCallBase();
+        publisher.GetOrCreateTelemetryClient().Returns(telemetryClient);
+        var report = new HealthReport(new Dictionary<string, HealthReportEntry>(), TimeSpan.FromSeconds(5));
+
+        await publisher.PublishAsync(report, CancellationToken.None);
+
+        telemetryChannel
+            .Received()
+            .Send( Arg.Is<ITelemetry>(i => i is EventTelemetry &&
+                                           (i as EventTelemetry)!.Properties.Count == 2 &&
+                                           (i as EventTelemetry)!.Metrics.Count == 2
+            ));
+    }
+
+    [Fact]
+    public async Task send_availabilityTelemetry_when_trackAsAvailability_and_detailedReport_is_true()
+    {
+        var telemetryChannel = Substitute.For<ITelemetryChannel>();
+        var telemetryConfiguration = new TelemetryConfiguration
+        {
+            TelemetryChannel = telemetryChannel,
+            DisableTelemetry = false
+        };
+        var telemetryClient = new TelemetryClient(telemetryConfiguration);
+        var options = Substitute.For<IOptions<TelemetryConfiguration>>();
+        var publisher = Substitute.ForPartsOf<ApplicationInsightsPublisher>(options, "ConnectionString", true, false, true);
+        publisher.When(svc => svc.GetOrCreateTelemetryClient()).DoNotCallBase();
+        publisher.GetOrCreateTelemetryClient().Returns(telemetryClient);
+        var reportEntry1 = new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.FromSeconds(2), null, new Dictionary<string, object>() );
+        var report = new HealthReport(new Dictionary<string, HealthReportEntry> { { "reportEntry1", reportEntry1 } }, TimeSpan.FromSeconds(5));
+
+        await publisher.PublishAsync(report, CancellationToken.None);
+
+        telemetryChannel
+            .Received()
+            .Send( Arg.Is<ITelemetry>(i => i is AvailabilityTelemetry &&
+                                           (i as AvailabilityTelemetry)!.Duration == reportEntry1.Duration &&
+                                           (i as AvailabilityTelemetry)!.RunLocation == Environment.MachineName &&
+                                           (i as AvailabilityTelemetry)!.Success &&
+                                           (i as AvailabilityTelemetry)!.Message == null &&
+                                           (i as AvailabilityTelemetry)!.Properties.Count == 2
+            ));
+    }
+
+    [Fact]
+    public async Task send_eventTelemetry_when_trackAsAvailability_is_false_and_detailedReport_is_true()
+    {
+        var telemetryChannel = Substitute.For<ITelemetryChannel>();
+        var telemetryConfiguration = new TelemetryConfiguration
+        {
+            TelemetryChannel = telemetryChannel,
+            DisableTelemetry = false
+        };
+        var telemetryClient = new TelemetryClient(telemetryConfiguration);
+        var options = Substitute.For<IOptions<TelemetryConfiguration>>();
+        var publisher = Substitute.ForPartsOf<ApplicationInsightsPublisher>(options, "ConnectionString", true, false, false);
+        publisher.When(svc => svc.GetOrCreateTelemetryClient()).DoNotCallBase();
+        publisher.GetOrCreateTelemetryClient().Returns(telemetryClient);
+        var reportEntry1 = new HealthReportEntry(HealthStatus.Healthy, null, TimeSpan.FromSeconds(2), null, new Dictionary<string, object>() );
+        var report = new HealthReport(new Dictionary<string, HealthReportEntry> { { "reportEntry1", reportEntry1 } }, TimeSpan.FromSeconds(5));
+
+        await publisher.PublishAsync(report, CancellationToken.None);
+
+        telemetryChannel
+            .Received()
+            .Send( Arg.Is<ITelemetry>(i => i is EventTelemetry &&
+                                           (i as EventTelemetry)!.Properties.Count == 2 &&
+                                           (i as EventTelemetry)!.Metrics.Count == 2
+            ));
     }
 }

--- a/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
+++ b/test/HealthChecks.Publisher.ApplicationInsights.Tests/HealthChecks.Publisher.ApplicationInsights.approved.txt
@@ -2,6 +2,6 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ApplicationInsightsHealthCheckBuilderExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddApplicationInsightsPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string? connectionString = null, bool saveDetailedReport = false, bool excludeHealthyReports = false) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddApplicationInsightsPublisher(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, string? connectionString = null, bool saveDetailedReport = false, bool excludeHealthyReports = false, bool trackAsAvailability = false) { }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Provide an option to publish healthCheck metrics through the `TelemetryClient.TrackAvailability()` method.

With this approach, healthCheck metrics are stored within the "AvailabilityResults" table in application insights.
In addition, a CUSTOM web-test will automatically be created in Azure Application Insights which allows to monitor your application easily.

For more details, please have a look at the official documentation: https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability?tabs=track#create-an-availability-test

**Which issue(s) this PR fixes**:

#2373

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The change does not include breaking-changes. The configuration is designed as optional opt-in.


Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
