### PR TITLE
Migrate HealthChecks.ClickHouse to use official ClickHouse client library

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.17.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
-    <PackageVersion Include="ClickHouse.Client" Version="7.8.2" />
+    <PackageVersion Include="ClickHouse.Driver" Version="0.7.20" />
     <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Dapr.Client" Version="1.12.0" />

--- a/src/HealthChecks.ClickHouse/ClickHouseHealthCheck.cs
+++ b/src/HealthChecks.ClickHouse/ClickHouseHealthCheck.cs
@@ -1,4 +1,4 @@
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.ClickHouse;

--- a/src/HealthChecks.ClickHouse/DependencyInjection/ClickHouseHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.ClickHouse/DependencyInjection/ClickHouseHealthCheckBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 using HealthChecks.ClickHouse;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 

--- a/src/HealthChecks.ClickHouse/HealthChecks.ClickHouse.csproj
+++ b/src/HealthChecks.ClickHouse/HealthChecks.ClickHouse.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClickHouse.Client" />
+    <PackageReference Include="ClickHouse.Driver" />
   </ItemGroup>
 
 </Project>

--- a/src/HealthChecks.ClickHouse/README.md
+++ b/src/HealthChecks.ClickHouse/README.md
@@ -1,6 +1,6 @@
 ## ClickHouse Health Check
 
-This health check verifies the ability to communicate with [ClickHouse](https://www.clickhouse.com/). It uses the [ClickHouse.Client](https://www.nuget.org/packages/ClickHouse.Client) library.
+This health check verifies the ability to communicate with [ClickHouse](https://www.clickhouse.com/). It uses the official [ClickHouse.Driver](https://www.nuget.org/packages/ClickHouse.Driver) library.
 
 ## Recommended approach
 

--- a/test/HealthChecks.ClickHouse.Tests/DependencyInjection/RegistrationTests.cs
+++ b/test/HealthChecks.ClickHouse.Tests/DependencyInjection/RegistrationTests.cs
@@ -1,4 +1,4 @@
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 
 namespace HealthChecks.ClickHouse.Tests.DependencyInjection;
 

--- a/test/HealthChecks.ClickHouse.Tests/Functional/ClickHouseHealthCheckTests.cs
+++ b/test/HealthChecks.ClickHouse.Tests/Functional/ClickHouseHealthCheckTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 

--- a/test/HealthChecks.ClickHouse.Tests/HealthChecks.ClickHouse.approved.txt
+++ b/test/HealthChecks.ClickHouse.Tests/HealthChecks.ClickHouse.approved.txt
@@ -2,7 +2,7 @@ namespace HealthChecks.ClickHouse
 {
     public class ClickHouseHealthCheck : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck
     {
-        public ClickHouseHealthCheck(ClickHouse.Client.ADO.ClickHouseConnection connection, string command) { }
+        public ClickHouseHealthCheck(ClickHouse.Driver.ADO.ClickHouseConnection connection, string command) { }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
@@ -10,6 +10,6 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ClickHouseHealthCheckBuilderExtensions
     {
-        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddClickHouse(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, ClickHouse.Client.ADO.ClickHouseConnection> connectionFactory, string healthQuery = "SELECT 1;", string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddClickHouse(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Func<System.IServiceProvider, ClickHouse.Driver.ADO.ClickHouseConnection> connectionFactory, string healthQuery = "SELECT 1;", string? name = null, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: The unofficial `ClickHouse.Client` repo was recently archived and migrated to the new official `ClickHouse.Driver` library. This PR migrates to the new official library.

**Does this PR introduce a user-facing change?**: It is a breaking change that migrates from a now archived and unsupported library to the new official client library.

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [X] Extended the documentation
- [ ] Provided sample for the feature
