### PR TITLE
test queue and topic send using CreateMessageBatchAsync to avoid management grants

### DIFF
--- a/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
+++ b/src/HealthChecks.AzureServiceBus/AzureServiceBusTopicHealthCheck.cs
@@ -5,10 +5,14 @@ namespace HealthChecks.AzureServiceBus;
 
 public class AzureServiceBusTopicHealthCheck : AzureServiceBusHealthCheck<AzureServiceBusTopicHealthCheckOptions>, IHealthCheck
 {
+    private readonly string _topicKey;
+
     public AzureServiceBusTopicHealthCheck(AzureServiceBusTopicHealthCheckOptions options, ServiceBusClientProvider clientProvider)
         : base(options, clientProvider)
     {
         Guard.ThrowIfNull(options.TopicName, true);
+
+        _topicKey = $"{nameof(AzureServiceBusTopicHealthCheck)}_{ConnectionKey}_{Options.TopicName}";
     }
 
     public AzureServiceBusTopicHealthCheck(AzureServiceBusTopicHealthCheckOptions options)
@@ -21,15 +25,34 @@ public class AzureServiceBusTopicHealthCheck : AzureServiceBusHealthCheck<AzureS
     {
         try
         {
-            var managementClient = ClientCache.GetOrAdd(ConnectionKey, _ => CreateManagementClient());
-
-            _ = await managementClient.GetTopicRuntimePropertiesAsync(Options.TopicName, cancellationToken).ConfigureAwait(false);
+            if (Options.UseCreateMessageBatchAsyncMode)
+                await CheckWithSender().ConfigureAwait(false);
+            else
+                await CheckWithManagement().ConfigureAwait(false);
 
             return HealthCheckResult.Healthy();
         }
         catch (Exception ex)
         {
             return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+
+        async Task CheckWithSender()
+        {
+            var client = await ClientCache.GetOrAddAsyncDisposableAsync(ConnectionKey, _ => CreateClient()).ConfigureAwait(false);
+            var sender = await ClientCache.GetOrAddAsyncDisposableAsync(
+                _topicKey,
+                _ => client.CreateSender(Options.TopicName))
+                .ConfigureAwait(false);
+
+            await sender.CreateMessageBatchAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        Task CheckWithManagement()
+        {
+            var managementClient = ClientCache.GetOrAdd(ConnectionKey, _ => CreateManagementClient());
+
+            return managementClient.GetTopicRuntimePropertiesAsync(Options.TopicName, cancellationToken);
         }
     }
 }

--- a/src/HealthChecks.AzureServiceBus/Configuration/AzureServiceBusQueueHealthCheckOptions.cs
+++ b/src/HealthChecks.AzureServiceBus/Configuration/AzureServiceBusQueueHealthCheckOptions.cs
@@ -21,6 +21,17 @@ public class AzureServiceBusQueueHealthCheckOptions : AzureServiceBusHealthCheck
     /// </remarks>
     public bool UsePeekMode { get; set; } = true;
 
+    /// <summary>
+    /// Will use <c>CreateMessageBatchAsync</c> method to determine status if set to <see langword="true"/> (default),
+    /// otherwise; will use <c>GetProperties*</c> method.
+    /// </summary>
+    /// <remarks>
+    /// CreateMessageBatch requires Send claim to work. However, if only Receiver claim using the Azure built-in roles (RBAC)
+    /// <see href="https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/integration#azure-service-bus-data-receiver">Azure Service Bus Data Receiver</see>
+    /// is used set this to <see langword="false"/>. By default <see langword="true"/>.
+    /// </remarks>
+    public bool UseCreateMessageBatchAsyncMode { get; set; } = true;
+
     public AzureServiceBusQueueHealthCheckOptions(string queueName)
     {
         QueueName = queueName;

--- a/src/HealthChecks.AzureServiceBus/Configuration/AzureServiceBusTopicHealthCheckOptions.cs
+++ b/src/HealthChecks.AzureServiceBus/Configuration/AzureServiceBusTopicHealthCheckOptions.cs
@@ -10,6 +10,17 @@ public class AzureServiceBusTopicHealthCheckOptions : AzureServiceBusHealthCheck
     /// </summary>
     public string TopicName { get; set; }
 
+    /// <summary>
+    /// Will use <c>CreateMessageBatchAsync</c> method to determine status if set to <see langword="true"/> (default),
+    /// otherwise; will use <c>GetProperties*</c> method.
+    /// </summary>
+    /// <remarks>
+    /// CreateMessageBatch requires Send claim to work. However, if only Receiver claim using the Azure built-in roles (RBAC)
+    /// <see href="https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/integration#azure-service-bus-data-receiver">Azure Service Bus Data Receiver</see>
+    /// is used set this to <see langword="false"/>. By default <see langword="true"/>.
+    /// </remarks>
+    public bool UseCreateMessageBatchAsyncMode { get; set; } = true;
+
     public AzureServiceBusTopicHealthCheckOptions(string topicName)
     {
         TopicName = topicName;

--- a/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
+++ b/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
@@ -10,8 +10,4 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Suppress NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
-    <NoWarn>$(NoWarn);NU1507</NoWarn>
-  </PropertyGroup>
 </Project>

--- a/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
+++ b/src/HealthChecks.AzureServiceBus/HealthChecks.AzureServiceBus.csproj
@@ -10,5 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" />
   </ItemGroup>
-
+  <PropertyGroup>
+    <!-- Suppress NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusQueueHealthCheckTests.cs
+++ b/test/HealthChecks.AzureServiceBus.Tests/AzureServiceBusQueueHealthCheckTests.cs
@@ -14,8 +14,12 @@ public class azureservicebusqueuehealthcheck_should
     private readonly string ConnectionString;
     private readonly string FullyQualifiedName;
     private readonly string QueueName;
+    private readonly string OtherQueueName;
     private readonly ServiceBusClient _serviceBusClient;
-    private readonly ServiceBusReceiver _serviceBusReceiver;
+    private readonly ServiceBusReceiver _serviceBusQueueReceiver;
+    private readonly ServiceBusSender _serviceBusQueueSender;
+    private readonly ServiceBusReceiver _serviceBusOtherQueueReceiver;
+    private readonly ServiceBusSender _serviceBusOtherQueueSender;
     private readonly ServiceBusClientProvider _clientProvider;
     private readonly ServiceBusAdministrationClient _serviceBusAdministrationClient;
     private readonly TokenCredential _tokenCredential;
@@ -25,9 +29,13 @@ public class azureservicebusqueuehealthcheck_should
         ConnectionString = Guid.NewGuid().ToString();
         FullyQualifiedName = Guid.NewGuid().ToString();
         QueueName = Guid.NewGuid().ToString();
+        OtherQueueName = Guid.NewGuid().ToString();
 
         _serviceBusClient = Substitute.For<ServiceBusClient>();
-        _serviceBusReceiver = Substitute.For<ServiceBusReceiver>();
+        _serviceBusQueueReceiver = Substitute.For<ServiceBusReceiver>();
+        _serviceBusQueueSender = Substitute.For<ServiceBusSender>();
+        _serviceBusOtherQueueReceiver = Substitute.For<ServiceBusReceiver>();
+        _serviceBusOtherQueueSender = Substitute.For<ServiceBusSender>();
         _clientProvider = Substitute.For<ServiceBusClientProvider>();
         _serviceBusAdministrationClient = Substitute.For<ServiceBusAdministrationClient>();
         _tokenCredential = Substitute.For<TokenCredential>();
@@ -36,26 +44,38 @@ public class azureservicebusqueuehealthcheck_should
         _clientProvider.CreateClient(FullyQualifiedName, _tokenCredential).Returns(_serviceBusClient);
         _clientProvider.CreateManagementClient(ConnectionString).Returns(_serviceBusAdministrationClient);
         _clientProvider.CreateManagementClient(FullyQualifiedName, _tokenCredential).Returns(_serviceBusAdministrationClient);
-        _serviceBusClient.CreateReceiver(QueueName).Returns(_serviceBusReceiver);
+        _serviceBusClient.CreateReceiver(QueueName).Returns(_serviceBusQueueReceiver);
+        _serviceBusClient.CreateSender(QueueName).Returns(_serviceBusQueueSender);
+        _serviceBusClient.CreateReceiver(OtherQueueName).Returns(_serviceBusOtherQueueReceiver);
+        _serviceBusClient.CreateSender(OtherQueueName).Returns(_serviceBusOtherQueueSender);
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task can_create_client_with_connection_string(bool peakMode)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task can_create_client_with_connection_string(bool peakMode, bool createMessageBatchAsyncMode)
     {
         using var tokenSource = new CancellationTokenSource();
 
         await ExecuteHealthCheckAsync(
             QueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
-        if (peakMode)
+        if (peakMode || createMessageBatchAsyncMode)
         {
             _clientProvider
                 .Received(1)
+                .CreateClient(ConnectionString);
+        }
+        else if (peakMode && createMessageBatchAsyncMode)
+        {
+            _clientProvider
+                .Received(2)
                 .CreateClient(ConnectionString);
         }
         else
@@ -67,38 +87,70 @@ public class azureservicebusqueuehealthcheck_should
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task reuses_existing_client_when_using_same_connection_string_with_different_queue(bool peakMode)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task reuses_existing_client_when_using_same_connection_string_with_different_queue(bool peakMode, bool createMessageBatchAsyncMode)
     {
         using var tokenSource = new CancellationTokenSource();
-        var otherQueueName = Guid.NewGuid().ToString();
 
         await ExecuteHealthCheckAsync(
             QueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
         await ExecuteHealthCheckAsync(
-            otherQueueName,
+            OtherQueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
-        if (peakMode)
+        if (peakMode || createMessageBatchAsyncMode)
         {
             _clientProvider
                 .Received(1)
                 .CreateClient(ConnectionString);
 
-            _serviceBusClient
-                .Received(1)
-                .CreateReceiver(QueueName);
+            if (peakMode)
+            {
+                _serviceBusClient
+                    .Received(1)
+                    .CreateReceiver(QueueName);
 
-            _serviceBusClient
-                .Received(1)
-                .CreateReceiver(otherQueueName);
+                _serviceBusClient
+                    .Received(1)
+                    .CreateReceiver(OtherQueueName);
+
+                await _serviceBusQueueReceiver
+                    .Received(1)
+                    .PeekMessageAsync(cancellationToken: tokenSource.Token);
+
+                await _serviceBusOtherQueueReceiver
+                    .Received(1)
+                    .PeekMessageAsync(cancellationToken: tokenSource.Token);
+            }
+            else if (createMessageBatchAsyncMode)
+            {
+                _serviceBusClient
+                    .Received(1)
+                    .CreateSender(QueueName);
+
+                _serviceBusClient
+                    .Received(1)
+                    .CreateSender(OtherQueueName);
+
+                await _serviceBusQueueSender
+                    .Received(1)
+                    .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
+
+                await _serviceBusOtherQueueSender
+                    .Received(1)
+                    .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
+            }
         }
         else
         {
@@ -112,24 +164,27 @@ public class azureservicebusqueuehealthcheck_should
 
             await _serviceBusAdministrationClient
                 .Received(1)
-                .GetQueueRuntimePropertiesAsync(otherQueueName, tokenSource.Token);
+                .GetQueueRuntimePropertiesAsync(OtherQueueName, tokenSource.Token);
         }
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task can_create_client_with_fully_qualified_endpoint(bool peakMode)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task can_create_client_with_fully_qualified_endpoint(bool peakMode, bool createMessageBatchAsyncMode)
     {
         using var tokenSource = new CancellationTokenSource();
 
         await ExecuteHealthCheckAsync(
             QueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             fullyQualifiedName: FullyQualifiedName,
             cancellationToken: tokenSource.Token);
 
-        if (peakMode)
+        if (peakMode || createMessageBatchAsyncMode)
         {
             _clientProvider
                 .Received(1)
@@ -144,38 +199,71 @@ public class azureservicebusqueuehealthcheck_should
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task reuses_existing_client_when_using_same_fully_qualified_name_with_different_queue(bool peakMode)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task reuses_existing_client_when_using_same_fully_qualified_name_with_different_queue(bool peakMode, bool createMessageBatchAsyncMode)
     {
         using var tokenSource = new CancellationTokenSource();
-        var otherQueueName = Guid.NewGuid().ToString();
 
         await ExecuteHealthCheckAsync(
             QueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             fullyQualifiedName: FullyQualifiedName,
             cancellationToken: tokenSource.Token);
 
         await ExecuteHealthCheckAsync(
-            otherQueueName,
+            OtherQueueName,
             peakMode,
+            createMessageBatchAsyncMode,
             fullyQualifiedName: FullyQualifiedName,
             cancellationToken: tokenSource.Token);
 
-        if (peakMode)
+        if (peakMode || createMessageBatchAsyncMode)
         {
             _clientProvider
                 .Received(1)
                 .CreateClient(FullyQualifiedName, _tokenCredential);
 
-            _serviceBusClient
-                .Received(1)
-                .CreateReceiver(QueueName);
+            if (peakMode)
+            {
+                _serviceBusClient
+                    .Received(1)
+                    .CreateReceiver(QueueName);
 
-            _serviceBusClient
-                .Received(1)
-                .CreateReceiver(otherQueueName);
+                _serviceBusClient
+                    .Received(1)
+                    .CreateReceiver(OtherQueueName);
+
+                await _serviceBusQueueReceiver
+                    .Received(1)
+                    .PeekMessageAsync(cancellationToken: tokenSource.Token);
+
+                await _serviceBusOtherQueueReceiver
+                    .Received(1)
+                    .PeekMessageAsync(cancellationToken: tokenSource.Token);
+            }
+            else if (createMessageBatchAsyncMode)
+            {
+                _serviceBusClient
+                    .Received(1)
+                    .CreateSender(QueueName);
+
+                _serviceBusClient
+                    .Received(1)
+                    .CreateSender(OtherQueueName);
+
+                await _serviceBusQueueSender
+                    .Received(1)
+                    .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
+
+                await _serviceBusOtherQueueSender
+                    .Received(1)
+                    .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
+
+            }
         }
         else
         {
@@ -189,7 +277,7 @@ public class azureservicebusqueuehealthcheck_should
 
             await _serviceBusAdministrationClient
                 .Received(1)
-                .GetQueueRuntimePropertiesAsync(otherQueueName, tokenSource.Token);
+                .GetQueueRuntimePropertiesAsync(OtherQueueName, tokenSource.Token);
         }
     }
 
@@ -201,6 +289,7 @@ public class azureservicebusqueuehealthcheck_should
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
             true,
+            false,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
@@ -210,9 +299,32 @@ public class azureservicebusqueuehealthcheck_should
             .Received(1)
             .CreateReceiver(QueueName);
 
-        await _serviceBusReceiver
+        await _serviceBusQueueReceiver
             .Received(1)
             .PeekMessageAsync(cancellationToken: tokenSource.Token);
+    }
+
+    [Fact]
+    public async Task return_healthy_when_checking_healthy_service_through_createmessagebatch_and_connection_string()
+    {
+        using var tokenSource = new CancellationTokenSource();
+
+        var actual = await ExecuteHealthCheckAsync(
+            QueueName,
+            false,
+            true,
+            connectionString: ConnectionString,
+            cancellationToken: tokenSource.Token);
+
+        actual.Status.ShouldBe(HealthStatus.Healthy);
+
+        _serviceBusClient
+            .Received(1)
+            .CreateSender(QueueName);
+
+        await _serviceBusQueueSender
+            .Received(1)
+            .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
     }
 
     [Fact]
@@ -223,6 +335,7 @@ public class azureservicebusqueuehealthcheck_should
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
             true,
+            false,
             fullyQualifiedName: FullyQualifiedName,
             cancellationToken: tokenSource.Token);
 
@@ -232,35 +345,87 @@ public class azureservicebusqueuehealthcheck_should
             .Received(1)
             .CreateReceiver(QueueName);
 
-        await _serviceBusReceiver
+        await _serviceBusQueueReceiver
             .Received(1)
             .PeekMessageAsync(cancellationToken: tokenSource.Token);
     }
 
     [Fact]
-    public async Task return_unhealthy_when_exception_is_thrown_by_client()
+    public async Task return_healthy_when_checking_healthy_service_through_createmessagebatch_and_fully_qualified_name()
     {
         using var tokenSource = new CancellationTokenSource();
 
-        _serviceBusReceiver
+        var actual = await ExecuteHealthCheckAsync(
+            QueueName,
+            false,
+            true,
+            fullyQualifiedName: FullyQualifiedName,
+            cancellationToken: tokenSource.Token);
+
+        actual.Status.ShouldBe(HealthStatus.Healthy);
+
+        _serviceBusClient
+            .Received(1)
+            .CreateSender(QueueName);
+
+        await _serviceBusQueueSender
+            .Received(1)
+            .CreateMessageBatchAsync(cancellationToken: tokenSource.Token);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task return_unhealthy_when_exception_is_thrown_by_client(bool peakMode, bool createMessageBatchAsyncMode)
+    {
+        using var tokenSource = new CancellationTokenSource();
+
+        _serviceBusQueueReceiver
             .PeekMessageAsync(cancellationToken: tokenSource.Token)
+            .ThrowsAsyncForAnyArgs(new InvalidOperationException());
+
+        _serviceBusQueueSender
+            .CreateMessageBatchAsync(cancellationToken: tokenSource.Token)
             .ThrowsAsyncForAnyArgs(new InvalidOperationException());
 
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
-            true,
+            peakMode,
+            createMessageBatchAsyncMode,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
         actual.Status.ShouldBe(HealthStatus.Unhealthy);
 
-        _serviceBusClient
-            .Received(1)
-            .CreateReceiver(QueueName);
+        if (peakMode || createMessageBatchAsyncMode)
+        {
+            _clientProvider
+                .Received(1)
+                .CreateClient(ConnectionString);
+        }
 
-        await _serviceBusReceiver
-            .Received(1)
-            .PeekMessageAsync(cancellationToken: tokenSource.Token);
+        if (peakMode)
+        {
+            _serviceBusClient
+                .ReceivedCalls().Count(call => call.GetMethodInfo().Name == "CreateReceiver" && call.GetArguments()[0]?.Equals(QueueName) == true)
+                .ShouldBeLessThanOrEqualTo(1);
+
+            _serviceBusQueueReceiver
+                .ReceivedCalls().Count(call => call.GetMethodInfo().Name == "PeekMessageAsync")
+                .ShouldBeLessThanOrEqualTo(1);
+        }
+
+        if (createMessageBatchAsyncMode)
+        {
+            _serviceBusClient
+                .ReceivedCalls().Count(call => call.GetMethodInfo().Name == "CreateSender" && call.GetArguments()[0]?.Equals(QueueName) == true)
+                .ShouldBeLessThanOrEqualTo(1);
+
+            _serviceBusQueueSender
+                .ReceivedCalls().Count(call => call.GetMethodInfo().Name == "CreateMessageBatchAsync")
+                .ShouldBeLessThanOrEqualTo(1);
+        }
     }
 
     [Fact]
@@ -270,6 +435,7 @@ public class azureservicebusqueuehealthcheck_should
 
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
+            false,
             false,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
@@ -288,6 +454,7 @@ public class azureservicebusqueuehealthcheck_should
 
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
+            false,
             false,
             fullyQualifiedName: FullyQualifiedName,
             cancellationToken: tokenSource.Token);
@@ -311,6 +478,7 @@ public class azureservicebusqueuehealthcheck_should
         var actual = await ExecuteHealthCheckAsync(
             QueueName,
             false,
+            false,
             connectionString: ConnectionString,
             cancellationToken: tokenSource.Token);
 
@@ -324,6 +492,7 @@ public class azureservicebusqueuehealthcheck_should
     private Task<HealthCheckResult> ExecuteHealthCheckAsync(
         string queueName,
         bool peakMode,
+        bool createMessageBatchAsyncMode,
         string? connectionString = null,
         string? fullyQualifiedName = null,
         CancellationToken cancellationToken = default)
@@ -334,6 +503,7 @@ public class azureservicebusqueuehealthcheck_should
             FullyQualifiedNamespace = fullyQualifiedName,
             Credential = fullyQualifiedName is null ? null : _tokenCredential,
             UsePeekMode = peakMode,
+            UseCreateMessageBatchAsyncMode = createMessageBatchAsyncMode
         };
         var healthCheck = new AzureServiceBusQueueHealthCheck(options, _clientProvider);
         var context = new HealthCheckContext


### PR DESCRIPTION
feat: test queue and topic send using CreateMessageBatchAsync to avoi…

<!--  Thanks for sending a pull request!
-->

**What this PR does / why we need it**:
This PR introduce a way to test topic or queue using send grant to avoid that we force to provide management roles to implement the hc

**Which issue(s) this PR fixes**:
Please reference the issue this PR will close: #555
Please reference the issue this PR will close: #727 

**Special notes for your reviewer**:
i'm leveraging **CreateMessageBatchAsync** since it does a network call to the Service Bus to fetch entity properties, such as MaxMessageSize.

Therefore, it verifies:
- The entity exists
- User connection and permissions allow access (send link)
- User know the maximum allowed message size

It does NOT send messages, **so no DLQ or queue pollution occurs**

Potentially could be possible also to use a probe message to verify that the configuration of the message is valid.

**Sample**
```csharp
  .AddAzureServiceBusQueue(publisherQueueConnectionString,
                          publisherQueueName,
                          configure: (op) =>
                          {
                              op.UsePeekMode = false;
                              op.UseCreateMessageBatchAsyncMode = true;
                          },
                          name: "test queue publish lib",
                          timeout: TimeSpan.FromSeconds(20))
```

```csharp
  .AddAzureServiceBusTopic(publisherTopicConnectionString,
                          publisherTopicName,
                          configure: (op) =>
                          {
                              op.UseCreateMessageBatchAsyncMode = true;
                          },
                          name: "test topic publish lib",
                          timeout: TimeSpan.FromSeconds(20))
```

**Does this PR introduce a user-facing change?**:
Yes.
For the queue, since queue can be consumed in both SEND and LISTEN mode, to mirror existing implementation i've set UseCreateMessageBatchAsyncMode = true as default.
This implies that if you want to test only LISTEN, is mandatory to explicitely set _configure_ in _AddAzureServiceBusQueue_ call, to maintein the same behaviour of current implementation,  like:
```csharp
  .AddAzureServiceBusQueue(subscriberQueueConnectionString,
                          subscriberQueueName,
                          configure: (op) =>
                          {
                              op.UsePeekMode = true;
                              op.UseCreateMessageBatchAsyncMode = false;
                          },
                          name: "test queue subscriber",
                          timeout: TimeSpan.FromSeconds(20))
```

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation
- [ ] Provided sample for the feature
