### PR TITLE
Make Microsoft.EntityFrameworkCore.Design a design-time dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />

--- a/src/HealthChecks.UI/HealthChecks.UI.csproj
+++ b/src/HealthChecks.UI/HealthChecks.UI.csproj
@@ -18,8 +18,12 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="KubernetesClient" />
   </ItemGroup>
 

--- a/test/HealthChecks.UI.Data.Tests/HealthChecksDbTests.cs
+++ b/test/HealthChecks.UI.Data.Tests/HealthChecksDbTests.cs
@@ -8,7 +8,7 @@ public class HealthChecksDbTests
     public async Task HealthChecksDb_Primitive_Test()
     {
         var services = new ServiceCollection();
-        services.AddDbContext<HealthChecksDb>(b => b.UseInMemoryDatabase(""));
+        services.AddDbContext<HealthChecksDb>(b => b.UseInMemoryDatabase("HealthChecksUI"));
         using var provider = services.BuildServiceProvider();
         var db = provider.GetRequiredService<HealthChecksDb>();
         (await db.Configurations.ToListAsync()).Count.ShouldBe(0);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: 
* Scope `Microsoft.EntityFrameworkCore.Design` to design time so `Microsoft.CodeAnalysis.*` packages aren't included as dependencies for NuGet package
* Explicitly add `Microsoft.EntityFrameworkCore.Relational` to support migrations at runtime
* Fix `HealthChecksDbTests.HealthChecksDb_Primitive_Test`

**Which issue(s) this PR fixes**: #2382 

Please reference the issue this PR will close: #2382

**Special notes for your reviewer**: Tested by adding Furion.Pure to `HealthChecks.UI.StorageProviders` with PostgreSQL and SQLite storage providers

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
