### PR TITLE
Migrate HealthChecks.UI tests to Testcontainers

### DIFF
--- a/.github/workflows/healthchecks_ui_ci.yml
+++ b/.github/workflows/healthchecks_ui_ci.yml
@@ -36,27 +36,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server
-        ports:
-          - 5433:1433
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: Password12!
-      npgsql:
-        image: postgres
-        ports:
-          - 8010:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: Password12!
-      mysql:
-        image: mysql
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: Password12!
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET

--- a/test/HealthChecks.UI.Tests/Fixtures/MySqlContainerFixture.cs
+++ b/test/HealthChecks.UI.Tests/Fixtures/MySqlContainerFixture.cs
@@ -1,0 +1,39 @@
+using Testcontainers.MySql;
+
+namespace HealthChecks.UI.Tests.Fixtures;
+
+public class MySqlContainerFixture : IAsyncLifetime
+{
+    private const string Registry = "docker.io";
+
+    private const string Image = "library/mysql";
+
+    private const string Tag = "9.4.0";
+
+    public MySqlContainer? Container { get; private set; }
+
+    public string GetConnectionString()
+    {
+        if (Container is null)
+        {
+            throw new InvalidOperationException("The test container was not initialized.");
+        }
+
+        return Container.GetConnectionString();
+    }
+
+    public async Task InitializeAsync() => Container = await CreateContainerAsync();
+
+    public Task DisposeAsync() => Container?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    private static async Task<MySqlContainer> CreateContainerAsync()
+    {
+        var container = new MySqlBuilder()
+            .WithImage($"{Registry}/{Image}:{Tag}")
+            .Build();
+
+        await container.StartAsync();
+
+        return container;
+    }
+}

--- a/test/HealthChecks.UI.Tests/Fixtures/PostgreSqlContainerFixture.cs
+++ b/test/HealthChecks.UI.Tests/Fixtures/PostgreSqlContainerFixture.cs
@@ -1,0 +1,39 @@
+using Testcontainers.PostgreSql;
+
+namespace HealthChecks.UI.Tests.Fixtures;
+
+public class PostgreSqlContainerFixture : IAsyncLifetime
+{
+    private const string Registry = "docker.io";
+
+    private const string Image = "library/postgres";
+
+    private const string Tag = "17.6-alpine3.22";
+
+    public PostgreSqlContainer? Container { get; private set; }
+
+    public string GetConnectionString()
+    {
+        if (Container is null)
+        {
+            throw new InvalidOperationException("The test container was not initialized.");
+        }
+
+        return Container.GetConnectionString();
+    }
+
+    public async Task InitializeAsync() => Container = await CreateContainerAsync();
+
+    public Task DisposeAsync() => Container?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    private static async Task<PostgreSqlContainer> CreateContainerAsync()
+    {
+        var container = new PostgreSqlBuilder()
+            .WithImage($"{Registry}/{Image}:{Tag}")
+            .Build();
+
+        await container.StartAsync();
+
+        return container;
+    }
+}

--- a/test/HealthChecks.UI.Tests/Fixtures/SqlServerContainerFixture.cs
+++ b/test/HealthChecks.UI.Tests/Fixtures/SqlServerContainerFixture.cs
@@ -1,0 +1,39 @@
+using Testcontainers.MsSql;
+
+namespace HealthChecks.UI.Tests.Fixtures;
+
+public class SqlServerContainerFixture : IAsyncLifetime
+{
+    private const string Registry = "mcr.microsoft.com";
+
+    private const string Image = "mssql/server";
+
+    private const string Tag = "2022-CU20-GDR1-ubuntu-22.04";
+
+    public MsSqlContainer? Container { get; private set; }
+
+    public string GetConnectionString()
+    {
+        if (Container is null)
+        {
+            throw new InvalidOperationException("The test container was not initialized.");
+        }
+
+        return Container.GetConnectionString();
+    }
+
+    public async Task InitializeAsync() => Container = await CreateContainerAsync();
+
+    public Task DisposeAsync() => Container?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    private static async Task<MsSqlContainer> CreateContainerAsync()
+    {
+        var container = new MsSqlBuilder()
+            .WithImage($"{Registry}/{Image}:{Tag}")
+            .Build();
+
+        await container.StartAsync();
+
+        return container;
+    }
+}

--- a/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
@@ -80,7 +80,7 @@ public class UI_configuration_should
         return Task.CompletedTask;
     }
 
