### PR TITLE
Add OpenTelemetry health check publisher

### DIFF
--- a/.github/workflows/healthchecks_publisher_opentelemetry_cd.yml
+++ b/.github/workflows/healthchecks_publisher_opentelemetry_cd.yml
@@ -1,0 +1,16 @@
+name: HealthChecks Publisher.OpenTelemetry CD
+
+on:
+  push:
+    tags:
+      - release-publisher_opentelemetry-*
+      - release-all-*
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable_cd_workflow.yml
+    secrets: inherit
+    with:
+      BUILD_CONFIG: Release
+      PROJECT_PATH: ./src/HealthChecks.Publisher.OpenTelemetry/HealthChecks.Publisher.OpenTelemetry.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.Publisher.OpenTelemetry

--- a/.github/workflows/healthchecks_publisher_opentelemetry_cd_preview.yml
+++ b/.github/workflows/healthchecks_publisher_opentelemetry_cd_preview.yml
@@ -1,0 +1,17 @@
+name: HealthChecks Publisher.OpenTelemetry Preview CD
+
+on:
+  push:
+    tags:
+      - preview-publisher_opentelemetry-*
+      - preview-all-*
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable_cd_preview_workflow.yml
+    secrets: inherit
+    with:
+      BUILD_CONFIG: Release
+      VERSION_SUFFIX_PREFIX: rc1
+      PROJECT_PATH: ./src/HealthChecks.Publisher.OpenTelemetry/HealthChecks.Publisher.OpenTelemetry.csproj
+      PACKAGE_NAME: AspNetCore.HealthChecks.Publisher.OpenTelemetry

