### PR TITLE
RavenDBHealthCheck: prevent health check from disposing shared client certificate.

### DIFF
--- a/src/HealthChecks.RavenDB/RavenDBHealthCheck.cs
+++ b/src/HealthChecks.RavenDB/RavenDBHealthCheck.cs
@@ -49,6 +49,10 @@ public class RavenDBHealthCheck : IHealthCheck
                     Certificate = o.Certificate
                 };
 
+                // Health check doesn't own the certificate lifetime; it may be shared (e.g. DI/KeyVault).
+                // Disposing it can break other RavenDB stores in the process.
+                store.Conventions.DisposeCertificate = false;
+
                 try
                 {
                     store.Initialize();

--- a/test/HealthChecks.RavenDb.Tests/Functional/RavenDbHealthCheckTests.cs
+++ b/test/HealthChecks.RavenDb.Tests/Functional/RavenDbHealthCheckTests.cs
@@ -1,4 +1,7 @@
 using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using HealthChecks.RavenDB;
 using HealthChecks.UI.Client;
 
 namespace HealthChecks.RavenDb.Tests.Functional;
@@ -150,5 +153,32 @@ public class ravendb_healthcheck_should(RavenDbContainerFixture ravenDbFixture) 
         using var response = await server.CreateRequest("/health").GetAsync();
 
         response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task not_dispose_shared_certificate_when_store_initialization_fails()
+    {
+        using var rsa = RSA.Create(2048);
+        var certificateRequest = new CertificateRequest("CN=ravendb-healthcheck-test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = certificateRequest.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+
+        var options = new RavenDBOptions
+        {
+            Urls = ["http://localhost:0"],
+            Certificate = certificate
+        };
+
+        var healthCheck = new RavenDBHealthCheck(options);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration("ravendb", _ => healthCheck, HealthStatus.Unhealthy, tags: null)
+        };
+
+        var result = await healthCheck.CheckHealthAsync(context);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+
+        using var privateKey = certificate.GetRSAPrivateKey();
+        privateKey.ShouldNotBeNull();
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Health check doesn't own the certificate lifetime; it may be shared (e.g. DI/KeyVault). Disposing it can break other RavenDB stores in the process.


**Which issue(s) this PR fixes**:

Please reference the issue this PR will close: #2466

**Special notes for your reviewer**:
Used RavenDB store convention to disable disposing certificate.

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation (bugfix - irrelevant)
- [x] Provided sample for the feature (bugfix - irrelevant)