-    [Fact(Skip = "Temporarily skipping in https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/pull/1807")]
+    [Fact]
     public Task configure_webhooks_endpoint_custom_delegating_handlers()
     {
         var hostReset = new ManualResetEventSlim(false);

--- a/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/Configuration/UIHttpMessageHandlerTests.cs
@@ -101,7 +101,7 @@ public class UI_configuration_should
                     setup.UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler>();
                     setup.UseWebHooksEndpointDelegatingHandler<CustomDelegatingHandler2>();
 
-                }).AddInMemoryStorage();
+                }).AddInMemoryStorage(databaseName: Guid.NewGuid().ToString());
             })
             .Configure(app =>
             {

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/DockerImageStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/DockerImageStorageProviderTests.cs
@@ -1,6 +1,7 @@
 using HealthChecks.UI.Data;
 using HealthChecks.UI.Image;
 using HealthChecks.UI.Image.Configuration;
+using HealthChecks.UI.Tests.Fixtures;
 using Microsoft.Extensions.Configuration;
 
 namespace HealthChecks.UI.Tests;
@@ -11,7 +12,6 @@ public class docker_image_storage_provider_configuration_should
     private const string SqliteProviderName = "Microsoft.EntityFrameworkCore.Sqlite";
     private const string PostgreProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
     private const string InMemoryProviderName = "Microsoft.EntityFrameworkCore.InMemory";
-    private const string MySqlProviderName = "Pomelo.EntityFrameworkCore.MySql";
 
     [Fact]
     public void fail_with_invalid_storage_provider_value()
@@ -183,11 +183,16 @@ public class docker_image_storage_provider_configuration_should
         var context = host.Services.GetRequiredService<HealthChecksDb>();
         context.Database.ProviderName.ShouldBe(InMemoryProviderName);
     }
+}
+
+[Collection("execution")]
+public class docker_image_storage_provider_mysql_configuration_should(MySqlContainerFixture mySqlFixture) : IClassFixture<MySqlContainerFixture>
+{
+    private const string MySqlProviderName = "Pomelo.EntityFrameworkCore.MySql";
 
     [Fact]
     public void register_mysql()
     {
-        //
         var hostBuilder = new WebHostBuilder()
             .ConfigureAppConfiguration(config =>
             {
@@ -196,8 +201,7 @@ public class docker_image_storage_provider_configuration_should
                 config.AddInMemoryCollection(new List<KeyValuePair<string, string?>>
                 {
                     new KeyValuePair<string, string?>("storage_provider", StorageProviderEnum.MySql.ToString()),
-                    new KeyValuePair<string, string?>("storage_connection", "Host=localhost;User Id=root;Password=Password12!;Database=UI"),
-
+                    new KeyValuePair<string, string?>("storage_connection", mySqlFixture.GetConnectionString()),
                 });
             })
             .UseStartup<Startup>();
@@ -225,5 +229,4 @@ public class docker_image_storage_provider_configuration_should
 
         Should.Throw<ArgumentNullException>(() => hostBuilder.Build());
     }
-
 }

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/InMemoryStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/InMemoryStorageProviderTests.cs
@@ -29,7 +29,7 @@ public class inmemory_storage_should
         customOptionsInvoked.ShouldBeTrue();
     }
 
-    [Fact(Skip = "conflicts with other tests that use inmemory storage too")]
+    [Fact]
     public async Task seed_database_and_serve_stored_executions()
     {
         var hostReset = new ManualResetEventSlim(false);
@@ -38,7 +38,7 @@ public class inmemory_storage_should
         var webHostBuilder = HostBuilderHelper.Create(
                hostReset,
                collectorReset,
-               configureUI: config => config.AddInMemoryStorage());
+               configureUI: config => config.AddInMemoryStorage(databaseName: Guid.NewGuid().ToString()));
 
         using var host = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/MySqlStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/MySqlStorageProviderTests.cs
@@ -1,9 +1,6 @@
 using HealthChecks.UI.Data;
-using HealthChecks.UI.Image;
-using HealthChecks.UI.Image.Configuration;
 using HealthChecks.UI.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 
 namespace HealthChecks.UI.Tests;
 

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/MySqlStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/MySqlStorageProviderTests.cs
@@ -1,9 +1,14 @@
 using HealthChecks.UI.Data;
+using HealthChecks.UI.Image;
+using HealthChecks.UI.Image.Configuration;
+using HealthChecks.UI.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace HealthChecks.UI.Tests;
 
-public class mysql_storage_should
+[Collection("execution")]
+public class mysql_storage_should(MySqlContainerFixture mySqlFixture) : IClassFixture<MySqlContainerFixture>
 {
     private const string PROVIDER_NAME = "Pomelo.EntityFrameworkCore.MySql";
 
@@ -17,7 +22,7 @@ public class mysql_storage_should
             .ConfigureServices(services =>
             {
                 services.AddHealthChecksUI()
-                .AddMySqlStorage("Host=localhost;User Id=root;Password=Password12!;Database=UI", options => customOptionsInvoked = true);
+                .AddMySqlStorage(mySqlFixture.GetConnectionString(), options => customOptionsInvoked = true);
             });
 
         var services = hostBuilder.Build().Services;
@@ -38,7 +43,7 @@ public class mysql_storage_should
         var webHostBuilder = HostBuilderHelper.Create(
                hostReset,
                collectorReset,
-               configureUI: config => config.AddMySqlStorage(ProviderTestHelper.MySqlConnectionString()));
+               configureUI: config => config.AddMySqlStorage(mySqlFixture.GetConnectionString()));
 
         using var host = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/PostgreSqlStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/PostgreSqlStorageProviderTests.cs
