### PR TITLE
Add ServiceURL support for AWS SQS health check

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,7 +105,7 @@
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.ClickHouse" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.Kafka" Version="$(TestcontainersVersion)" />
-    <PackageVersion Include="Testcontainers.LocalStack" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.Milvus" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="TestContainers.MongoDb" Version="$(TestcontainersVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,6 +105,7 @@
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.ClickHouse" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.Kafka" Version="$(TestcontainersVersion)" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="4.1.0" />
     <PackageVersion Include="Testcontainers.Milvus" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="$(TestcontainersVersion)" />
     <PackageVersion Include="TestContainers.MongoDb" Version="$(TestcontainersVersion)" />

--- a/src/HealthChecks.Aws.Sqs/README.md
+++ b/src/HealthChecks.Aws.Sqs/README.md
@@ -13,7 +13,7 @@ With all of the following examples, you can additionally add the following param
 
 ### Basic
 
-### Check existence of a queue and load credentials from the application's default configuration
+### Check the existence of a queue and load credentials from the application's default configuration
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -27,7 +27,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-### Check existence of a queue and directly pass credentials
+### Check the existence of a queue and directly pass credentials
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -42,7 +42,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-### Check existence of a queue and specify region endpoint
+### Check the existence of a queue and specify region endpoint
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -57,7 +57,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-### Check existence of a queue and specify credentials with region endpoint
+### Check the existence of a queue and specify credentials with region endpoint
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -69,6 +69,21 @@ public void ConfigureServices(IServiceCollection services)
             options.AddQueue("queueName");
             options.Credentials = new BasicAWSCredentials("access-key", "secret-key");
             options.RegionEndpoint = RegionEndpoint.EUCentral1;
+        });
+}
+```
+
+### Check the existence of a queue and specify service URL
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services
+        .AddHealthChecks()
+        .AddSqs(options =>
+        {
+            options.AddQueue("queueName");
+            options.ServiceURL = "http://localhost:4566";
         });
 }
 ```

--- a/src/HealthChecks.Aws.Sqs/SqsOptions.cs
+++ b/src/HealthChecks.Aws.Sqs/SqsOptions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Amazon;
 using Amazon.Runtime;
 
