### PR TITLE
fix: remove manual connect to SurrealDB instance on checkl

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,7 +95,7 @@
     <PackageVersion Include="SolrNet.Core" Version="1.1.1" />
     <PackageVersion Include="SSH.NET" Version="2023.0.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.4" />
-    <PackageVersion Include="SurrealDb.Net" Version="0.7.0" />
+    <PackageVersion Include="SurrealDb.Net" Version="0.9.0" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="8.0.0" />

--- a/src/HealthChecks.SurrealDb/SurrealDbHealthCheck.cs
+++ b/src/HealthChecks.SurrealDb/SurrealDbHealthCheck.cs
@@ -20,8 +20,6 @@ public class SurrealDbHealthCheck : IHealthCheck
     {
         try
         {
-            await _client.Connect(cancellationToken).ConfigureAwait(false);
-
             return await _client.Health(cancellationToken).ConfigureAwait(false)
                 ? HealthCheckResult.Healthy()
                 : HealthCheckResult.Unhealthy();


### PR DESCRIPTION
There is an issue with the current implementation of the `SurrealDB` healthcheck: calling `Connect` when already connected throws an exception.

Since connection and reconnection are handled internally in the library, there is no need to call the method manually. It will also be called internally within `Health` if the client is not connected.