@@ -1,10 +1,11 @@
 using HealthChecks.UI.Data;
+using HealthChecks.UI.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 
 namespace HealthChecks.UI.Tests;
 
 [Collection("execution")]
-public class postgre_storage_should
+public class postgre_storage_should(PostgreSqlContainerFixture postgreSqlFixture) : IClassFixture<PostgreSqlContainerFixture>
 {
     private const string ProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
 
@@ -18,7 +19,7 @@ public class postgre_storage_should
             .ConfigureServices(services =>
             {
                 services.AddHealthChecksUI()
-                .AddPostgreSqlStorage("connectionString", options => customOptionsInvoked = true);
+                .AddPostgreSqlStorage(postgreSqlFixture.GetConnectionString(), _ => customOptionsInvoked = true);
             });
 
         var services = hostBuilder.Build().Services;
@@ -39,7 +40,7 @@ public class postgre_storage_should
         var webHostBuilder = HostBuilderHelper.Create(
                hostReset,
                collectorReset,
-               configureUI: config => config.AddPostgreSqlStorage(ProviderTestHelper.PostgresConnectionString()));
+               configureUI: config => config.AddPostgreSqlStorage(postgreSqlFixture.GetConnectionString()));
 
         using var host = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/SqlServerStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/SqlServerStorageProviderTests.cs
@@ -1,9 +1,10 @@
 using HealthChecks.UI.Data;
+using HealthChecks.UI.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 
 namespace HealthChecks.UI.Tests;
 
-public class sqlserver_storage_should
+public class sqlserver_storage_should(SqlServerContainerFixture sqlServerFixture) : IClassFixture<SqlServerContainerFixture>
 {
     private const string ProviderName = "Microsoft.EntityFrameworkCore.SqlServer";
 
@@ -17,7 +18,7 @@ public class sqlserver_storage_should
             .ConfigureServices(services =>
             {
                 services.AddHealthChecksUI()
-                .AddSqlServerStorage("connectionString", opt => customOptionsInvoked = true);
+                .AddSqlServerStorage(sqlServerFixture.GetConnectionString(), opt => customOptionsInvoked = true);
             });
 
         var services = hostBuilder.Build().Services;
@@ -38,7 +39,7 @@ public class sqlserver_storage_should
         var webHostBuilder = HostBuilderHelper.Create(
                hostReset,
                collectorReset,
-               configureUI: config => config.AddSqlServerStorage(ProviderTestHelper.SqlServerConnectionString()));
+               configureUI: config => config.AddSqlServerStorage(sqlServerFixture.GetConnectionString()));
 
         using var host = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/SqliteStorageProviderTests.cs
+++ b/test/HealthChecks.UI.Tests/Functional/DatabaseProviders/SqliteStorageProviderTests.cs
@@ -38,7 +38,7 @@ public class sqlite_storage_should
         var webHostBuilder = HostBuilderHelper.Create(
                hostReset,
                collectorReset,
-               configureUI: setup => setup.AddSqliteStorage(ProviderTestHelper.SqliteConnectionString()));
+               configureUI: setup => setup.AddSqliteStorage("Data Source = sqlite.db"));
 
         using var host = new TestServer(webHostBuilder);
 

--- a/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
+++ b/test/HealthChecks.UI.Tests/HealthChecks.UI.Tests.csproj
@@ -28,4 +28,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="Testcontainers.MySql" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+  </ItemGroup>
+
 </Project>

--- a/test/HealthChecks.UI.Tests/Seedwork/ProviderTestHelper.cs
+++ b/test/HealthChecks.UI.Tests/Seedwork/ProviderTestHelper.cs
@@ -10,9 +10,4 @@ public class ProviderTestHelper
         ("host1", "http://localhost/health"),
         ("host2", "http://localhost/health")
     };
-
-    public static string SqlServerConnectionString() => "Server=tcp:localhost,5433;Initial Catalog=master;User Id=sa;Password=Password12!;TrustServerCertificate=true";
-    public static string PostgresConnectionString() => "Server=127.0.0.1;Port=8010;User ID=postgres;Password=Password12!;database=ui";
-    public static string MySqlConnectionString() => "Host=localhost;User Id=root;Password=Password12!;Database=UI";
-    public static string SqliteConnectionString() => "Data Source = sqlite.db";
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**: 
* Add Testcontainers fixtures to HealthChecks.UI tests
* Unskip `inmemory_storage_should.seed_database_and_serve_stored_executions`
* Move MySQL tests from `docker_image_storage_provider_configuration_should` into a separate test class, as they require a running database

**Which issue(s) this PR fixes**: Contributes to #2335 

Please reference the issue this PR will close:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