@@ -8,11 +9,14 @@ namespace HealthChecks.Aws.Sqs;
 /// </summary>
 public class SqsOptions
 {
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public string? ServiceURL { get; set; }
+
     public AWSCredentials? Credentials { get; set; }
 
     public RegionEndpoint? RegionEndpoint { get; set; }
 
-    internal HashSet<string> Queues { get; } = new HashSet<string>();
+    internal HashSet<string> Queues { get; } = [];
 
     /// <summary>
     /// Add an AWS SQS queue to be checked.

--- a/test/HealthChecks.Aws.Sqs.Tests/Functional/SqsHealthCheckTests.cs
+++ b/test/HealthChecks.Aws.Sqs.Tests/Functional/SqsHealthCheckTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using Amazon.Runtime;
+
+namespace HealthChecks.Aws.Sqs.Tests.Functional;
+
+public class aws_sqs_healthcheck_should(LocalStackContainerFixture localStackFixture) : IClassFixture<LocalStackContainerFixture>
+{
+    [Fact]
+    public async Task be_healthy_if_aws_sqs_queue_is_available()
+    {
+        string connectionString = localStackFixture.GetConnectionString();
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddSqs(
+                        options =>
+                        {
+                            options.Credentials = new BasicAWSCredentials("test", "test");
+                            options.ServiceURL = connectionString;
+
+                            options.AddQueue("healthchecks");
+                        },
+                        tags: ["sqs"]);
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("sqs")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task be_healthy_if_aws_sqs_multiple_queues_are_available()
+    {
+        string connectionString = localStackFixture.GetConnectionString();
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddSqs(
+                        options =>
+                        {
+                            options.Credentials = new BasicAWSCredentials("test", "test");
+                            options.ServiceURL = connectionString;
+
+                            options.AddQueue("healthchecks");
+                            options.AddQueue("healthchecks");
+                        },
+                        tags: ["sqs"]);
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("sqs")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task be_unhealthy_if_aws_sqs_is_unavailable()
+    {
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddSqs(
+                        options =>
+                        {
+                            options.Credentials = new BasicAWSCredentials("test", "test");
+                            options.ServiceURL = "invalid";
+
+                            options.AddQueue("healthchecks");
+                        },
+                        tags: ["sqs"]);
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("sqs")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task be_unhealthy_if_aws_sqs_credentials_not_provided()
+    {
+        string connectionString = localStackFixture.GetConnectionString();
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddSqs(
+                        options =>
+                        {
+                            options.ServiceURL = connectionString;
+
+                            options.AddQueue("healthchecks");
+                        },
+                        tags: ["sqs"]);
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("sqs")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task be_unhealthy_if_aws_sqs_queue_does_not_exist()
+    {
+        string connectionString = localStackFixture.GetConnectionString();
+
+        var webHostBuilder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddHealthChecks()
+                    .AddSqs(
+                        options =>
+                        {
+                            options.Credentials = new BasicAWSCredentials("test", "test");
+                            options.ServiceURL = connectionString;
+
+                            options.AddQueue("invalid");
+                        },
+                        tags: ["sqs"]);
+            })
+            .Configure(app =>
+            {
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("sqs")
+                });
+            });
+
+        using var server = new TestServer(webHostBuilder);
+
+        using var response = await server.CreateRequest("/health").GetAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+}

--- a/test/HealthChecks.Aws.Sqs.Tests/HealthChecks.Aws.Sqs.Tests.csproj
+++ b/test/HealthChecks.Aws.Sqs.Tests/HealthChecks.Aws.Sqs.Tests.csproj
@@ -4,4 +4,8 @@
     <ProjectReference Include="..\..\src\HealthChecks.Aws.Sqs\HealthChecks.Aws.Sqs.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Testcontainers.LocalStack" />
+  </ItemGroup>
+
 </Project>

--- a/test/HealthChecks.Aws.Sqs.Tests/HealthChecks.Aws.Sqs.approved.txt
+++ b/test/HealthChecks.Aws.Sqs.Tests/HealthChecks.Aws.Sqs.approved.txt
@@ -10,6 +10,7 @@ namespace HealthChecks.Aws.Sqs
         public SqsOptions() { }
         public Amazon.Runtime.AWSCredentials? Credentials { get; set; }
         public Amazon.RegionEndpoint? RegionEndpoint { get; set; }
+        public string? ServiceURL { get; set; }
         public HealthChecks.Aws.Sqs.SqsOptions AddQueue(string queueName) { }
     }
 }

--- a/test/HealthChecks.Aws.Sqs.Tests/LocalStackContainerFixture.cs
+++ b/test/HealthChecks.Aws.Sqs.Tests/LocalStackContainerFixture.cs
@@ -1,0 +1,44 @@
+using Testcontainers.LocalStack;
+
+namespace HealthChecks.Aws.Sqs.Tests;
+
+public class LocalStackContainerFixture : IAsyncLifetime
+{
+    private const string Registry = "docker.io";
+
+    private const string Image = "localstack/localstack";
+
+    private const string Tag = "4.7.0";
+
+    public LocalStackContainer? Container { get; private set; }
+
+    public string GetConnectionString()
+    {
+        if (Container is null)
+        {
+            throw new InvalidOperationException("The test container was not initialized.");
+        }
+
+        return Container.GetConnectionString();
+    }
+
+    public async Task InitializeAsync()
+    {
+        Container = await CreateContainerAsync();
+
+        await Container.ExecAsync(["awslocal", "sqs", "create-queue", "--queue-name", "healthchecks"]);
+    }
+
+    public Task DisposeAsync() => Container?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    private static async Task<LocalStackContainer> CreateContainerAsync()
+    {
+        var container = new LocalStackBuilder()
+            .WithImage($"{Registry}/{Image}:{Tag}")
+            .Build();
+
+        await container.StartAsync();
+
+        return container;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
* Allow users to set a different Service URL for non-custom setups or testing purposes
* Add functional tests for the AWS SQS health check

**Which issue(s) this PR fixes**: #2179 

Please reference the issue this PR will close: #2179

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: extends `SqsOptions`

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation
- [ ] Provided sample for the feature