--- a/.github/workflows/healthchecks_publisher_opentelemetry_ci.yml
+++ b/.github/workflows/healthchecks_publisher_opentelemetry_ci.yml
@@ -1,0 +1,38 @@
+name: HealthChecks Publisher.OpenTelemetry CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths:
+      - src/HealthChecks.Publisher.OpenTelemetry/**
+      - test/HealthChecks.Publisher.OpenTelemetry.Tests/**
+      - test/_SHARED/**
+      - .github/workflows/healthchecks_publisher_opentelemetry_ci.yml
+      - .github/workflows/reusable_ci_workflow.yml
+      - Directory.Build.props
+      - Directory.Build.targets
+      - Directory.Packages.props
+    tags-ignore:
+      - release-*
+      - preview-*
+
+  pull_request:
+    branches: [ master ]
+    paths:
+      - src/HealthChecks.Publisher.OpenTelemetry/**
+      - test/HealthChecks.Publisher.OpenTelemetry.Tests/**
+      - test/_SHARED/**
+      - .github/workflows/healthchecks_publisher_opentelemetry_ci.yml
+      - .github/workflows/reusable_ci_workflow.yml
+      - Directory.Build.props
+      - Directory.Build.targets
+      - Directory.Packages.props
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable_ci_workflow.yml
+    with:
+      PROJECT_PATH: ./src/HealthChecks.Publisher.OpenTelemetry/HealthChecks.Publisher.OpenTelemetry.csproj
+      TEST_PROJECT_PATH: ./test/HealthChecks.Publisher.OpenTelemetry.Tests/HealthChecks.Publisher.OpenTelemetry.Tests.csproj
+      CODECOV_FLAGS: Publisher.OpenTelemetry

--- a/AspNetCore.Diagnostics.HealthChecks.sln
+++ b/AspNetCore.Diagnostics.HealthChecks.sln
@@ -323,6 +323,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.ClickHouse", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.ClickHouse.Tests", "test\HealthChecks.ClickHouse.Tests\HealthChecks.ClickHouse.Tests.csproj", "{2FB5CB9F-F870-48DE-BD1D-306AE86A67CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.Publisher.OpenTelemetry", "src\HealthChecks.Publisher.OpenTelemetry\HealthChecks.Publisher.OpenTelemetry.csproj", "{1D0251D3-12C0-4347-B537-471AFC7A53E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthChecks.Publisher.OpenTelemetry.Tests", "test\HealthChecks.Publisher.OpenTelemetry.Tests\HealthChecks.Publisher.OpenTelemetry.Tests.csproj", "{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -905,6 +909,14 @@ Global
 		{2FB5CB9F-F870-48DE-BD1D-306AE86A67CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FB5CB9F-F870-48DE-BD1D-306AE86A67CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FB5CB9F-F870-48DE-BD1D-306AE86A67CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D0251D3-12C0-4347-B537-471AFC7A53E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D0251D3-12C0-4347-B537-471AFC7A53E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D0251D3-12C0-4347-B537-471AFC7A53E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D0251D3-12C0-4347-B537-471AFC7A53E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1054,6 +1066,8 @@ Global
 		{44BB97EE-88DB-4C9B-8195-2C6D889AE391} = {FF4414C2-8863-4ADA-8A1D-4B9F25C361FE}
 		{96E2B0A3-02BD-456B-8888-4D96DABA99EB} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
 		{2FB5CB9F-F870-48DE-BD1D-306AE86A67CA} = {FF4414C2-8863-4ADA-8A1D-4B9F25C361FE}
+		{1D0251D3-12C0-4347-B537-471AFC7A53E0} = {2A3FD988-2BB8-43CF-B3A2-B70E648259D4}
+		{3FBA06CE-2AF9-4B98-8FDF-65969AF96BF6} = {FF4414C2-8863-4ADA-8A1D-4B9F25C361FE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2B8C62A1-11B6-469F-874C-A02443256568}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,8 @@
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="2.19.190" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.120" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />

--- a/src/HealthChecks.Publisher.OpenTelemetry/DependencyInjection/OpenTelemetryHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.Publisher.OpenTelemetry/DependencyInjection/OpenTelemetryHealthCheckBuilderExtensions.cs
@@ -1,0 +1,14 @@
+using HealthChecks.Publisher.OpenTelemetry;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class OpenTelemetryHealthCheckBuilderExtensions
+{
+    public static IHealthChecksBuilder AddOpenTelemetryPublisher(this IHealthChecksBuilder builder)
+    {
+        builder.Services.AddSingleton<IHealthCheckPublisher, OpenTelemetryPublisher>();
+        builder.Services.AddOpenTelemetry().WithMetrics(x => x.AddMeter(OpenTelemetryPublisher.METER_NAME));
+        return builder;
+    }
+}

--- a/src/HealthChecks.Publisher.OpenTelemetry/HealthChecks.Publisher.OpenTelemetry.csproj
+++ b/src/HealthChecks.Publisher.OpenTelemetry/HealthChecks.Publisher.OpenTelemetry.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    </ItemGroup>
+
+</Project>

--- a/src/HealthChecks.Publisher.OpenTelemetry/OpenTelemetryPublisher.cs
+++ b/src/HealthChecks.Publisher.OpenTelemetry/OpenTelemetryPublisher.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecks.Publisher.OpenTelemetry;
+
+public sealed class OpenTelemetryPublisher : IHealthCheckPublisher
+{
+    internal const string METER_NAME = "Microsoft.AspNetCore.Diagnostics.HealthChecks";
+
+    private const string HEALTH_CHECK_NAME = "health_check.name";
+
+    private const string HEALTH_CHECK_STATUS_NAME = "health_check.status";
+    private const string HEALTH_CHECK_STATUS_DESCRIPTION = "ASP.NET Core health check status (0 == Unhealthy, 0.5 == Degraded, 1 == Healthy)";
+
+    private const string HEALTH_CHECK_DURATION_NAME = "health_check.duration";
+    private const string HEALTH_CHECK_DURATION_DESCRIPTION = "Shows duration of the health check execution in seconds";
+
+    private HealthReport? _lastReport;
+
+    public OpenTelemetryPublisher()
+    {
+        var meter = new Meter(METER_NAME);
+
+        meter.CreateObservableGauge(
+            HEALTH_CHECK_STATUS_NAME,
+            ObserveStatus,
+            unit: "status",
+            description: HEALTH_CHECK_STATUS_DESCRIPTION);
+
+        meter.CreateObservableGauge(
+            HEALTH_CHECK_DURATION_NAME,
+            ObserveDuration,
+            unit: "seconds",
+            description: HEALTH_CHECK_DURATION_DESCRIPTION);
+    }
+
+    public Task PublishAsync(
+        HealthReport report,
+        CancellationToken cancellationToken)
+    {
+        _lastReport = report;
+        return Task.CompletedTask;
+    }
+
+    private IEnumerable<Measurement<double>> ObserveStatus()
+    {
+        if (_lastReport is null)
+        {
+            yield break;
+        }
+
+        foreach (var (key, entry) in _lastReport.Entries)
+        {
+            yield return new Measurement<double>(
+                HealthStatusToMetricValue(entry.Status),
+                new KeyValuePair<string, object?>(HEALTH_CHECK_NAME, key));
+        }
+    }
+
+    private IEnumerable<Measurement<double>> ObserveDuration()
+    {
+        if (_lastReport is null)
+        {
+            yield break;
+        }
+
+        foreach (var (key, entry) in _lastReport.Entries)
+        {
+            yield return new Measurement<double>(
+                entry.Duration.TotalSeconds,
+                new KeyValuePair<string, object?>(HEALTH_CHECK_NAME, key));
+        }
+    }
+
+    private static double HealthStatusToMetricValue(HealthStatus status)
+        => status switch
+        {
+            HealthStatus.Unhealthy => 0,
+            HealthStatus.Degraded => 0.5,
+            HealthStatus.Healthy => 1,
+            _ => throw new NotSupportedException($"Unexpected HealthStatus value: {status}"),
+        };
+}

--- a/src/HealthChecks.Publisher.OpenTelemetry/README.md
+++ b/src/HealthChecks.Publisher.OpenTelemetry/README.md
@@ -1,0 +1,51 @@
+## OpenTelemetry HealthCheck Publisher
+
+This publisher sends health reports as OpenTelemetry metrics.
+
+Every time the OpenTelemetry exporter sends a batch, it reads the latest available health report and emits each health check as two gauge instruments, `health_check.status` and `health_check.duration`.
+
+- `health_check.status` – Represents the health status. It is mapped in the following way:
+
+    | HealthStatus | Value |
+    |--------------|-------|
+    | Healthy      | 1     |
+    | Degraded     | 0.5   |
+    | Unhealthy    | 0     |
+
+
+- `health_check.duration` - The time (in seconds) it took to run the health check.
+
+Each metric includes the following tag:
+- `health_check.name` - The distinct name of the health check.
+
+### Note
+The batching interval is controlled by the `OTEL_METRIC_EXPORT_INTERVAL` environment variable. It defaults to 60000 (60 seconds).
+
+OpenTelemetry exporters must be configured separately.
+
+## Usage
+
+To enable OpenTelemetry publishing for health checks, call the provided extension method:
+```
+IHealthChecksBuilder AddOpenTelemetryPublisher(this IHealthChecksBuilder builder)
+```
+
+This method also configures instrumentation for the `Microsoft.AspNetCore.Diagnostics.HealthChecks` Meter.
+
+### Example
+
+```csharp
+public void ConfigureHealthChecks(IServiceCollection services) 
+{
+    services.Configure<HealthCheckPublisherOptions>(options =>
+    {
+        options.Delay = TimeSpan.FromSeconds(5);
+        options.Period = TimeSpan.FromSeconds(30);
+    });
+
+    services
+        .AddHealthChecks()
+        .AddOpenTelemetryPublisher();
+}
+```
+

--- a/test/HealthChecks.Publisher.OpenTelemetry.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.Publisher.OpenTelemetry.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,0 +1,18 @@
+namespace HealthChecks.Publisher.OpenTelemetry.Tests.DependencyInjection;
+
+public class open_telemetry_publisher_registration_should
+{
+    [Fact]
+    public void add_healthcheck_when_properly_configured()
+    {
+        var services = new ServiceCollection()
+            .AddHealthChecks()
+            .AddOpenTelemetryPublisher()
+            .Services;
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var publisher = serviceProvider.GetService<IHealthCheckPublisher>();
+
+        publisher.ShouldNotBeNull();
+    }
+}

--- a/test/HealthChecks.Publisher.OpenTelemetry.Tests/Functional/OpenTelemetryPublisherTests.cs
+++ b/test/HealthChecks.Publisher.OpenTelemetry.Tests/Functional/OpenTelemetryPublisherTests.cs
@@ -1,0 +1,94 @@
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace HealthChecks.Publisher.OpenTelemetry.Tests.Functional;
+
+public class open_telemetry_publisher_should
+{
+    [Theory]
+    [InlineData(HealthStatus.Healthy, 1)]
+    [InlineData(HealthStatus.Degraded, 0.5)]
+    [InlineData(HealthStatus.Unhealthy, 0)]
+    public void publish_report_as_metrics(HealthStatus healthStatus, double metricValue)
+    {
+        // Arrange
+        const string meterName = "Microsoft.AspNetCore.Diagnostics.HealthChecks";
+        const string nameTagKey = "health_check.name";
+        const string statusMetricName = "health_check.status";
+        const string durationMetricName = "health_check.duration";
+        const string healthCheckName = "unit_test";
+
+        var exportedItems = new List<Metric>();
+
+        var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddInMemoryExporter(exportedItems)
+            .AddMeter(meterName)
+            .Build();
+
+        var duration = TimeSpan.FromSeconds(9.5);
+
+        var healthCheck = new HealthReportEntry(
+            healthStatus,
+            description: null,
+            duration: duration,
+            exception: null,
+            data: null);
+
+        var healthChecks = new Dictionary<string, HealthReportEntry> { { healthCheckName, healthCheck } };
+
+        var sut = new OpenTelemetryPublisher();
+
+        // Act
+        sut.PublishAsync(new HealthReport(healthChecks, duration), CancellationToken.None);
+
+        // Assert
+        meterProvider.ForceFlush();
+        exportedItems.Count.ShouldBe(2);
+        exportedItems.ShouldAllBe(x => x.MeterName == meterName);
+
+        var statusMetric = exportedItems.Find(x => x.Name == statusMetricName);
+        statusMetric.ShouldNotBeNull();
+
+        var statusPoint = GetFirstMetricPoint(statusMetric.GetMetricPoints());
+        statusPoint.ShouldNotBeNull();
+        statusPoint.Value.GetGaugeLastValueDouble().ShouldBe(metricValue);
+
+        string? statusNameTag = GetTagByKey(statusPoint.Value, nameTagKey);
+        statusNameTag.ShouldNotBeNull();
+        statusNameTag.ShouldBe(healthCheckName);
+
+        var durationMetric = exportedItems.Find(x => x.Name == durationMetricName);
+        durationMetric.ShouldNotBeNull();
+
+        var durationPoint = GetFirstMetricPoint(durationMetric.GetMetricPoints());
+        durationPoint.ShouldNotBeNull();
+        durationPoint.Value.GetGaugeLastValueDouble().ShouldBe(duration.TotalSeconds);
+
+        string? durationNameTag = GetTagByKey(durationPoint.Value, nameTagKey);
+        durationNameTag.ShouldNotBeNull();
+        durationNameTag.ShouldBe(healthCheckName);
+    }
+
+    private static MetricPoint? GetFirstMetricPoint(MetricPointsAccessor accessor)
+    {
+        foreach (var metricPoint in accessor)
+        {
+            return metricPoint;
+        }
+
+        return null;
+    }
+
+    private static string? GetTagByKey(MetricPoint metricPoint, string key)
+    {
+        foreach (var tag in metricPoint.Tags)
+        {
+            if (tag.Key == key)
+            {
+                return tag.Value?.ToString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/test/HealthChecks.Publisher.OpenTelemetry.Tests/HealthChecks.Publisher.OpenTelemetry.Tests.csproj
+++ b/test/HealthChecks.Publisher.OpenTelemetry.Tests/HealthChecks.Publisher.OpenTelemetry.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\HealthChecks.Publisher.OpenTelemetry\HealthChecks.Publisher.OpenTelemetry.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a generic OpenTelemetry health check publisher that can be used for backends like for Aspire and Azure Monitor.

**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #2254 #2025

**Special notes for your reviewer**:
[OpenTelemetry guidelines](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/README.md#extension-method-reference) advices that we should create extension methods on `MeterProviderBuilder`, instead of calling `services.AddOpenTelemetry().WithMetrics(x => ...)` from a library.

While I believe this is correct 99% of the time, this would require clients of this package to first add the `OpenTelemetryPublisher` on the `IHealthCheckBuilder` and then also manually add the `Meter` with name `"Microsoft.AspNetCore.Diagnostics.HealthChecks"` in their `MeterProviderBuilder`. Forget one of the two and it will not publish anything.
The client has already consented to using OpenTelemetry by calling  our  `healthCheckBuilder.AddOpenTelemetryPublisher()`, so I think it is beneficial to register the Meter for them immediately.
Multiple calls to `services.AddOpenTelemetry()` will not result in multiple providers. Only a single MeterProvider will be created in the target, so no harm will be done.

Also a note on the unit tests:
Unit testing with the internals of OpenTelemetry is very hard and cumbersome.
I currently can not think of a way to make the functional test shorter.
I also wish I could assert that the Meter was added in `OpenTelemetryBuilder.WithMetrics(x => ...)`, in the extension method, but I could not find any way of doing so.

I'm open for feedback and debate on any subject of thir PR. Please let me know what you think.

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [x] Provided sample for the feature
