### PR TITLE
Fixes ServiceBus PeekMessageAsync Cancellation Token bug

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusQueueHealthCheck.cs
@@ -43,8 +43,15 @@ public class AzureServiceBusQueueHealthCheck : AzureServiceBusHealthCheck<AzureS
                 _queueKey,
                 _ => client.CreateReceiver(Options.QueueName))
                 .ConfigureAwait(false);
-
-            await receiver.PeekMessageAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var cancel_task = Task.Delay(Timeout.Infinite, cts.Token);
+            var peek_task = receiver.PeekMessageAsync(cancellationToken: cancellationToken);
+            var winner = await Task.WhenAny(peek_task, cancel_task).ConfigureAwait(false);
+            if (winner == peek_task)
+            {
+                cts.Cancel();
+            }
+            await winner.ConfigureAwait(false);
         }
 
         Task CheckWithManagement()

--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusSubscriptionHealthCheck.cs
@@ -45,7 +45,15 @@ public class AzureServiceBusSubscriptionHealthCheck : AzureServiceBusHealthCheck
                 _ => client.CreateReceiver(Options.TopicName, Options.SubscriptionName))
                 .ConfigureAwait(false);
 
-            await receiver.PeekMessageAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var cancel_task = Task.Delay(Timeout.Infinite, cts.Token);
+            var peek_task = receiver.PeekMessageAsync(cancellationToken: cancellationToken);
+            var winner = await Task.WhenAny(peek_task, cancel_task).ConfigureAwait(false);
+            if (winner == peek_task)
+            {
+                cts.Cancel();
+            }
+            await winner.ConfigureAwait(false);
         }
 
         Task CheckWithManagement()

--- a/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusQueueHealthCheckTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusQueueHealthCheckTests.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using HealthChecks.AzureServiceBus.Configuration;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Xunit.Abstractions;
 
 namespace HealthChecks.AzureServiceBus.Tests;
 
@@ -19,8 +21,9 @@ public class azureservicebusqueuehealthcheck_should
     private readonly ServiceBusClientProvider _clientProvider;
     private readonly ServiceBusAdministrationClient _serviceBusAdministrationClient;
     private readonly TokenCredential _tokenCredential;
+    private readonly ITestOutputHelper _output;
 
-    public azureservicebusqueuehealthcheck_should()
+    public azureservicebusqueuehealthcheck_should(ITestOutputHelper output)
     {
         ConnectionString = Guid.NewGuid().ToString();
         FullyQualifiedName = Guid.NewGuid().ToString();
@@ -37,6 +40,7 @@ public class azureservicebusqueuehealthcheck_should
         _clientProvider.CreateManagementClient(ConnectionString).Returns(_serviceBusAdministrationClient);
         _clientProvider.CreateManagementClient(FullyQualifiedName, _tokenCredential).Returns(_serviceBusAdministrationClient);
         _serviceBusClient.CreateReceiver(QueueName).Returns(_serviceBusReceiver);
+        _output = output;
     }
 
     [Theory]
@@ -253,6 +257,38 @@ public class azureservicebusqueuehealthcheck_should
             cancellationToken: tokenSource.Token);
 
         actual.Status.ShouldBe(HealthStatus.Unhealthy);
+
+        _serviceBusClient
+            .Received(1)
+            .CreateReceiver(QueueName);
+
+        await _serviceBusReceiver
+            .Received(1)
+            .PeekMessageAsync(cancellationToken: tokenSource.Token);
+    }
+
+    [Fact]
+    public async Task respect_cancellation_token_when_using_peek()
+    {
+        _serviceBusReceiver
+            .PeekMessageAsync(cancellationToken: default)
+            .ReturnsForAnyArgs(async Task<ServiceBusReceivedMessage> (call_info) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                throw new Exception();
+            });
+
+        using var tokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        var sw = new Stopwatch();
+        sw.Start();
+        var actual = await ExecuteHealthCheckAsync(
+            QueueName,
+            true,
+            connectionString: ConnectionString,
+            cancellationToken: tokenSource.Token);
+        sw.Stop();
+        actual.Status.ShouldBe(HealthStatus.Unhealthy);
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(1));
 
         _serviceBusClient
             .Received(1)

--- a/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusSubscriptionHealthCheckTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusSubscriptionHealthCheckTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -255,6 +256,38 @@ public class azureservicebussubscriptionhealthcheck_should
             cancellationToken: tokenSource.Token);
 
         actual.Status.ShouldBe(HealthStatus.Unhealthy);
+
+        _serviceBusClient
+            .Received(1)
+            .CreateReceiver(TopicName, SubscriptionName);
+
+        await _serviceBusReceiver
+            .Received(1)
+            .PeekMessageAsync(cancellationToken: tokenSource.Token);
+    }
+
+    [Fact]
+    public async Task respect_cancellation_token_when_using_peek()
+    {
+        _serviceBusReceiver
+            .PeekMessageAsync(cancellationToken: default)
+            .ReturnsForAnyArgs(async Task<ServiceBusReceivedMessage> (call_info) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                throw new Exception();
+            });
+
+        using var tokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        var sw = new Stopwatch();
+        sw.Start();
+        var actual = await ExecuteHealthCheckAsync(
+            TopicName,
+            true,
+            connectionString: ConnectionString,
+            cancellationToken: tokenSource.Token);
+        sw.Stop();
+        actual.Status.ShouldBe(HealthStatus.Unhealthy);
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(1));
 
         _serviceBusClient
             .Received(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
ServiceBusReceiver.PeekMessageAsync does not necessarily respect the cancellation token. See https://github.com/Azure/azure-sdk-for-net/issues/52620. This causes the SB Queue and Subscription health checks to not return. In production environments where request timeouts and output cache for health endpoints are vital to avoiding health check cascading and DDOS attacks, this limitation prevents the usual request timeout and output caching patterns in AspNet Core from operating correctly. 
To get around this, this PR fails the health check if the receiver.PeekMessage does not return before the cancellation token is triggered.

**Which issue(s) this PR fixes**:
Please reference the issue this PR will close: #2432

**Does this PR introduce a user-facing change?**: No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly (The Dapr project fails due to deprecated dependency warnings, but that issue is already present in master)
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
