### PR TITLE
Migrate HealthChecks.Kubernetes tests to Testcontainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -104,6 +104,7 @@
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.ClickHouse" Version="$(TestcontainersVersion)" />
+    <PackageVersion Include="Testcontainers.K3s" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.Kafka" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.Milvus" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="$(TestcontainersVersion)" />

--- a/test/HealthChecks.Kubernetes.Tests/HealthChecks.Kubernetes.Tests.csproj
+++ b/test/HealthChecks.Kubernetes.Tests/HealthChecks.Kubernetes.Tests.csproj
@@ -4,4 +4,8 @@
     <ProjectReference Include="..\..\src\HealthChecks.Kubernetes\HealthChecks.Kubernetes.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Testcontainers.K3s" />
+  </ItemGroup>
+
 </Project>

--- a/test/HealthChecks.Kubernetes.Tests/K3sContainerFixture.cs
+++ b/test/HealthChecks.Kubernetes.Tests/K3sContainerFixture.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using k8s;
+using Testcontainers.K3s;
+
+namespace HealthChecks.Kubernetes.Tests;
+
+public class K3sContainerFixture : IAsyncLifetime
+{
+    private const string Registry = "docker.io";
+
+    private const string Image = "rancher/k3s";
+
+    private const string Tag = "v1.26.2-k3s1";
+
+    public K3sContainer? Container { get; private set; }
+
+    public async Task<KubernetesClientConfiguration> GetKubeconfigAsync()
+    {
+        if (Container is null)
+        {
+            throw new InvalidOperationException("The test container was not initialized.");
+        }
+
+        string? kubeconfig = await Container.GetKubeconfigAsync();
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(kubeconfig));
+
+        return await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(stream);
+    }
+
+    public async Task InitializeAsync() => Container = await CreateContainerAsync();
+
+    public Task DisposeAsync() => Container?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    private static async Task<K3sContainer> CreateContainerAsync()
+    {
+        var container = new K3sBuilder()
+            .WithImage($"{Registry}/{Image}:{Tag}")
+            .Build();
+
+        await container.StartAsync();
+
+        return container;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: 
* Add Testcontainers fixture to HealthChecks.Kubernetes tests
* Implement `kubernetes_healthcheck_should.be_healthy_if_kubernetes_is_available` test

**Which issue(s) this PR fixes**: Contributes to #2335 

Please reference the issue this PR will close:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
