### PR TITLE
feat: added an overload for the AddS3 extension method to take the IS…

### DIFF
--- a/src/HealthChecks.Aws.S3/DependencyInjection/S3HealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Aws.S3/DependencyInjection/S3HealthCheckBuilderExtensions.cs
@@ -41,4 +41,40 @@ public static class S3HealthCheckBuilderExtensions
             tags,
             timeout));
     }
+
+    /// <summary>
+    /// Add a health check for AWS S3, passing in the IServiceProvider.
+    /// The overload makes it easier to pull configuration from appsettings.json or environment variables as you can now call GetRequiredService in the passed in Action
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="setup">The action to configure the S3 Configuration e.g. bucket, region etc.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'aws s3' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddS3(
+        this IHealthChecksBuilder builder,
+        Action<IServiceProvider, S3BucketOptions>? setup,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name ?? NAME + " with sp",
+            sp =>
+            {
+                var options = new S3BucketOptions();
+                setup?.Invoke(sp, options);
+
+                return new S3HealthCheck(options);
+            },
+            failureStatus,
+            tags,
+            timeout));
+    }
 }

--- a/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Aws.S3.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,4 +1,5 @@
 using Amazon.S3;
+using Amazon.Util;
 
 namespace HealthChecks.Aws.S3.Tests.DependencyInjection;
 
@@ -87,4 +88,99 @@ public class aws_s3_registration_should
         registration.Name.ShouldBe("my-s3-group");
         check.ShouldBeOfType<S3HealthCheck>();
     }
+
+
+    /// <summary>
+    /// Interface representing some potential configuration class to be used by the AddS3 Health Check class.
+    /// </summary>
+    private interface IS3Config
+    {
+        string ServiceUrl { get; set; }
+        string AccessKey { get; set; }
+        string SecretKey { get; set; }
+
+    }
+
+    private class S3Config : IS3Config
+    {
+        public required string ServiceUrl { get; set; }
+        public required string AccessKey { get; set; }
+        public required string SecretKey { get; set; }
+    }
+
+
+    [Fact]
+    public void add_health_check_when_properly_configured_with_serviceprovider()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IS3Config>(p => new S3Config
+        {
+            ServiceUrl = "http://localhost:9000",
+            AccessKey = "access-key",
+            SecretKey = "secret-key"
+        });
+
+        services.AddHealthChecks()
+            .AddS3((sp, options) =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var cfg = sp.GetRequiredService<IS3Config>();
+                options.AccessKey = cfg.AccessKey;
+                options.BucketName = "bucket-name";
+                options.SecretKey = cfg.SecretKey;
+                options.S3Config = new AmazonS3Config
+                {
+                    ServiceURL = cfg.ServiceUrl
+                };
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.ShouldBe("aws s3 with sp");
+        check.ShouldBeOfType<S3HealthCheck>();
+    }
+
+    [Fact]
+    public void add_named_health_check_when_properly_configured_with_serviceprovider()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IS3Config>(p => new S3Config
+        {
+            ServiceUrl = "http://localhost:9000",
+            AccessKey = "access-key",
+            SecretKey = "secret-key"
+        });
+
+        services.AddHealthChecks()
+             .AddS3((sp, options) =>
+             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                 var cfg = sp.GetRequiredService<IS3Config>();
+                 options.AccessKey = cfg.AccessKey;
+                 options.BucketName = "bucket-name";
+                 options.SecretKey = cfg.SecretKey;
+                 options.S3Config = new AmazonS3Config
+                 {
+                     ServiceURL = cfg.ServiceUrl
+                 };
+#pragma warning restore CS0618 // Type or member is obsolete
+             }, name: "aws s3 check");
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+        var registration = options.Value.Registrations.First();
+        var check = registration.Factory(serviceProvider);
+
+        registration.Name.ShouldBe("aws s3 check");
+        check.ShouldBeOfType<S3HealthCheck>();
+    }
+
+
+
 }


### PR DESCRIPTION
feat: added an overload for the AddS3 extension method to take the IServiceProvider

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
Other health checks pass the IServiceProvider into the action/func parameter. This change add that option. I was in a position in my own project where fetching values from my appsettings.json couldn't work easily. The S3 ServiceUrl, access and secret keys needed to passed as well on the options and the only option seemed to be to hard code. Given .NET's HealthCheckRegistration provides the IServiceProvider it made more sense to place the S3HealthCheck instantian in that delegate and pass the SP through to the caller. Adding as an overload prevents old clients from breaking.

**Which issue(s) this PR fixes**:
None, feature only.

Please reference the issue this PR will close: #_[issue number]_

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
As it's an overload, all existing calling code will continue working.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [y] Code compiles correctly
- [y] Created/updated tests
- [y] Unit tests passing
- [x] End-to-end tests passing - I only added an optional extension method and I'm not in a position to do end to end testing on the entire suite of health checks you provide
- [ ] Extended the documentation
- [ ] Provided sample for the feature
